### PR TITLE
Fix blank system test timing inputs

### DIFF
--- a/tests/system/test_helpers.py
+++ b/tests/system/test_helpers.py
@@ -31,33 +31,38 @@ _FATAL_SYSTEM_TEST_LOG_PREFIXES = (
 )
 
 
+def _get_nonempty_env(*names: str) -> Optional[str]:
+    """Return the first environment value that is present and not blank."""
+    for name in names:
+        value = os.getenv(name)
+        if value is None:
+            continue
+
+        stripped = value.strip()
+        if stripped:
+            return stripped
+
+    return None
+
+
 def get_system_test_poll_interval(default: float = 10.0) -> float:
     """Return poll interval for system-test job/status polling."""
     return float(
-        os.getenv(
-            "KINDLING_SYSTEM_TEST_POLL_INTERVAL",
-            os.getenv("POLL_INTERVAL", str(default)),
-        )
+        _get_nonempty_env("KINDLING_SYSTEM_TEST_POLL_INTERVAL", "POLL_INTERVAL") or str(default)
     )
 
 
 def get_system_test_stream_max_wait(default: float = 600.0) -> float:
     """Return max stdout stream wait for system tests."""
     return float(
-        os.getenv(
-            "KINDLING_SYSTEM_TEST_STREAM_MAX_WAIT",
-            os.getenv("TEST_TIMEOUT", str(default)),
-        )
+        _get_nonempty_env("KINDLING_SYSTEM_TEST_STREAM_MAX_WAIT", "TEST_TIMEOUT") or str(default)
     )
 
 
 def get_system_test_completion_timeout(default: float = 600.0) -> float:
     """Return completion timeout for tests that poll status directly."""
     return float(
-        os.getenv(
-            "KINDLING_SYSTEM_TEST_COMPLETION_TIMEOUT",
-            os.getenv("TEST_TIMEOUT", str(default)),
-        )
+        _get_nonempty_env("KINDLING_SYSTEM_TEST_COMPLETION_TIMEOUT", "TEST_TIMEOUT") or str(default)
     )
 
 

--- a/tests/unit/test_system_test_helpers.py
+++ b/tests/unit/test_system_test_helpers.py
@@ -7,6 +7,9 @@ from tests.system.test_helpers import (
     apply_env_config_overrides,
     assert_no_fatal_system_test_log_lines,
     find_fatal_system_test_log_lines,
+    get_system_test_completion_timeout,
+    get_system_test_poll_interval,
+    get_system_test_stream_max_wait,
 )
 
 
@@ -217,6 +220,28 @@ def test_assert_no_fatal_system_test_log_lines_raises_for_extension_failures():
         assert_no_fatal_system_test_log_lines(
             "ERROR: (KindlingBootstrap) Failed to install extension kindling-otel-azure==0.3.2"
         )
+
+
+def test_system_test_timing_helpers_ignore_blank_env_vars(monkeypatch):
+    monkeypatch.setenv("KINDLING_SYSTEM_TEST_POLL_INTERVAL", "")
+    monkeypatch.setenv("KINDLING_SYSTEM_TEST_STREAM_MAX_WAIT", "")
+    monkeypatch.setenv("KINDLING_SYSTEM_TEST_COMPLETION_TIMEOUT", "")
+
+    assert get_system_test_poll_interval(10.0) == 10.0
+    assert get_system_test_stream_max_wait(600.0) == 600.0
+    assert get_system_test_completion_timeout(600.0) == 600.0
+
+
+def test_system_test_timing_helpers_fall_back_to_legacy_env_vars(monkeypatch):
+    monkeypatch.setenv("KINDLING_SYSTEM_TEST_POLL_INTERVAL", "")
+    monkeypatch.setenv("KINDLING_SYSTEM_TEST_STREAM_MAX_WAIT", "")
+    monkeypatch.setenv("KINDLING_SYSTEM_TEST_COMPLETION_TIMEOUT", "")
+    monkeypatch.setenv("POLL_INTERVAL", "15")
+    monkeypatch.setenv("TEST_TIMEOUT", "900")
+
+    assert get_system_test_poll_interval(10.0) == 15.0
+    assert get_system_test_stream_max_wait(600.0) == 900.0
+    assert get_system_test_completion_timeout(600.0) == 900.0
 
 
 def test_stdout_validator_validate_completion_fails_when_fatal_log_lines_present():


### PR DESCRIPTION
## Summary
- ignore blank GitHub Actions system-test timing inputs instead of treating them as numeric values
- restore fallback behavior for default timing values and legacy env vars
- add regression coverage for blank workflow inputs

## Validation
- pytest tests/unit/test_system_test_helpers.py -q
