### PR TITLE
fix: move pyspark/delta-spark/pandas/pyarrow to [standalone] extra (v0.9.1)

### DIFF
--- a/docs/releases/v0.9.1.md
+++ b/docs/releases/v0.9.1.md
@@ -1,0 +1,30 @@
+# Release Notes - v0.9.1
+
+Patch release that fixes a regression in v0.9.0 where the combined runtime wheel declared `pyspark`, `delta-spark`, `pandas`, and `pyarrow` as required distribution dependencies. On Synapse clusters those packages are provided by the runtime via a non-pip mechanism, so `pip install` of the wheel hung trying to re-resolve them — the `test_default_telemetry[synapse]` system test went from ~2.5 min on v0.8.15 to timing out at 600s on v0.9.0.
+
+## What's Changed
+
+- `pyspark`, `delta-spark`, `pandas`, `pyarrow` moved from required base dependencies into the `[standalone]` extra. Managed cloud runtimes (Synapse, Fabric, Databricks) no longer see these in `Requires-Dist`; local/CI consumers who need them install via `pip install 'spark-kindling[standalone]'`.
+- Loosened `azure-identity` pin from `>=1.15.0` → `>=1.12.0` (match v0.8.x per-platform wheels).
+- Loosened `azure-storage-file-datalake` pin from `>=12.14.0` → `>=12.0.0` (same).
+- Dropped explicit `azure-storage-blob` requirement — it's pulled in transitively by `azure-storage-file-datalake`.
+
+## Wheel metadata diff vs v0.9.0
+
+| Package | v0.9.0 | v0.9.1 |
+|---|---|---|
+| `pyspark` | required | `[standalone]` extra |
+| `delta-spark` | required | `[standalone]` extra |
+| `pandas` | required | `[standalone]` extra |
+| `pyarrow` | required | `[standalone]` extra |
+| `azure-identity` | `>=1.15.0` | `>=1.12.0` |
+| `azure-storage-file-datalake` | `>=12.14.0` | `>=12.0.0` |
+| `azure-storage-blob` | `>=12.14.0` | (removed; transitive) |
+
+Post-fix base `Requires-Dist` is a strict subset of the v0.8.15 synapse wheel's dep list — the shape known to install cleanly on every cloud Spark runtime.
+
+## Upgrade
+
+No action required for runtime consumers — the runtime bootstrap picks up the new wheel automatically.
+
+Local/CI consumers that were relying on `pip install spark-kindling` pulling pyspark should switch to `pip install 'spark-kindling[standalone]'`.

--- a/packages/kindling_cli/pyproject.toml
+++ b/packages/kindling_cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "spark-kindling-cli"
-version = "0.9.0"
+version = "0.9.1"
 description = "Command-line tooling for Kindling"
 authors = ["SEP Engineering <engineering@sep.com>"]
 license = "MIT"

--- a/packages/kindling_sdk/pyproject.toml
+++ b/packages/kindling_sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "spark-kindling-sdk"
-version = "0.9.0"
+version = "0.9.1"
 description = "Design-time platform SDK for Kindling"
 authors = ["SEP Engineering <engineering@sep.com>"]
 license = "MIT"

--- a/poetry.lock
+++ b/poetry.lock
@@ -998,14 +998,14 @@ files = [
 name = "delta-spark"
 version = "4.0.0"
 description = "Python APIs for using Delta Lake with Apache Spark"
-optional = true
+optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"standalone\" or extra == \"all\""
+groups = ["main", "dev"]
 files = [
     {file = "delta-spark-4.0.0.tar.gz", hash = "sha256:39325d76d6e5d8b5fea9d47827c59f5e0674844cb95f97b2cc613bfc5209c7ec"},
     {file = "delta_spark-4.0.0-py3-none-any.whl", hash = "sha256:4e4ded07bb9ee4f6a0df45606d84395239d4b82001e765a627fecc1e914f3029"},
 ]
+markers = {main = "extra == \"standalone\" or extra == \"all\""}
 
 [package.dependencies]
 importlib-metadata = ">=1.0.0"
@@ -1231,14 +1231,14 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 name = "importlib-metadata"
 version = "8.7.0"
 description = "Read metadata from Python packages"
-optional = true
+optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"standalone\" or extra == \"all\""
+groups = ["main", "dev"]
 files = [
     {file = "importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd"},
     {file = "importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000"},
 ]
+markers = {main = "extra == \"standalone\" or extra == \"all\""}
 
 [package.dependencies]
 zipp = ">=3.20"
@@ -2210,10 +2210,9 @@ test = ["pytest", "pytest-console-scripts", "pytest-jupyter", "pytest-tornasync"
 name = "numpy"
 version = "2.2.6"
 description = "Fundamental package for array computing in Python"
-optional = true
+optional = false
 python-versions = ">=3.10"
-groups = ["main"]
-markers = "(extra == \"standalone\" or extra == \"all\") and python_version == \"3.10\""
+groups = ["main", "dev"]
 files = [
     {file = "numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb"},
     {file = "numpy-2.2.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e41fd67c52b86603a91c1a505ebaef50b3314de0213461c7a6e99c9a3beff90"},
@@ -2271,15 +2270,15 @@ files = [
     {file = "numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00"},
     {file = "numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd"},
 ]
+markers = {main = "(extra == \"standalone\" or extra == \"all\") and python_version == \"3.10\"", dev = "python_version == \"3.10\""}
 
 [[package]]
 name = "numpy"
 version = "2.3.4"
 description = "Fundamental package for array computing in Python"
-optional = true
+optional = false
 python-versions = ">=3.11"
-groups = ["main"]
-markers = "python_version >= \"3.11\" and (extra == \"standalone\" or extra == \"all\")"
+groups = ["main", "dev"]
 files = [
     {file = "numpy-2.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e78aecd2800b32e8347ce49316d3eaf04aed849cd5b38e0af39f829a4e59f5eb"},
     {file = "numpy-2.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7fd09cc5d65bda1e79432859c40978010622112e9194e581e3415a3eccc7f43f"},
@@ -2356,6 +2355,7 @@ files = [
     {file = "numpy-2.3.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:81b3a59793523e552c4a96109dde028aa4448ae06ccac5a76ff6532a85558a7f"},
     {file = "numpy-2.3.4.tar.gz", hash = "sha256:a7d018bfedb375a8d979ac758b120ba846a7fe764911a64465fd87b8729f4a6a"},
 ]
+markers = {main = "python_version >= \"3.11\" and (extra == \"standalone\" or extra == \"all\")", dev = "python_version >= \"3.11\""}
 
 [[package]]
 name = "overrides"
@@ -2386,10 +2386,9 @@ files = [
 name = "pandas"
 version = "2.3.3"
 description = "Powerful data structures for data analysis, time series, and statistics"
-optional = true
+optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"standalone\" or extra == \"all\""
+groups = ["main", "dev"]
 files = [
     {file = "pandas-2.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:376c6446ae31770764215a6c937f72d917f214b43560603cd60da6408f183b6c"},
     {file = "pandas-2.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e19d192383eab2f4ceb30b412b22ea30690c9e618f78870357ae1d682912015a"},
@@ -2447,6 +2446,7 @@ files = [
     {file = "pandas-2.3.3-cp39-cp39-win_amd64.whl", hash = "sha256:d3e28b3e83862ccf4d85ff19cf8c20b2ae7e503881711ff2d534dc8f761131aa"},
     {file = "pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b"},
 ]
+markers = {main = "extra == \"standalone\" or extra == \"all\""}
 
 [package.dependencies]
 numpy = [
@@ -2710,23 +2710,22 @@ tests = ["pytest"]
 name = "py4j"
 version = "0.10.9.9"
 description = "Enables Python programs to dynamically access arbitrary Java objects"
-optional = true
+optional = false
 python-versions = "*"
-groups = ["main"]
-markers = "extra == \"standalone\" or extra == \"all\""
+groups = ["main", "dev"]
 files = [
     {file = "py4j-0.10.9.9-py2.py3-none-any.whl", hash = "sha256:c7c26e4158defb37b0bb124933163641a2ff6e3a3913f7811b0ddbe07ed61533"},
     {file = "py4j-0.10.9.9.tar.gz", hash = "sha256:f694cad19efa5bd1dee4f3e5270eb406613c974394035e5bfc4ec1aba870b879"},
 ]
+markers = {main = "extra == \"standalone\" or extra == \"all\""}
 
 [[package]]
 name = "pyarrow"
 version = "21.0.0"
 description = "Python library for Apache Arrow"
-optional = true
+optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"standalone\" or extra == \"all\""
+groups = ["main", "dev"]
 files = [
     {file = "pyarrow-21.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:e563271e2c5ff4d4a4cbeb2c83d5cf0d4938b891518e676025f7268c6fe5fe26"},
     {file = "pyarrow-21.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:fee33b0ca46f4c85443d6c450357101e47d53e6c3f008d658c27a2d020d44c79"},
@@ -2772,6 +2771,7 @@ files = [
     {file = "pyarrow-21.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:cdc4c17afda4dab2a9c0b79148a43a7f4e1094916b3e18d8975bfd6d6d52241f"},
     {file = "pyarrow-21.0.0.tar.gz", hash = "sha256:5051f2dccf0e283ff56335760cbc8622cf52264d67e359d5569541ac11b6d5bc"},
 ]
+markers = {main = "extra == \"standalone\" or extra == \"all\""}
 
 [package.extras]
 test = ["cffi", "hypothesis", "pandas", "pytest", "pytz"]
@@ -2888,13 +2888,13 @@ testutils = ["gitpython (>3)"]
 name = "pyspark"
 version = "4.0.1"
 description = "Apache Spark Python API"
-optional = true
+optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"standalone\" or extra == \"all\""
+groups = ["main", "dev"]
 files = [
     {file = "pyspark-4.0.1.tar.gz", hash = "sha256:9d1f22d994f60369228397e3479003ffe2dd736ba79165003246ff7bd48e2c73"},
 ]
+markers = {main = "extra == \"standalone\" or extra == \"all\""}
 
 [package.dependencies]
 py4j = "0.10.9.9"
@@ -3055,14 +3055,14 @@ dev = ["black", "build", "mypy", "pytest", "pytest-cov", "setuptools", "tox", "t
 name = "pytz"
 version = "2025.2"
 description = "World timezone definitions, modern and historical"
-optional = true
+optional = false
 python-versions = "*"
-groups = ["main"]
-markers = "extra == \"standalone\" or extra == \"all\""
+groups = ["main", "dev"]
 files = [
     {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
     {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
 ]
+markers = {main = "extra == \"standalone\" or extra == \"all\""}
 
 [[package]]
 name = "pywinpty"
@@ -3803,14 +3803,14 @@ files = [
 name = "tzdata"
 version = "2025.2"
 description = "Provider of IANA time zone data"
-optional = true
+optional = false
 python-versions = ">=2"
-groups = ["main"]
-markers = "extra == \"standalone\" or extra == \"all\""
+groups = ["main", "dev"]
 files = [
     {file = "tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8"},
     {file = "tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9"},
 ]
+markers = {main = "extra == \"standalone\" or extra == \"all\""}
 
 [[package]]
 name = "uri-template"
@@ -3914,14 +3914,14 @@ files = [
 name = "zipp"
 version = "3.23.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = true
+optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"standalone\" or extra == \"all\""
+groups = ["main", "dev"]
 files = [
     {file = "zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
     {file = "zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"},
 ]
+markers = {main = "extra == \"standalone\" or extra == \"all\""}
 
 [package.extras]
 check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
@@ -3941,4 +3941,4 @@ synapse = ["azure-synapse-artifacts"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "a01c812b91b83bb839446757fbfbca3ddb4e92e420fb02e353e14382e96000c9"
+content-hash = "826bfc9e783797ead74596f83dd9b0486dae01f0f440ffcd9612129aca768936"

--- a/poetry.lock
+++ b/poetry.lock
@@ -998,9 +998,10 @@ files = [
 name = "delta-spark"
 version = "4.0.0"
 description = "Python APIs for using Delta Lake with Apache Spark"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"standalone\" or extra == \"all\""
 files = [
     {file = "delta-spark-4.0.0.tar.gz", hash = "sha256:39325d76d6e5d8b5fea9d47827c59f5e0674844cb95f97b2cc613bfc5209c7ec"},
     {file = "delta_spark-4.0.0-py3-none-any.whl", hash = "sha256:4e4ded07bb9ee4f6a0df45606d84395239d4b82001e765a627fecc1e914f3029"},
@@ -1230,9 +1231,10 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 name = "importlib-metadata"
 version = "8.7.0"
 description = "Read metadata from Python packages"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"standalone\" or extra == \"all\""
 files = [
     {file = "importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd"},
     {file = "importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000"},
@@ -2208,10 +2210,10 @@ test = ["pytest", "pytest-console-scripts", "pytest-jupyter", "pytest-tornasync"
 name = "numpy"
 version = "2.2.6"
 description = "Fundamental package for array computing in Python"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version == \"3.10\""
+markers = "(extra == \"standalone\" or extra == \"all\") and python_version == \"3.10\""
 files = [
     {file = "numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb"},
     {file = "numpy-2.2.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e41fd67c52b86603a91c1a505ebaef50b3314de0213461c7a6e99c9a3beff90"},
@@ -2274,10 +2276,10 @@ files = [
 name = "numpy"
 version = "2.3.4"
 description = "Fundamental package for array computing in Python"
-optional = false
+optional = true
 python-versions = ">=3.11"
 groups = ["main"]
-markers = "python_version >= \"3.11\""
+markers = "python_version >= \"3.11\" and (extra == \"standalone\" or extra == \"all\")"
 files = [
     {file = "numpy-2.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e78aecd2800b32e8347ce49316d3eaf04aed849cd5b38e0af39f829a4e59f5eb"},
     {file = "numpy-2.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7fd09cc5d65bda1e79432859c40978010622112e9194e581e3415a3eccc7f43f"},
@@ -2384,9 +2386,10 @@ files = [
 name = "pandas"
 version = "2.3.3"
 description = "Powerful data structures for data analysis, time series, and statistics"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"standalone\" or extra == \"all\""
 files = [
     {file = "pandas-2.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:376c6446ae31770764215a6c937f72d917f214b43560603cd60da6408f183b6c"},
     {file = "pandas-2.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e19d192383eab2f4ceb30b412b22ea30690c9e618f78870357ae1d682912015a"},
@@ -2707,9 +2710,10 @@ tests = ["pytest"]
 name = "py4j"
 version = "0.10.9.9"
 description = "Enables Python programs to dynamically access arbitrary Java objects"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"standalone\" or extra == \"all\""
 files = [
     {file = "py4j-0.10.9.9-py2.py3-none-any.whl", hash = "sha256:c7c26e4158defb37b0bb124933163641a2ff6e3a3913f7811b0ddbe07ed61533"},
     {file = "py4j-0.10.9.9.tar.gz", hash = "sha256:f694cad19efa5bd1dee4f3e5270eb406613c974394035e5bfc4ec1aba870b879"},
@@ -2719,9 +2723,10 @@ files = [
 name = "pyarrow"
 version = "21.0.0"
 description = "Python library for Apache Arrow"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"standalone\" or extra == \"all\""
 files = [
     {file = "pyarrow-21.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:e563271e2c5ff4d4a4cbeb2c83d5cf0d4938b891518e676025f7268c6fe5fe26"},
     {file = "pyarrow-21.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:fee33b0ca46f4c85443d6c450357101e47d53e6c3f008d658c27a2d020d44c79"},
@@ -2883,9 +2888,10 @@ testutils = ["gitpython (>3)"]
 name = "pyspark"
 version = "4.0.1"
 description = "Apache Spark Python API"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"standalone\" or extra == \"all\""
 files = [
     {file = "pyspark-4.0.1.tar.gz", hash = "sha256:9d1f22d994f60369228397e3479003ffe2dd736ba79165003246ff7bd48e2c73"},
 ]
@@ -3010,6 +3016,7 @@ files = [
     {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
     {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
 ]
+markers = {main = "extra == \"standalone\" or extra == \"all\""}
 
 [package.dependencies]
 six = ">=1.5"
@@ -3048,9 +3055,10 @@ dev = ["black", "build", "mypy", "pytest", "pytest-cov", "setuptools", "tox", "t
 name = "pytz"
 version = "2025.2"
 description = "World timezone definitions, modern and historical"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"standalone\" or extra == \"all\""
 files = [
     {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
     {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
@@ -3795,9 +3803,10 @@ files = [
 name = "tzdata"
 version = "2025.2"
 description = "Provider of IANA time zone data"
-optional = false
+optional = true
 python-versions = ">=2"
 groups = ["main"]
+markers = "extra == \"standalone\" or extra == \"all\""
 files = [
     {file = "tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8"},
     {file = "tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9"},
@@ -3905,9 +3914,10 @@ files = [
 name = "zipp"
 version = "3.23.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"standalone\" or extra == \"all\""
 files = [
     {file = "zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
     {file = "zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"},
@@ -3922,13 +3932,13 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_it
 type = ["pytest-mypy"]
 
 [extras]
-all = ["azure-synapse-artifacts", "databricks-sdk"]
+all = ["azure-synapse-artifacts", "databricks-sdk", "delta-spark", "pandas", "pyarrow", "pyspark"]
 databricks = ["databricks-sdk"]
 fabric = []
-standalone = []
+standalone = ["delta-spark", "pandas", "pyarrow", "pyspark"]
 synapse = ["azure-synapse-artifacts"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "41fd9402085472f76966651f488883d04acac603a4cb2a1df6f96e19c2b1858d"
+content-hash = "a01c812b91b83bb839446757fbfbca3ddb4e92e420fb02e353e14382e96000c9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,14 @@ azure-mgmt-storage = "22.1.0"
 # and kindling_sdk.platform_* use them at design time.
 databricks-sdk = ">=0.12.0"
 azure-synapse-artifacts = ">=0.17.0"
+# Spark runtime also needed at dev time: unit tests import from kindling
+# modules that do `from pyspark import ...` at module scope. Managed cloud
+# runtimes provide these via non-pip mechanisms (hence [standalone] extra
+# for local/CI consumers), but dev env has to pip-install them directly.
+pyspark = ">=3.4.0"
+delta-spark = ">=2.4.0"
+pandas = ">=2.0.0"
+pyarrow = ">=12.0.0"
 
 [tool.poe.tasks]
 # Version management

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "spark-kindling"
-version = "0.9.0"
+version = "0.9.1"
 description = "A unified framework for data apps across Fabric, Synapse, and Databricks"
 authors = ["SEP Engineering <engineering@sep.com>"]
 license = "MIT"
@@ -15,32 +15,51 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-# Core framework (required on every platform)
-pyspark = ">=3.4.0"
-delta-spark = ">=2.4.0"
-pandas = ">=2.0.0"
-pyarrow = ">=12.0.0"
+# Core framework (required on every platform). Kept as a narrow,
+# pure-Python set so the wheel installs cleanly on cloud Spark runtimes
+# (Synapse, Fabric, Databricks) without pip trying to upgrade packages
+# the runtime already provides via non-pip mechanisms.
 injector = ">=0.20.1"
 dynaconf = ">=3.1.0"
 pyyaml = ">=6.0"
 packaging = ">=23.0"
 blinker = ">=1.6.0"
-# Azure storage (shared across Synapse, Fabric, and Azure-backed Databricks)
-azure-storage-blob = ">=12.14.0"
-azure-storage-file-datalake = ">=12.14.0"
-azure-identity = ">=1.15.0"
+# Azure SDKs used by every Azure-backed platform.
+# Pins intentionally loose — match the v0.8.x per-platform wheels so pip
+# accepts the cluster's pre-installed versions without re-resolving.
 azure-core = ">=1.30.0,<1.31.0"  # Pin to 1.30.x - compatible with Fabric runtime 1.30.2
-# Platform-exclusive runtime deps live in extras (see [tool.poetry.extras])
+azure-identity = ">=1.12.0"
+azure-storage-file-datalake = ">=12.0.0"
+# Platform-exclusive runtime deps live in extras (see [tool.poetry.extras]).
+# Spark runtime deps (pyspark, delta-spark, pandas, pyarrow) are optional
+# because managed runtimes provide them via non-pip mechanisms; declaring
+# them as required Requires-Dist causes pip to hang trying to resolve them
+# during on-cluster install. Local/CI consumers get them via the
+# [standalone] extra instead.
 azure-synapse-artifacts = {version = ">=0.17.0", optional = true}
 databricks-sdk = {version = ">=0.12.0", optional = true}
+pyspark = {version = ">=3.4.0", optional = true}
+delta-spark = {version = ">=2.4.0", optional = true}
+pandas = {version = ">=2.0.0", optional = true}
+pyarrow = {version = ">=12.0.0", optional = true}
 
 [tool.poetry.extras]
 # Install with: pip install 'spark-kindling[synapse]' etc.
+# synapse/databricks/fabric: for cloud consumers — add platform-specific SDKs.
+# standalone: for local dev / CI / generic-Spark consumers — pull in pyspark
+#   and friends that managed runtimes already provide.
 synapse = ["azure-synapse-artifacts"]
 databricks = ["databricks-sdk"]
 fabric = []
-standalone = []
-all = ["azure-synapse-artifacts", "databricks-sdk"]
+standalone = ["pyspark", "delta-spark", "pandas", "pyarrow"]
+all = [
+    "azure-synapse-artifacts",
+    "databricks-sdk",
+    "pyspark",
+    "delta-spark",
+    "pandas",
+    "pyarrow",
+]
 
 [tool.poetry.plugins."spark_kindling.platforms"]
 # Platform service discovery via importlib.metadata entry points.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,19 +15,21 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-# Core framework (required on every platform). Kept as a narrow,
-# pure-Python set so the wheel installs cleanly on cloud Spark runtimes
-# (Synapse, Fabric, Databricks) without pip trying to upgrade packages
-# the runtime already provides via non-pip mechanisms.
+# Core framework (required on every platform). Kept as a minimal base
+# dependency set with no Spark runtime deps so the wheel installs cleanly
+# on cloud Spark runtimes (Synapse, Fabric, Databricks) without pip trying
+# to upgrade packages the runtime already provides via non-pip mechanisms.
 injector = ">=0.20.1"
 dynaconf = ">=3.1.0"
 pyyaml = ">=6.0"
 packaging = ">=23.0"
 blinker = ">=1.6.0"
 # Azure SDKs used by every Azure-backed platform.
-# Pins intentionally loose — match the v0.8.x per-platform wheels so pip
-# accepts the cluster's pre-installed versions without re-resolving.
-azure-core = ">=1.30.0,<1.31.0"  # Pin to 1.30.x - compatible with Fabric runtime 1.30.2
+# `azure-core` is intentionally constrained to 1.30.x for managed-runtime
+# compatibility (for example, Fabric runtime 1.30.2). `azure-identity` and
+# `azure-storage-file-datalake` are intentionally kept loose so pip accepts
+# the cluster's pre-installed versions without unnecessary re-resolution.
+azure-core = ">=1.30.0,<1.31.0"
 azure-identity = ">=1.12.0"
 azure-storage-file-datalake = ">=12.0.0"
 # Platform-exclusive runtime deps live in extras (see [tool.poetry.extras]).


### PR DESCRIPTION
## Summary

Patch fix for the v0.9.0 synapse regression. The combined runtime wheel was declaring `pyspark`, `delta-spark`, `pandas`, `pyarrow` as required distribution deps. On Synapse clusters those are runtime-provided via a non-pip mechanism, so pip hangs trying to upgrade/fetch during on-cluster install. Moves them into the `[standalone]` extra, matching the shape of the v0.8.x per-platform wheels.

## Evidence

| | v0.8.15 | v0.9.0 | v0.9.1 |
|---|---|---|---|
| `test_default_telemetry[synapse]` | passed in 2m34s | **hung, 600s timeout** | expected to pass cleanly |
| Wheel `Requires-Dist` | 8 packages | 16 packages | 8 packages (+ `blinker`) |

Fetched and diffed the actual wheel METADATA from the v0.8.15 GitHub release asset vs the v0.9.0 release asset to confirm the regression surface.

## What changes

- `pyspark`, `delta-spark`, `pandas`, `pyarrow` → moved from `[tool.poetry.dependencies]` to `[tool.poetry.extras].standalone`.
- `azure-identity` pin loosened `>=1.15.0` → `>=1.12.0` (match v0.8.x per-platform wheels).
- `azure-storage-file-datalake` pin loosened `>=12.14.0` → `>=12.0.0` (same).
- Dropped explicit `azure-storage-blob` — transitive via `azure-storage-file-datalake`.
- Bumps to `0.9.1` in all three pyprojects.

## Test plan

- [x] Unit tests pass (26/26 on the targeted suites).
- [x] New wheel METADATA diffed against v0.8.15 — base `Requires-Dist` is now a strict subset.
- [ ] Post-merge: deploy v0.9.1 to Azure Storage, re-run `test_default_telemetry[synapse]`, confirm drop back to ~2-3 min.
- [ ] Cut v0.9.1 release; CI system tests act as the final gate.

## Upgrade note

Managed-runtime consumers (Synapse/Fabric/Databricks notebooks using the bootstrap script): **no action required** — the bootstrap picks up the new wheel automatically.

Local / CI consumers that expected `pip install spark-kindling` to pull pyspark should switch to `pip install 'spark-kindling[standalone]'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)