### PR TITLE
Polish local dev workflow and bump version to 0.9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -654,10 +654,34 @@ jobs:
           name: platform-wheels
           path: dist/
 
+      - name: Create stable release alias assets
+        run: |
+          set -euo pipefail
+          RUNTIME_WHEEL=$(ls dist/spark_kindling-*.whl 2>/dev/null | head -1)
+          if [ -z "$RUNTIME_WHEEL" ]; then
+            echo "❌ Could not find runtime wheel in dist/"
+            ls -lh dist/ || true
+            exit 1
+          fi
+
+          RUNTIME_WHEEL_NAME=$(basename "$RUNTIME_WHEEL")
+          RELEASE_TAG="${{ github.event.release.tag_name }}"
+          printf '%s\n' \
+            "https://github.com/${{ github.repository }}/releases/download/${RELEASE_TAG}/${RUNTIME_WHEEL_NAME}" \
+            > dist/spark_kindling-current-url.txt
+
+          printf '%s\n%s\n' \
+            "CURRENT_RUNTIME_URL=\$(curl -fsSL https://github.com/${{ github.repository }}/releases/latest/download/spark_kindling-current-url.txt)" \
+            'pip install "spark-kindling[standalone] @ ${CURRENT_RUNTIME_URL}"' \
+            > dist/spark_kindling-current-install.txt
+
       - name: Attach wheels to release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/*.whl
+          files: |
+            dist/*.whl
+            dist/spark_kindling-current-url.txt
+            dist/spark_kindling-current-install.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -669,10 +693,10 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Package | File |" >> $GITHUB_STEP_SUMMARY
           echo "|---------|------|" >> $GITHUB_STEP_SUMMARY
-          for wheel in dist/*.whl; do
-            filename=$(basename "$wheel")
-            size=$(du -h "$wheel" | cut -f1)
-            echo "| ${filename%.whl} | $filename ($size) |" >> $GITHUB_STEP_SUMMARY
+          for asset in dist/*; do
+            filename=$(basename "$asset")
+            size=$(du -h "$asset" | cut -f1)
+            echo "| ${filename%.*} | $filename ($size) |" >> $GITHUB_STEP_SUMMARY
           done
 
   test-summary:

--- a/docs/ci_cd_setup.md
+++ b/docs/ci_cd_setup.md
@@ -74,7 +74,7 @@ For release/manual system-test runs, CI:
 
 1. builds wheel artifacts
 2. downloads them into `dist/`
-3. deploys them to Azure storage with `python scripts/deploy.py`
+3. deploys them to Azure storage with `poetry run poe deploy`
 4. passes the resolved `AZURE_BASE_PATH` into system tests
 5. attaches wheels to the GitHub release only after all platform lanes succeed
 

--- a/docs/ci_cd_setup.md
+++ b/docs/ci_cd_setup.md
@@ -1,359 +1,105 @@
 # CI/CD Pipeline Setup Guide
 
-This guide explains how to set up and use the Kindling CI/CD pipeline.
+This document describes how CI/CD works in the current repository state.
 
-## 🎯 Overview
+## Current Workflow Triggers
 
-The CI/CD pipeline provides automated:
-- **Build**: Poetry-based platform wheel building
-- **Test**: Unit, integration, KDA packaging, and system tests
-- **Quality**: Code formatting, linting, type checking, and security scanning
-- **Release**: Build artifacts ready for distribution
+The main workflow is `.github/workflows/ci.yml`.
 
-## 📋 Pipeline Jobs
+It runs on:
 
-### Core Jobs (Run on Every Push/PR)
+- push to `main` and `develop`
+- pull requests targeting `main`
+- published releases
+- manual `workflow_dispatch`
 
-1. **Unit Tests** - Fast tests of individual components
-2. **Code Quality** - Black, pylint, mypy checks
-3. **Build Platform Wheels** - Creates platform-specific wheels
+## What Runs When
 
-### Extended Jobs (Run on main/develop)
+### On Push / Pull Request
 
-4. **Integration Tests** - Azure storage integration (requires credentials)
-5. **KDA Packaging Tests** - Validates KDA packaging system
-6. **System Tests** - End-to-end platform testing (synapse, databricks, fabric, local)
-7. **Security Scan** - Vulnerability and security analysis
+These lanes run as part of normal CI:
 
-### Summary Job
+- build CI container image
+- unit tests / quality lanes
+- integration tests
+- KDA packaging tests
+- summary reporting
 
-8. **Test Summary** - Aggregates results from all jobs
+### On Release / Manual Dispatch
 
-## 🔐 Required GitHub Secrets
+These additional lanes run only for release publishing or manual dispatch:
 
-Configure these in: **Repository Settings** → **Secrets and variables** → **Actions**
+- build wheel artifacts for release/system-test use
+- deploy candidate artifacts to Azure storage
+- system tests for Synapse, Fabric, and Databricks
+- attach wheels to the GitHub release, but only if all system tests pass
 
-### Secrets (Sensitive)
-```
-AZURE_STORAGE_KEY_TEST     - Storage account key for testing
-AZURE_STORAGE_KEY_STAGING  - Storage account key for staging (optional)
-```
+That means pushes to `main` do **not** automatically run full system tests in
+current CI. System tests are reserved for `release` and `workflow_dispatch`.
 
-### Variables (Non-sensitive)
-```
-TEST_STORAGE_ACCOUNT       - Azure storage account name for tests
-TEST_CONTAINER             - Azure container name for tests
-STAGING_STORAGE_ACCOUNT    - Azure storage account name for staging (optional)
-STAGING_CONTAINER          - Azure container name for staging (optional)
-```
+## Authentication Model
 
-## 🔑 Azure Storage Authentication Setup
+The workflow uses Azure service-principal authentication, not storage-account keys.
 
-### Get Storage Account Key
+Shared Azure auth secrets used by deploy/system-test lanes:
 
-#### Option 1: Azure Portal
-1. Navigate to your Storage Account
-2. Go to **Security + networking** → **Access keys**
-3. Copy **key1** or **key2** value
+- `AZURE_TENANT_ID`
+- `AZURE_CLIENT_ID`
+- `AZURE_CLIENT_SECRET`
 
-#### Option 2: Azure CLI
-```bash
-# Get storage account key
-az storage account keys list \
-  --account-name YOUR-STORAGE-ACCOUNT \
-  --resource-group YOUR-RESOURCE-GROUP \
-  --query '[0].value' -o tsv
-```
+Shared storage variables:
 
-### Add to GitHub Secrets
+- `AZURE_STORAGE_ACCOUNT`
+- `AZURE_CONTAINER`
 
-1. Go to **Repository Settings** → **Secrets and variables** → **Actions**
-2. Click **New repository secret**
-3. Add secrets:
-   - Name: `AZURE_STORAGE_KEY_TEST`
-   - Value: (paste your storage account key)
-   - Name: `AZURE_STORAGE_KEY_STAGING` (optional, for system tests)
-   - Value: (paste your staging storage account key)
+Additional platform secrets used by system tests:
 
-### Add to GitHub Variables
+- `FABRIC_WORKSPACE_ID`
+- `FABRIC_LAKEHOUSE_ID`
+- `SYNAPSE_WORKSPACE_NAME`
+- `SYNAPSE_SPARK_POOL`
+- `DATABRICKS_HOST`
+- `DATABRICKS_CLUSTER_ID`
+- platform Key Vault / test resource secrets already referenced in the workflow
 
-1. Go to **Repository Settings** → **Secrets and variables** → **Actions** → **Variables** tab
-2. Click **New repository variable**
-3. Add variables:
-   - `TEST_STORAGE_ACCOUNT`: Your storage account name (e.g., "mystorageacct")
-   - `TEST_CONTAINER`: Your container name (e.g., "kindling-tests")
-   - `STAGING_STORAGE_ACCOUNT`: (optional) Staging storage account name
-   - `STAGING_CONTAINER`: (optional) Staging container name
+## Artifact Flow
 
-> **Note**: Storage account key authentication is simpler than Service Principal and sufficient for storage-only access. It doesn't require Azure Active Directory setup or RBAC permissions.
+The repo now builds and deploys a combined runtime wheel:
 
-## �� Usage
+- `spark_kindling-<version>-py3-none-any.whl`
+- `spark_kindling_cli-<version>-py3-none-any.whl`
+- `spark_kindling_sdk-<version>-py3-none-any.whl`
 
-### Automatic Triggers
+For release/manual system-test runs, CI:
 
-The pipeline runs automatically on:
+1. builds wheel artifacts
+2. downloads them into `dist/`
+3. deploys them to Azure storage with `python scripts/deploy.py`
+4. passes the resolved `AZURE_BASE_PATH` into system tests
+5. attaches wheels to the GitHub release only after all platform lanes succeed
 
-**Pull Requests** → Runs: unit tests, code quality, build wheels
+## Local Parity Commands
 
-**Push to develop** → Runs: Everything above + integration tests + KDA tests
-
-**Push to main** → Runs: Everything above + system tests
-
-### Manual Workflow Run
-
-1. Go to **Actions** tab in GitHub
-2. Select "Kindling CI/CD Pipeline"
-3. Click "Run workflow"
-4. Choose branch and click "Run"
-
-## 📦 Build Artifacts
-
-After each workflow run, artifacts are available:
-
-| Artifact | Contains |
-|----------|----------|
-| `unit-test-results` | Test results XML + HTML coverage |
-| `code-quality-reports` | Pylint and mypy reports |
-| `integration-test-results` | Integration test XML |
-| `kda-test-results` | KDA packaging test results |
-| `system-test-results-{platform}` | System test results per platform |
-| `security-reports` | Safety and bandit scan results |
-| `platform-wheels` | Built .whl files for all platforms |
-
-### Download Artifacts
-
-1. Go to **Actions** → Select a workflow run
-2. Scroll to **Artifacts** section
-3. Click artifact name to download
-
-### Use Built Wheels
+The repo tasks that map most closely to CI are:
 
 ```bash
-# Download platform-wheels artifact
-unzip platform-wheels.zip
-
-# Install specific platform
-pip install kindling_synapse-0.2.0-py3-none-any.whl
-pip install kindling_databricks-0.2.0-py3-none-any.whl
-pip install kindling_fabric-0.2.0-py3-none-any.whl
+poetry install
+poetry run poe test-unit
+poetry run poe test-integration
+poetry run poe test-system --platform synapse
+poetry run poe build
+poetry run poe deploy
 ```
 
-## 🧪 Running Tests Locally
+## Manual System Test Dispatch
 
-### Prerequisites
-```bash
-# Install Poetry
-curl -sSL https://install.python-poetry.org | python3 -
+`workflow_dispatch` supports targeted system-test runs and worker overrides.
+The workflow exposes inputs for:
 
-# Install dependencies
-poetry install --with dev
-```
+- platform selection
+- xdist worker count override
+- poll interval override
+- stdout stream max wait override
+- completion timeout override
 
-### Run Tests
-
-```bash
-# Unit tests
-poetry run pytest tests/unit/ -v
-
-# Unit tests with coverage
-poetry run pytest tests/unit/ --cov=packages/kindling --cov-report=html
-
-# Integration tests (requires Azure credentials)
-export AZURE_STORAGE_ACCOUNT="your-account"
-export AZURE_CONTAINER="your-container"
-poetry run pytest tests/integration/ -v
-
-# KDA packaging tests
-poetry run python tests/test_kda_packaging.py
-
-# Code quality
-poetry run black --check packages/ tests/
-poetry run pylint packages/kindling/
-poetry run mypy packages/kindling/
-```
-
-### Build Wheels Locally
-
-```bash
-# Build all platform wheels
-chmod +x scripts/build_platform_wheels.sh
-./scripts/build_platform_wheels.sh
-
-# Check built wheels
-ls -lh dist/
-```
-
-## 🐛 Troubleshooting
-
-### Unit Tests Fail
-
-1. Check test output in **Actions** → workflow run → **unit-tests** job
-2. Download `unit-test-results` artifact for detailed HTML report
-3. Run locally: `poetry run pytest tests/unit/ -v`
-
-### Integration Tests Fail
-
-**Common issues:**
-- ❌ Azure storage key not configured → Add `AZURE_STORAGE_KEY_TEST` secret
-- ❌ Storage account/container variables missing → Add `TEST_STORAGE_ACCOUNT` and `TEST_CONTAINER` variables
-- ❌ Storage account not accessible → Check firewall rules or network restrictions
-- ❌ Container doesn't exist → Create the container in your storage account
-
-**Debug:**
-```bash
-# Test storage access with key
-az storage container list \
-  --account-name YOUR-STORAGE-ACCOUNT \
-  --account-key YOUR-STORAGE-KEY
-
-# Create container if needed
-az storage container create \
-  --name kindling-tests \
-  --account-name YOUR-STORAGE-ACCOUNT \
-  --account-key YOUR-STORAGE-KEY
-```
-
-### Build Wheels Fail
-
-**Common issues:**
-- ❌ Poetry not installed → Check "Install Poetry" step in workflow
-- ❌ Missing platform configs → Ensure `build-configs/*.toml` exist
-- ❌ Source files missing → Verify `packages/kindling/` exists
-
-### System Tests Fail
-
-System tests are **expected to fail** if you don't have real Azure Synapse/Databricks/Fabric environments configured. They're marked with `|| true` in the workflow to not block the pipeline.
-
-To enable:
-1. Configure real platform credentials
-2. Remove `|| true` from system tests step
-3. Update platform-specific test configurations
-
-## 🎨 Customization
-
-### Skip Certain Jobs
-
-Edit `.github/workflows/ci.yml` and add conditions:
-
-```yaml
-integration-tests:
-  if: github.ref == 'refs/heads/main' && false  # Always skip
-```
-
-### Change Python Version
-
-```yaml
-env:
-  PYTHON_VERSION: "3.11"  # Change to 3.10, 3.12, etc.
-```
-
-### Add New Test Suite
-
-```yaml
-  custom-tests:
-    name: Custom Tests
-    runs-on: ubuntu-latest
-    needs: unit-tests
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install Poetry
-        run: pip install poetry
-
-      - name: Install dependencies
-        run: poetry install --with dev
-
-      - name: Run custom tests
-        run: poetry run pytest tests/custom/ -v
-```
-
-## 📊 Monitoring & Metrics
-
-### GitHub Actions Dashboard
-
-View all runs: `https://github.com/{owner}/{repo}/actions`
-
-### Status Badge
-
-Add to README.md:
-```markdown
-![CI/CD](https://github.com/{owner}/{repo}/workflows/Kindling%20CI%2FCD%20Pipeline/badge.svg)
-```
-
-### Codecov Integration
-
-If you have Codecov configured:
-1. Coverage is automatically uploaded
-2. View at: `https://codecov.io/gh/{owner}/{repo}`
-
-## 🔄 Future Enhancements
-
-When you're ready to add publishing:
-
-### PyPI Publishing
-```yaml
-  publish-to-pypi:
-    name: Publish to PyPI
-    runs-on: ubuntu-latest
-    needs: [build-platform-wheels, system-tests]
-    environment: production
-    if: github.event_name == 'release'
-
-    steps:
-      - name: Download wheels
-        uses: actions/download-artifact@v3
-        with:
-          name: platform-wheels
-          path: dist/
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-```
-
-### GitHub Packages Publishing
-```yaml
-  publish-to-github:
-    name: Publish to GitHub Packages
-    runs-on: ubuntu-latest
-    needs: [build-platform-wheels]
-    if: github.ref == 'refs/heads/main'
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Poetry
-        run: pip install poetry
-
-      - name: Configure GitHub Packages
-        run: |
-          poetry config repositories.github https://pypi.pkg.github.com/${{ github.repository_owner }}
-          poetry config pypi-token.github ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish
-        run: poetry publish --repository github
-```
-
-## 📚 Additional Resources
-
-- [GitHub Actions Documentation](https://docs.github.com/en/actions)
-- [Poetry Documentation](https://python-poetry.org/docs/)
-- [Azure CLI Service Principal](https://learn.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli)
-- [Kindling Build System](./build_system.md)
-
-## 💡 Tips
-
-1. **Start Simple**: Begin with just unit tests, add more as needed
-2. **Use Environments**: Separate test/staging/prod with approvals
-3. **Monitor Costs**: Azure integration tests use cloud resources
-4. **Cache Dependencies**: Poetry cache speeds up builds significantly
-5. **Parallel Jobs**: Jobs run in parallel when possible for speed
+That is the supported path for ad hoc end-to-end validation without cutting a release.

--- a/docs/developer_workflow.md
+++ b/docs/developer_workflow.md
@@ -1,312 +1,81 @@
 # Developer Workflow
 
-## Quick Start with poethepoet
+This repo uses Poetry plus Poe the Poet for day-to-day development.
 
-This project uses [poethepoet](https://poethepoet.natn.io/) as a task runner, similar to npm scripts. All development tasks are defined in `pyproject.toml` under `[tool.poe.tasks]`.
-
-### Available Tasks
+## Core Commands
 
 ```bash
-# Build platform-specific wheels
+poetry install
+poetry run poe test-unit
+poetry run poe test-integration
+poetry run poe test-system --platform synapse
 poetry run poe build
-
-# Deploy wheels to Azure Storage
-poetry run poe deploy                           # Deploy all platforms
-poetry run poe deploy --platform synapse        # Deploy only synapse wheel
-poetry run poe deploy --platform databricks     # Deploy only databricks wheel
-poetry run poe deploy --platform fabric         # Deploy only fabric wheel
-
-# Deploy from GitHub release assets (production)
-poetry run poe deploy --release latest          # Deploy all platforms from latest release
-poetry run poe deploy --release <version>           # Deploy all platforms from specific release
-
-# Run tests with coverage
-poetry run poe test
-
-# Format code with black
-poetry run poe format
-
-# Lint code with pylint
-poetry run poe lint
-
-# Run all checks (format, lint, test)
-poetry run poe check
+poetry run poe deploy --platform fabric
+poetry run poe upload
 ```
 
-## Build & Deploy Workflow
+## Build Model
 
-### 1. Local Development Testing
+`poetry run poe build` produces the current artifact set:
 
-```bash
-# Make your changes to packages/kindling/
+- `spark_kindling-<version>-py3-none-any.whl` — combined runtime wheel
+- `spark_kindling_cli-<version>-py3-none-any.whl` — CLI wheel
+- `spark_kindling_sdk-<version>-py3-none-any.whl` — SDK wheel
 
-# Build wheels
-poetry run poe build
-
-# Deploy to Azure Storage for testing
-az login  # One-time authentication
-poetry run poe deploy                         # Deploy all platforms
-
-# OR deploy individual platforms:
-poetry run poe deploy --platform synapse      # Deploy only synapse
-poetry run poe deploy --platform databricks   # Deploy only databricks
-poetry run poe deploy --platform fabric       # Deploy only fabric
-```
-
-This builds one combined runtime wheel (plus CLI and SDK) and uploads them to:
-```
-sepstdatalakedev/artifacts/packages/
-  ├── spark_kindling-<version>-py3-none-any.whl
-  ├── spark_kindling_cli-<version>-py3-none-any.whl
-  └── spark_kindling_sdk-<version>-py3-none-any.whl
-```
-
-The combined wheel ships every `platform_*.py` module; consumers select their
-platform's runtime deps via extras at install time:
+The runtime wheel contains every platform module. Consumers select platform
+runtime dependencies with extras such as:
 
 ```bash
 pip install 'spark-kindling[synapse]'
 pip install 'spark-kindling[databricks]'
 pip install 'spark-kindling[fabric]'
+pip install 'spark-kindling[standalone]'
 ```
 
-**Platform-specific deployment** is useful when:
-- Testing changes that only affect one platform
-- Faster iteration during development
-- Deploying hotfixes to specific platforms
+## Deploy Paths
 
-### 2. Release Deployment
+There are two common deployment flows:
 
 ```bash
-# After creating a GitHub release with wheels attached:
-poetry run poe deploy --release latest
-
-# Or deploy a specific release version:
-poetry run poe deploy --release <version>
-```
-
-### 3. Advanced Usage (Debug Only)
-
-Calling the scripts directly is supported for debugging but not the recommended workflow. Prefer the `poetry run poe ...` tasks above for normal development.
-
-```bash
-# Same as `poe deploy` with finer-grained flags
-python scripts/deploy.py --release
-python scripts/deploy.py --release <version>
-python scripts/deploy.py --release --platform synapse
-```
-
-## Build System Architecture
-
-### Python Scripts (scripts/ directory)
-
-The build and deployment tools are Python modules in the `scripts/` package:
-
-- **`scripts/build.py`**: Builds the combined `spark-kindling` runtime wheel plus the design-time `spark-kindling-cli` and `spark-kindling-sdk` wheels.
-- **`scripts/deploy.py`**: Deploys wheels to Azure Storage using azure-identity SDK
-
-### Key Features
-
-1. **Single Source Version**: Version is read from root `pyproject.toml` only.
-2. **Combined Runtime Wheel**: One wheel ships every `platform_*.py` module. Install-time extras (`[synapse]`, `[databricks]`, `[fabric]`) pull in platform-exclusive runtime deps.
-3. **Platform Discovery via Entry Points**: `[tool.poetry.plugins."spark_kindling.platforms"]` advertises which platform modules are available; `initialize_platform_services` uses `importlib.metadata.entry_points` to locate them and raises an actionable error if the matching extra isn't installed.
-4. **Azure Identity Integration**: Uses DefaultAzureCredential (Azure CLI, environment variables, managed identity).
-
-### Directory Structure
-
-```
-scripts/                    # Build/deployment tools (not distributed)
-  __init__.py
-  build.py                 # Combined-wheel builder
-  deploy.py                # Azure Storage deployment
-
-packages/kindling/          # The actual library (distributed in the runtime wheel)
-  __init__.py
-  bootstrap.py
-  platform_provider.py
-  platform_synapse.py      # Shipped in every wheel; synapse extras needed to use
-  platform_databricks.py   # Shipped in every wheel; databricks extras needed to use
-  platform_fabric.py       # Shipped in every wheel
-  platform_standalone.py   # Shipped in every wheel; local-dev fallback
-  ...
-```
-
-## Authentication Methods
-
-### DefaultAzureCredential
-
-The deploy script uses Azure Identity's `DefaultAzureCredential`, which automatically tries authentication methods in this order:
-
-1. **Environment Variables** (service principal)
-2. **Managed Identity** (when running in Azure)
-3. **Azure CLI** (`az login`)
-4. **Visual Studio Code**
-5. **Azure PowerShell**
-
-### Local Development with Service Principal
-
-```bash
-# Set environment variables
-export AZURE_CLIENT_ID="<service-principal-client-id>"
-export AZURE_CLIENT_SECRET="<service-principal-secret>"
-export AZURE_TENANT_ID="<tenant-id>"
-
-# Deploy
+# Upload the current runtime artifacts to storage
 poetry run poe deploy
+poetry run poe upload
+
+# Push workspace bootstrap assets and config
+kindling workspace deploy --platform synapse --storage-account <account>
 ```
 
-Or use a `.env` file (add to `.gitignore`!):
+The Python deploy helpers now prefer the combined runtime wheel and only fall
+back to legacy `kindling_<platform>-*.whl` artifacts when needed.
+
+## CLI Lifecycle Commands
+
+The CLI now exposes design-time lifecycle commands beyond config/workspace:
 
 ```bash
-# Create .env
-cat > .env << 'ENV'
-AZURE_CLIENT_ID=<client-id>
-AZURE_CLIENT_SECRET=<secret>
-AZURE_TENANT_ID=<tenant-id>
-ENV
-
-# Load and deploy
-source .env
-poetry run poe deploy
+kindling app package <app-dir>
+kindling app deploy <app-dir-or-kda> --platform fabric
+kindling app cleanup <app-name> --platform fabric
+kindling job create job.yaml --platform synapse
+kindling job run <job-id> --platform synapse
+kindling job status <run-id> --platform synapse
+kindling job logs <run-id> --platform synapse
+kindling job cancel <run-id> --platform synapse
+kindling job delete <job-id> --platform synapse
 ```
 
-### Local Development with Azure CLI
+Remote app/job commands require `spark-kindling-sdk`.
 
-```bash
-# One-time login
-az login
+## Authentication
 
-# Deploy (uses cached credentials)
-poetry run poe deploy
-```
+Repo deploy and CI flows use Azure identity, not storage keys:
 
-### Required Azure Permissions
+- `AZURE_TENANT_ID`
+- `AZURE_CLIENT_ID`
+- `AZURE_CLIENT_SECRET`
+- `AZURE_STORAGE_ACCOUNT`
+- `AZURE_CONTAINER`
+- optional `AZURE_BASE_PATH`
 
-The service principal needs the **Storage Blob Data Contributor** role:
-
-```bash
-az role assignment create \
-  --assignee <client-id> \
-  --role "Storage Blob Data Contributor" \
-  --scope "/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.Storage/storageAccounts/sepstdatalakedev"
-```
-
-## CI/CD Integration
-
-### GitHub Actions
-
-The Python scripts work seamlessly in GitHub Actions:
-
-```yaml
-name: Build and Deploy
-
-on:
-  push:
-    branches: [main]
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-
-      - name: Install Poetry
-        run: pip install poetry
-
-      - name: Install dependencies
-        run: poetry install
-
-      - name: Build wheels
-        run: poetry run poe build
-
-      - name: Deploy to Azure
-        env:
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-        run: poetry run poe deploy
-```
-
-**Setup GitHub Secrets:**
-1. Go to repository Settings → Secrets and variables → Actions
-2. Add secrets:
-   - `AZURE_CLIENT_ID`
-   - `AZURE_CLIENT_SECRET`
-   - `AZURE_TENANT_ID`
-
-### Testing Authentication
-
-Test service principal authentication without deploying:
-
-```bash
-python -c "
-from azure.identity import DefaultAzureCredential
-from azure.storage.blob import BlobServiceClient
-
-credential = DefaultAzureCredential()
-client = BlobServiceClient(
-    'https://sepstdatalakedev.blob.core.windows.net',
-    credential=credential
-)
-container = client.get_container_client('artifacts')
-print('✅ Authentication successful!')
-print(f'Container: {container.container_name}')
-"
-```
-
-## Version Management
-
-The version is managed in a single location:
-
-```toml
-# pyproject.toml
-[tool.poetry]
-version = "<version>"  # Single source of truth
-```
-
-Platform-specific builds automatically use this version.
-
-## Platform-Specific Dependencies
-
-Dependencies are configured in `scripts/generate_platform_config.py`:
-
-```python
-PLATFORM_DEPS = {
-    "synapse": ['azure-synapse-artifacts = ">=0.17.0"'],
-    "databricks": [],  # All in runtime
-    "fabric": [],      # All in runtime
-}
-```
-
-Only Synapse requires additional packages not provided by the runtime.
-
-## Testing
-
-```bash
-# Run all tests with coverage
-poetry run poe test
-
-# Run specific test file
-poetry run pytest tests/test_bootstrap.py -v
-
-# Run with coverage report
-poetry run pytest --cov=kindling --cov-report=html
-```
-
-## Code Quality
-
-```bash
-# Format code (auto-fix)
-poetry run poe format
-
-# Lint code (check only)
-poetry run poe lint
-
-# Run all checks
-poetry run poe check
-```
+For local work you can either export those values directly or use `az login`
+when the command supports `DefaultAzureCredential`.

--- a/docs/local_python_first.md
+++ b/docs/local_python_first.md
@@ -7,6 +7,11 @@ only move to remote workspaces when you want deployment or end-to-end tests.
 ## Quick Start
 
 ```bash
+# Install Kindling from this repo's latest GitHub release.
+CURRENT_RUNTIME_URL=$(curl -fsSL https://github.com/sep/spark-kindling-framework/releases/latest/download/spark_kindling-current-url.txt)
+pip install "spark-kindling[standalone] @ ${CURRENT_RUNTIME_URL}"
+
+# Then scaffold and work on your local project.
 kindling new my-pipeline
 cd my_pipeline
 poetry install
@@ -44,10 +49,17 @@ The package import still stays `import kindling`.
 
 ## Installing the Framework Locally
 
-There are three supported paths:
+Assuming you are installing Kindling from this project's GitHub releases:
 
 ```bash
-# 1. Released package for local/CI use
+CURRENT_RUNTIME_URL=$(curl -fsSL https://github.com/sep/spark-kindling-framework/releases/latest/download/spark_kindling-current-url.txt)
+pip install "spark-kindling[standalone] @ ${CURRENT_RUNTIME_URL}"
+```
+
+Other supported paths are:
+
+```bash
+# 1. Released package for local/CI use from PyPI
 pip install 'spark-kindling[standalone]'
 
 # 2. Editable source install for framework iteration

--- a/docs/local_python_first.md
+++ b/docs/local_python_first.md
@@ -1,298 +1,130 @@
 # Local Python-First Development with Kindling
 
-This guide covers how to build, test, and package a Kindling data pipeline project entirely in Python — no notebooks required during development.
+This guide covers the current local-development path for Kindling projects.
+The generated workflow is Python-first: scaffold locally, run `poe` tasks, and
+only move to remote workspaces when you want deployment or end-to-end tests.
 
-**Background:** see `docs/proposals/local_code_first_development.md` for the design rationale.
-
----
-
-## Quick start
+## Quick Start
 
 ```bash
-# Scaffold a new project
 kindling new my-pipeline
-
 cd my_pipeline
-
-# Install deps (kindling separately — see "Installing Kindling" below)
 poetry install
-pip install kindling  # or: pip install -e /path/to/kindling-source
-
-# Copy and fill in credentials
 cp .env.example .env
-# edit .env
-
-# Run unit and component tests (no Azure needed)
 source .env
-poetry run pytest tests/unit tests/component
 
-# Run integration tests (requires Azure credentials in .env)
-poetry run pytest tests/integration
+poetry run poe test
+poetry run poe build
 ```
 
----
-
-## Project structure
-
-`kindling new` generates a project with this layout — the same regardless of `--layers` or `--auth`:
-
-```
-my_pipeline/
-  src/my_pipeline/
-    app.py              initialize() + register_all()
-    entities/           DataEntities.entity() registrations
-    pipes/              @DataPipes.pipe decorators
-    transforms/         pure-PySpark functions (unit-testable)
-  config/
-    settings.yaml       base Kindling config
-    env.local.yaml      ABFSS entity paths from env vars
-  .env.example          all required env vars (auth-specific)
-  .gitignore
-  tests/
-    conftest.py         Spark fixtures (auth-flavored)
-    unit/               pure Python, no Spark catalog, no Azure
-    component/          DI wiring, no Azure
-    integration/        live ABFSS reads/writes
-  pyproject.toml
-```
-
-### `kindling new` options
-
-| Option | Values | Effect |
-|--------|--------|--------|
-| `--auth` | `oauth` (default), `key`, `cli` | ABFSS auth method in conftest.py |
-| `--layers` | `medallion` (default), `minimal` | Template content (bronze/silver vs. raw) |
-| `--no-integration` | flag | Skip `tests/integration/` |
-| `--output-dir` | path | Parent directory (default: `.`) |
-
-All combinations produce the same directory structure and wheel layout.
-
----
-
-## Installing Kindling locally
-
-Kindling is not pinned to a path in `pyproject.toml` by design — the environment controls which version is installed:
+If you generated integration tests and have Azure credentials available:
 
 ```bash
-# Option A: use the kindling-local wheel (all platforms, full runtime deps)
-poetry run poe build          # from the kindling repo
-pip install dist/kindling_local-*.whl
+poetry run poe test-integration
+```
 
-# Option B: editable install from source (fastest inner loop)
+## What `kindling new` Creates
+
+`kindling new` now generates:
+
+- `src/<pkg>/...` application source
+- `config/settings.yaml` plus `config/env.local.yaml`
+- `tests/unit`, `tests/component`, and optionally `tests/integration`
+- `pyproject.toml` with `poethepoet` tasks
+- `.github/workflows/ci.yml` with a starter CI job that runs `poe test` and `poe build`
+- `.devcontainer/` for local containerized development
+
+The generated `pyproject.toml` depends on the published runtime distribution:
+
+```toml
+spark-kindling = { version = ">=0.9.1", extras = ["standalone"] }
+```
+
+The package import still stays `import kindling`.
+
+## Installing the Framework Locally
+
+There are three supported paths:
+
+```bash
+# 1. Released package for local/CI use
+pip install 'spark-kindling[standalone]'
+
+# 2. Editable source install for framework iteration
 pip install -e /path/to/kindling
 
-# Option C: install a released version
-pip install "kindling>=0.8.14"
+# 3. Local wheel built from this repo
+poetry run poe build
+pip install 'spark-kindling[standalone] @ file:///path/to/dist/spark_kindling-<version>-py3-none-any.whl'
 ```
 
----
+Use the `standalone` extra for local work because it brings in the Spark runtime
+packages that managed platforms already provide.
 
-## Setting up the local Spark stack
+## Local Test Tasks
 
-Unit tests run with a plain `SparkSession` and need no special setup. Component tests need Kindling's DI system but not Spark at all. Integration tests need the full stack:
-
-### 1. Java
-
-PySpark requires Java 11 or later on `PATH`:
+Generated projects expose these tasks:
 
 ```bash
-# Ubuntu / Debian
-sudo apt-get install -y openjdk-17-jdk
-java -version
+poetry run poe test-unit
+poetry run poe test-component
+poetry run poe test
+poetry run poe build
 ```
 
-### 2. PySpark and delta-spark
-
-These are declared as `[tool.poetry.dependencies]` in your `pyproject.toml`:
+When integration tests are included, the scaffold also adds:
 
 ```bash
-poetry install   # installs pyspark and delta-spark automatically
+poetry run poe test-integration
+poetry run poe test-all
 ```
 
-### 3. Hadoop-Azure JARs
+## Local Spark Prerequisites
 
-Maven resolution is unreliable in dev containers. Pre-download the JARs and the generated `conftest.py` will reference them via `spark.jars`:
+For local integration tests against ABFSS you still need:
 
-```bash
-mkdir -p /tmp/hadoop-jars
-cd /tmp/hadoop-jars
+1. Java 11+ on `PATH`
+2. The Python environment installed via `poetry install`
+3. Hadoop Azure JARs in `/tmp/hadoop-jars`
 
-curl -LO https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/3.3.4/hadoop-azure-3.3.4.jar
-curl -LO https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure-datalake/3.3.4/hadoop-azure-datalake-3.3.4.jar
-curl -LO https://repo1.maven.org/maven2/com/microsoft/azure/azure-storage/8.6.6/azure-storage-8.6.6.jar
-curl -LO https://repo1.maven.org/maven2/org/wildfly/openssl/wildfly-openssl/1.1.3.Final/wildfly-openssl-1.1.3.Final.jar
-curl -LO https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util-ajax/9.4.51.v20230217/jetty-util-ajax-9.4.51.v20230217.jar
-```
-
-### Verify the full local stack
+The CLI checks all of this for you:
 
 ```bash
 kindling env check --local --config config/settings.yaml
 ```
 
-Expected output when everything is ready:
+## Packaging and Remote Lifecycle
 
-```
-[PASS] python_version: 3.11.x (>=3.10)
-[PASS] config_file_exists: config/settings.yaml
-[PASS] kindling_section_present: root.kindling is a mapping
-[PASS] java: openjdk version "17.0.x" ...
-[PASS] pyspark: 3.5.x
-[PASS] delta_spark: 3.x.x
-[PASS] hadoop_azure_jars: /tmp/hadoop-jars
-Environment check passed.
-```
-
----
-
-## Configuration
-
-### `config/settings.yaml` — base config
-
-```yaml
-kindling:
-  delta:
-    access_mode: storage     # use explicit provider.path, not Spark catalog
-    optimize_write: false
-
-  telemetry:
-    logging:
-      level: INFO
-      print: true
-
-  bootstrap:
-    load_local: false        # consumer code is imported explicitly
-```
-
-### `config/env.local.yaml` — local overlay
-
-Entity paths are resolved from environment variables using `@secret:` references:
-
-```yaml
-# IMPORTANT: entity_tags must be at the TOP LEVEL — no 'default:' wrapper.
-# Dynaconf's get_entity_tags() looks for a top-level key.
-entity_tags:
-  bronze.records:
-    provider.path: "@secret:ABFSS_BRONZE_PATH"
-  silver.records:
-    provider.path: "@secret:ABFSS_SILVER_PATH"
-```
-
-`StandaloneService` resolves `@secret:VAR_NAME` from environment variables. Set them in `.env`:
+The CLI now covers the basic local-to-remote app lifecycle:
 
 ```bash
-ABFSS_BRONZE_PATH=abfss://kindling-dev@myaccount.dfs.core.windows.net/bronze/records
-ABFSS_SILVER_PATH=abfss://kindling-dev@myaccount.dfs.core.windows.net/silver/records
+# Package an app directory into a .kda archive
+kindling app package path/to/app-dir
+
+# Deploy an app directory or .kda package
+kindling app deploy path/to/app-dir --platform fabric --app-name my-app
+
+# Create and run remote jobs from YAML/JSON
+kindling job create job.yaml --platform synapse
+kindling job run <job-id> --platform synapse
+kindling job status <run-id> --platform synapse
+kindling job logs <run-id> --platform synapse
 ```
 
----
+These remote operations use `spark-kindling-sdk`, so install it alongside the
+CLI when you want deploy/manage capabilities.
 
-## The three test layers
+## Artifact Storage and Workspace Bootstrap
 
-### Unit tests — pure Python
-
-```python
-# tests/unit/test_transforms.py
-def test_drop_null_keys(spark_local):
-    from my_pipeline.transforms.quality import drop_null_keys
-    df = spark_local.createDataFrame([Row(id="a"), Row(id=None)])
-    assert drop_null_keys(df).count() == 1
-```
-
-- Uses the `spark_local` fixture: plain `SparkSession`, no Delta catalog, no Azure
-- No credentials needed
-- Fast — Spark starts in seconds without Delta or Azure JARs
-
-### Component tests — DI wiring
-
-```python
-# tests/component/test_registration.py
-@pytest.fixture(scope="module", autouse=True)
-def initialize_my_pipeline():
-    from my_pipeline.app import initialize
-    initialize(env="local")   # reads config/env.local.yaml
-
-def test_pipe_is_registered():
-    pipe = GlobalInjector.get(DataPipesRegistry).get_pipe_definition("bronze_to_silver")
-    assert pipe.output_entity_id == "silver.records"
-```
-
-- Calls `initialize(env="local")` — bootstraps Kindling's DI with the standalone platform
-- No Spark, no Azure — `@secret:` references are left unresolved (that's fine for metadata tests)
-- Validates entity/pipe registration, metadata, and DI graph correctness
-
-### Integration tests — live ABFSS
-
-```python
-# tests/integration/test_pipeline.py
-@pytest.mark.integration
-@pytest.mark.requires_azure
-class TestPipeline:
-    @pytest.fixture(autouse=True)
-    def _setup(self, spark_abfss):
-        from my_pipeline.app import initialize
-        self.spark = spark_abfss
-        self.svc = initialize(env="local")
-```
-
-- Uses `spark_abfss` fixture: Delta-enabled session with Azure auth
-- Skipped automatically when Azure credentials are absent
-- Reads and writes real ABFSS Delta tables
-
----
-
-## Key implementation notes
-
-### Initialization order matters
-
-```python
-# app.py — this order is required
-svc = initialize_framework({"platform": "standalone", ...})
-register_all()   # AFTER — @DataPipes.pipe resolves DataPipesRegistry from DI at import time
-```
-
-### Schema and tags are required
-
-`DataEntities.entity()` requires `schema=` (a `StructType`). `@DataPipes.pipe` requires `tags=`. Both are included in the `kindling new` templates.
-
-### `spark_local` must not configure Delta catalog
-
-Without Delta JARs on the classpath, Spark fails on _any_ query if the Delta catalog extension is configured. Unit test fixtures omit Delta configuration entirely; only `spark_abfss` enables it.
-
-### YAML format for `entity_tags`
-
-Dynaconf's `get_entity_tags()` looks for a **top-level** `entity_tags` key. Do not nest it under `default:`:
-
-```yaml
-# CORRECT
-entity_tags:
-  bronze.records:
-    provider.path: "@secret:ABFSS_BRONZE_PATH"
-
-# WRONG — get_entity_tags() returns {}
-default:
-  entity_tags:
-    bronze.records:
-      provider.path: "@secret:ABFSS_BRONZE_PATH"
-```
-
----
-
-## Building and distributing the wheel
-
-Your project is a standard Python package. Build it with Poetry:
+For notebook-backed platforms, the storage bootstrap flow still uses:
 
 ```bash
-poetry build
-# produces dist/my-pipeline-0.1.0-py3-none-any.whl
+kindling workspace deploy --platform synapse --storage-account <account>
 ```
 
-The wheel can be installed in any environment that has Kindling available — cloud notebooks, CI pipelines, or other local environments. The build output is identical regardless of which `kindling new` options were used.
+`workspace deploy` now prefers the combined runtime wheel:
 
-For the Kindling framework itself, use `poetry run poe build` to produce the `kindling-local` wheel (includes all platforms and full runtime deps):
+- `dist/spark_kindling-*.whl`
+- falls back to legacy `dist/kindling_<platform>-*.whl` if needed
 
-```bash
-# from the kindling repo root
-poetry run poe build
-pip install dist/kindling_local-*.whl
-```
+It also uploads `runtime/scripts/kindling_bootstrap.py` plus config overlays.

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -107,8 +107,9 @@ pip install 'spark-kindling[synapse] @ file:///path/to/spark_kindling-<version>-
 # Install directly from GitHub Release (one wheel, pick your extra)
 pip install 'spark-kindling[synapse] @ https://github.com/sep/spark-kindling-framework/releases/download/v<version>/spark_kindling-<version>-py3-none-any.whl'
 
-# Or use the "latest" release
-pip install 'spark-kindling[databricks] @ https://github.com/sep/spark-kindling-framework/releases/latest/download/spark_kindling-<version>-py3-none-any.whl'
+# Or resolve the latest release through the stable alias asset
+CURRENT_RUNTIME_URL=$(curl -fsSL https://github.com/sep/spark-kindling-framework/releases/latest/download/spark_kindling-current-url.txt)
+pip install "spark-kindling[databricks] @ ${CURRENT_RUNTIME_URL}"
 ```
 
 ### In requirements.txt
@@ -119,8 +120,8 @@ pip install 'spark-kindling[databricks] @ https://github.com/sep/spark-kindling-
 # Install specific version from release with synapse extras
 spark-kindling[synapse] @ https://github.com/sep/spark-kindling-framework/releases/download/v<version>/spark_kindling-<version>-py3-none-any.whl
 
-# Or always use latest with databricks extras
-spark-kindling[databricks] @ https://github.com/sep/spark-kindling-framework/releases/latest/download/spark_kindling-<version>-py3-none-any.whl
+# Or resolve latest from the stable alias asset before generating requirements
+# (the wheel filename itself remains versioned)
 ```
 
 ### In Databricks/Synapse/Fabric

--- a/packages/kindling_cli/README.md
+++ b/packages/kindling_cli/README.md
@@ -9,17 +9,30 @@ Command-line tooling for the Spark Kindling Framework. Distributed on PyPI as
 pip install spark-kindling-cli
 ```
 
-Depends on `spark-kindling-sdk` for the underlying platform operations; install
-it explicitly if you want to use the SDK directly.
+Depends on `spark-kindling-sdk` for remote platform lifecycle operations.
+Install the SDK alongside the CLI when you want to deploy apps or manage jobs:
+
+```bash
+pip install spark-kindling-sdk
+```
 
 ## Commands
 
 - `kindling config init` — generate a starter `settings.yaml`
 - `kindling config set <key> <value>` — set a config value using dot-notation
 - `kindling env check` — validate the local Python/config environment
-- `kindling workspace check` — validate the configured platform workspace (auto-detects platform from env vars)
+- `kindling workspace check` — validate the configured platform workspace
 - `kindling workspace init` — scaffold bootstrap + starter notebook files for a platform
-- `kindling workspace deploy` — upload wheels, bootstrap, config, and notebooks to the configured artifacts storage
+- `kindling workspace deploy` — upload the runtime wheel, bootstrap script, config, and notebooks to artifact storage
+- `kindling app package` — build a `.kda` archive from a local app directory
+- `kindling app deploy` — deploy an app directory or `.kda` package through the SDK
+- `kindling app cleanup` — remove a deployed app from remote storage
+- `kindling job create` — create a remote job from a YAML/JSON config file
+- `kindling job run` — start a job run, optionally with parameters
+- `kindling job status` — fetch the current run status
+- `kindling job logs` — fetch or stream run logs
+- `kindling job cancel` — cancel an active run
+- `kindling job delete` — delete a remote job definition
 
 Run any command with `--help` for full options.
 

--- a/packages/kindling_cli/kindling_cli/cli.py
+++ b/packages/kindling_cli/kindling_cli/cli.py
@@ -4,7 +4,7 @@ import json
 import os
 import sys
 import zipfile
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import quote
 
@@ -119,6 +119,23 @@ def _read_text_file(file_path: Path) -> str:
         raise click.ClickException(f"Failed to read `{file_path}`: {exc}") from exc
 
 
+def _normalize_archive_entry_path(entry_name: str) -> str:
+    """Validate and normalize archive entry paths to safe POSIX-relative paths."""
+    normalized = str(entry_name or "").replace("\\", "/").strip()
+    if not normalized:
+        raise click.ClickException("Archive contains an empty file path.")
+    if normalized.startswith("/") or (len(normalized) >= 2 and normalized[1] == ":"):
+        raise click.ClickException(f"Archive contains an unsafe absolute path: `{entry_name}`")
+
+    posix_path = PurePosixPath(normalized)
+    if any(part in ("", ".", "..") for part in posix_path.parts):
+        raise click.ClickException(
+            f"Archive contains an unsafe relative path traversal: `{entry_name}`"
+        )
+
+    return posix_path.as_posix()
+
+
 def _prepare_app_files(app_path: Path) -> Dict[str, str]:
     """Collect app source files from a directory or a .kda archive."""
     resolved_path = app_path.expanduser().resolve()
@@ -132,7 +149,8 @@ def _prepare_app_files(app_path: Path) -> Dict[str, str]:
                         continue
                     if not file_info.filename.endswith((".py", ".yaml", ".yml")):
                         continue
-                    app_files[file_info.filename] = archive.read(file_info.filename).decode("utf-8")
+                    rel_path = _normalize_archive_entry_path(file_info.filename)
+                    app_files[rel_path] = archive.read(file_info.filename).decode("utf-8")
         except Exception as exc:
             raise click.ClickException(
                 f"Failed to read app package `{resolved_path}`: {exc}"

--- a/packages/kindling_cli/kindling_cli/cli.py
+++ b/packages/kindling_cli/kindling_cli/cli.py
@@ -1,7 +1,9 @@
 """CLI entrypoint for Kindling design-time tooling."""
 
+import json
 import os
 import sys
+import zipfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import quote
@@ -58,6 +60,112 @@ def _load_yaml_config(config_path: Path) -> Dict[str, Any]:
             f"Config file `{config_path}` must contain a YAML object at root."
         )
     return data
+
+
+def _load_mapping_file(file_path: Path, label: str) -> Dict[str, Any]:
+    """Load a JSON or YAML file whose root object must be a mapping."""
+    resolved_path = file_path.expanduser().resolve()
+    if not resolved_path.exists():
+        raise click.ClickException(f"{label} file `{resolved_path}` was not found.")
+
+    try:
+        raw_text = resolved_path.read_text(encoding="utf-8")
+    except Exception as exc:
+        raise click.ClickException(f"Failed to read {label} file `{resolved_path}`: {exc}") from exc
+
+    try:
+        if resolved_path.suffix.lower() == ".json":
+            data = json.loads(raw_text)
+        else:
+            data = yaml.safe_load(raw_text) or {}
+    except Exception as exc:
+        raise click.ClickException(
+            f"Failed to parse {label} file `{resolved_path}`: {exc}"
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise click.ClickException(
+            f"{label.capitalize()} file `{resolved_path}` must contain a JSON/YAML object at root."
+        )
+    return data
+
+
+def _emit_json(data: Any) -> None:
+    """Pretty-print structured output for CLI responses."""
+    click.echo(json.dumps(data, indent=2, sort_keys=True, default=str))
+
+
+def _create_platform_api(platform: str):
+    """Construct a remote platform API client from the current environment."""
+    try:
+        from kindling_sdk.platform_provider import create_platform_api_from_env
+    except ImportError as exc:
+        raise click.ClickException(
+            "Remote platform operations require spark-kindling-sdk.\n"
+            "Install with: pip install spark-kindling-sdk"
+        ) from exc
+
+    try:
+        api_client, resolved_platform = create_platform_api_from_env(platform)
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+    return api_client, resolved_platform
+
+
+def _read_text_file(file_path: Path) -> str:
+    try:
+        return file_path.read_text(encoding="utf-8")
+    except Exception as exc:
+        raise click.ClickException(f"Failed to read `{file_path}`: {exc}") from exc
+
+
+def _prepare_app_files(app_path: Path) -> Dict[str, str]:
+    """Collect app source files from a directory or a .kda archive."""
+    resolved_path = app_path.expanduser().resolve()
+
+    if resolved_path.is_file() and resolved_path.suffix.lower() == ".kda":
+        app_files: Dict[str, str] = {}
+        try:
+            with zipfile.ZipFile(resolved_path, "r") as archive:
+                for file_info in archive.infolist():
+                    if file_info.is_dir():
+                        continue
+                    if not file_info.filename.endswith((".py", ".yaml", ".yml")):
+                        continue
+                    app_files[file_info.filename] = archive.read(file_info.filename).decode("utf-8")
+        except Exception as exc:
+            raise click.ClickException(
+                f"Failed to read app package `{resolved_path}`: {exc}"
+            ) from exc
+
+        if not app_files:
+            raise click.ClickException(
+                f"No application files were found in `{resolved_path}`. "
+                "Expected .py, .yaml, or .yml entries."
+            )
+        return app_files
+
+    if resolved_path.is_dir():
+        app_files = {}
+        for pattern in ("*.py", "*.yaml", "*.yml"):
+            for file_path in sorted(resolved_path.rglob(pattern)):
+                rel_path = file_path.relative_to(resolved_path).as_posix()
+                app_files[rel_path] = _read_text_file(file_path)
+
+        if not app_files:
+            raise click.ClickException(
+                f"No application files were found in `{resolved_path}`. "
+                "Expected at least one .py, .yaml, or .yml file."
+            )
+        return app_files
+
+    raise click.ClickException(
+        f"Invalid app path `{resolved_path}`. Expected a directory or a `.kda` archive."
+    )
+
+
+def _default_app_name(app_path: Path) -> str:
+    return app_path.stem if app_path.is_file() else app_path.name
 
 
 def _coerce_value(raw: str) -> Any:
@@ -586,15 +694,18 @@ def _upload_blob(
 
 
 def _find_wheels(dist_dir: Path, platform: Optional[str] = None) -> List[Path]:
-    """Find kindling platform wheels in a directory."""
+    """Find runtime wheels, preferring the combined spark-kindling artifact."""
+    combined_wheels = sorted(dist_dir.glob("spark_kindling-*.whl"))
+    if combined_wheels:
+        return combined_wheels
+
     if platform:
-        wheels = sorted(dist_dir.glob(f"kindling_{platform}-*.whl"))
-    else:
-        wheels = []
-        for p in ("synapse", "databricks", "fabric"):
-            wheels.extend(dist_dir.glob(f"kindling_{p}-*.whl"))
-        wheels = sorted(wheels)
-    return wheels
+        return sorted(dist_dir.glob(f"kindling_{platform}-*.whl"))
+
+    legacy_wheels: List[Path] = []
+    for legacy_platform in ("synapse", "databricks", "fabric"):
+        legacy_wheels.extend(dist_dir.glob(f"kindling_{legacy_platform}-*.whl"))
+    return sorted(legacy_wheels)
 
 
 def _deploy_wheels(
@@ -1171,9 +1282,9 @@ def workspace_deploy(
     \b
     Deploys the following artifacts to the target storage account:
 
-      - Kindling platform wheel(s) → {base}/packages/
-      - kindling_bootstrap.py      → {base}/scripts/
-      - settings.yaml + overlays   → {base}/config/
+      - spark_kindling-*.whl (or legacy runtime wheel[s]) → {base}/packages/
+      - kindling_bootstrap.py                            → {base}/scripts/
+      - settings.yaml + overlays                         → {base}/config/
 
     \b
     With --create-notebooks and --workspace, also imports starter notebooks
@@ -1232,7 +1343,8 @@ def workspace_deploy(
         wheels = _find_wheels(resolved_dist, resolved_platform)
         if not wheels:
             raise click.ClickException(
-                f"No kindling_{resolved_platform} wheels found in {resolved_dist}."
+                f"No runtime wheel artifacts were found in {resolved_dist}.\n"
+                "Expected dist/spark_kindling-*.whl or legacy dist/kindling_<platform>-*.whl."
             )
         click.echo(f"Packages → {packages_path}/")
         count = _deploy_wheels(blob_service_client, resolved_container, packages_path, wheels)
@@ -1299,6 +1411,288 @@ def workspace_deploy(
         click.echo()
 
     click.echo("Deploy complete.")
+
+
+@cli.group("app")
+def app_group() -> None:
+    """Package and deploy Kindling applications."""
+
+
+@app_group.command("package")
+@click.argument(
+    "app_path",
+    type=click.Path(path_type=Path, exists=True, file_okay=False),
+)
+@click.option(
+    "--output",
+    "output_path",
+    default=None,
+    type=click.Path(path_type=Path, dir_okay=False),
+    help="Destination .kda file. Defaults to dist/<app-dir>.kda.",
+)
+def app_package(app_path: Path, output_path: Optional[Path]) -> None:
+    """Package an application directory into a .kda archive."""
+    resolved_app_path = app_path.expanduser().resolve()
+    app_files = _prepare_app_files(resolved_app_path)
+
+    resolved_output = (
+        output_path.expanduser().resolve()
+        if output_path
+        else (Path.cwd() / "dist" / f"{resolved_app_path.name}.kda").resolve()
+    )
+    resolved_output.parent.mkdir(parents=True, exist_ok=True)
+
+    with zipfile.ZipFile(resolved_output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for rel_path, content in sorted(app_files.items()):
+            archive.writestr(rel_path, content)
+
+    click.echo(f"Packaged `{resolved_app_path}` -> `{resolved_output}` ({len(app_files)} file(s)).")
+
+
+@app_group.command("deploy")
+@click.argument(
+    "app_path",
+    type=click.Path(path_type=Path, exists=True),
+)
+@click.option("--app-name", default=None, help="Remote app name. Defaults to the path stem/name.")
+@click.option(
+    "--platform",
+    type=click.Choice(SUPPORTED_PLATFORMS),
+    default=None,
+    help="Target platform. Auto-detected from environment if omitted.",
+)
+def app_deploy(app_path: Path, app_name: Optional[str], platform: Optional[str]) -> None:
+    """Deploy an app directory or .kda package using the remote platform SDK."""
+    resolved_platform = platform or _detect_platform_from_environment()
+    if not resolved_platform:
+        raise click.ClickException(
+            "Unable to determine platform. Set --platform or one of "
+            "FABRIC_WORKSPACE_ID, SYNAPSE_WORKSPACE_NAME, DATABRICKS_HOST."
+        )
+
+    resolved_app_path = app_path.expanduser().resolve()
+    app_files = _prepare_app_files(resolved_app_path)
+    api_client, resolved_platform = _create_platform_api(resolved_platform)
+    resolved_name = (app_name or _default_app_name(resolved_app_path)).strip()
+    if not resolved_name:
+        raise click.ClickException("App name resolved to an empty string.")
+
+    storage_path = api_client.deploy_app(resolved_name, app_files)
+    click.echo(
+        f"Deployed app `{resolved_name}` to `{storage_path}` "
+        f"on {resolved_platform} ({len(app_files)} file(s))."
+    )
+
+
+@app_group.command("cleanup")
+@click.argument("app_name")
+@click.option(
+    "--platform",
+    type=click.Choice(SUPPORTED_PLATFORMS),
+    default=None,
+    help="Target platform. Auto-detected from environment if omitted.",
+)
+def app_cleanup(app_name: str, platform: Optional[str]) -> None:
+    """Delete a previously deployed remote application."""
+    resolved_platform = platform or _detect_platform_from_environment()
+    if not resolved_platform:
+        raise click.ClickException(
+            "Unable to determine platform. Set --platform or one of "
+            "FABRIC_WORKSPACE_ID, SYNAPSE_WORKSPACE_NAME, DATABRICKS_HOST."
+        )
+
+    api_client, resolved_platform = _create_platform_api(resolved_platform)
+    deleted = api_client.cleanup_app(app_name)
+    if not deleted:
+        raise click.ClickException(
+            f"Remote cleanup for app `{app_name}` did not succeed on {resolved_platform}."
+        )
+    click.echo(f"Deleted app `{app_name}` on {resolved_platform}.")
+
+
+@cli.group("job")
+def job_group() -> None:
+    """Create and manage remote Spark jobs."""
+
+
+@job_group.command("create")
+@click.argument(
+    "config_path",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+)
+@click.option(
+    "--platform",
+    type=click.Choice(SUPPORTED_PLATFORMS),
+    default=None,
+    help="Target platform. Auto-detected from environment if omitted.",
+)
+def job_create(config_path: Path, platform: Optional[str]) -> None:
+    """Create a remote job definition from a YAML or JSON config file."""
+    resolved_platform = platform or _detect_platform_from_environment()
+    if not resolved_platform:
+        raise click.ClickException(
+            "Unable to determine platform. Set --platform or one of "
+            "FABRIC_WORKSPACE_ID, SYNAPSE_WORKSPACE_NAME, DATABRICKS_HOST."
+        )
+
+    job_config = _load_mapping_file(config_path, "job config")
+    job_name = str(job_config.get("job_name") or "").strip()
+    if not job_name:
+        raise click.ClickException("Job config must define `job_name`.")
+
+    api_client, _ = _create_platform_api(resolved_platform)
+    _emit_json(api_client.create_job(job_name, job_config))
+
+
+@job_group.command("run")
+@click.argument("job_id")
+@click.option(
+    "--parameters",
+    "parameters_path",
+    default=None,
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    help="Optional YAML/JSON file of run parameters.",
+)
+@click.option(
+    "--platform",
+    type=click.Choice(SUPPORTED_PLATFORMS),
+    default=None,
+    help="Target platform. Auto-detected from environment if omitted.",
+)
+def job_run(job_id: str, parameters_path: Optional[Path], platform: Optional[str]) -> None:
+    """Start a remote job run."""
+    resolved_platform = platform or _detect_platform_from_environment()
+    if not resolved_platform:
+        raise click.ClickException(
+            "Unable to determine platform. Set --platform or one of "
+            "FABRIC_WORKSPACE_ID, SYNAPSE_WORKSPACE_NAME, DATABRICKS_HOST."
+        )
+
+    parameters = _load_mapping_file(parameters_path, "parameters") if parameters_path else None
+    api_client, _ = _create_platform_api(resolved_platform)
+    click.echo(api_client.run_job(job_id, parameters=parameters))
+
+
+@job_group.command("status")
+@click.argument("run_id")
+@click.option(
+    "--platform",
+    type=click.Choice(SUPPORTED_PLATFORMS),
+    default=None,
+    help="Target platform. Auto-detected from environment if omitted.",
+)
+def job_status(run_id: str, platform: Optional[str]) -> None:
+    """Fetch the current status for a job run."""
+    resolved_platform = platform or _detect_platform_from_environment()
+    if not resolved_platform:
+        raise click.ClickException(
+            "Unable to determine platform. Set --platform or one of "
+            "FABRIC_WORKSPACE_ID, SYNAPSE_WORKSPACE_NAME, DATABRICKS_HOST."
+        )
+
+    api_client, _ = _create_platform_api(resolved_platform)
+    _emit_json(api_client.get_job_status(run_id))
+
+
+@job_group.command("logs")
+@click.argument("run_id")
+@click.option(
+    "--job-id",
+    default=None,
+    help="Job identifier. Required when --stream is used.",
+)
+@click.option("--from-line", default=0, show_default=True, type=int)
+@click.option("--size", default=1000, show_default=True, type=int)
+@click.option("--stream", is_flag=True, help="Tail stdout logs until completion or timeout.")
+@click.option("--poll-interval", default=5.0, show_default=True, type=float)
+@click.option("--max-wait", default=300.0, show_default=True, type=float)
+@click.option(
+    "--platform",
+    type=click.Choice(SUPPORTED_PLATFORMS),
+    default=None,
+    help="Target platform. Auto-detected from environment if omitted.",
+)
+def job_logs(
+    run_id: str,
+    job_id: Optional[str],
+    from_line: int,
+    size: int,
+    stream: bool,
+    poll_interval: float,
+    max_wait: float,
+    platform: Optional[str],
+) -> None:
+    """Fetch or stream logs for a remote job run."""
+    resolved_platform = platform or _detect_platform_from_environment()
+    if not resolved_platform:
+        raise click.ClickException(
+            "Unable to determine platform. Set --platform or one of "
+            "FABRIC_WORKSPACE_ID, SYNAPSE_WORKSPACE_NAME, DATABRICKS_HOST."
+        )
+
+    if stream and not job_id:
+        raise click.ClickException("--job-id is required when --stream is used.")
+
+    api_client, _ = _create_platform_api(resolved_platform)
+    if stream:
+        api_client.stream_stdout_logs(
+            job_id=job_id,
+            run_id=run_id,
+            callback=click.echo,
+            poll_interval=poll_interval,
+            max_wait=max_wait,
+        )
+        return
+
+    _emit_json(api_client.get_job_logs(run_id, from_line=from_line, size=size))
+
+
+@job_group.command("cancel")
+@click.argument("run_id")
+@click.option(
+    "--platform",
+    type=click.Choice(SUPPORTED_PLATFORMS),
+    default=None,
+    help="Target platform. Auto-detected from environment if omitted.",
+)
+def job_cancel(run_id: str, platform: Optional[str]) -> None:
+    """Cancel a remote job run."""
+    resolved_platform = platform or _detect_platform_from_environment()
+    if not resolved_platform:
+        raise click.ClickException(
+            "Unable to determine platform. Set --platform or one of "
+            "FABRIC_WORKSPACE_ID, SYNAPSE_WORKSPACE_NAME, DATABRICKS_HOST."
+        )
+
+    api_client, _ = _create_platform_api(resolved_platform)
+    cancelled = api_client.cancel_job(run_id)
+    if not cancelled:
+        raise click.ClickException(f"Failed to cancel run `{run_id}`.")
+    click.echo(f"Cancelled run `{run_id}`.")
+
+
+@job_group.command("delete")
+@click.argument("job_id")
+@click.option(
+    "--platform",
+    type=click.Choice(SUPPORTED_PLATFORMS),
+    default=None,
+    help="Target platform. Auto-detected from environment if omitted.",
+)
+def job_delete(job_id: str, platform: Optional[str]) -> None:
+    """Delete a remote job definition."""
+    resolved_platform = platform or _detect_platform_from_environment()
+    if not resolved_platform:
+        raise click.ClickException(
+            "Unable to determine platform. Set --platform or one of "
+            "FABRIC_WORKSPACE_ID, SYNAPSE_WORKSPACE_NAME, DATABRICKS_HOST."
+        )
+
+    api_client, _ = _create_platform_api(resolved_platform)
+    deleted = api_client.delete_job(job_id)
+    if not deleted:
+        raise click.ClickException(f"Failed to delete job `{job_id}`.")
+    click.echo(f"Deleted job `{job_id}`.")
 
 
 @cli.command("new")
@@ -1375,6 +1769,8 @@ def new_project(
         unit/             — transform functions, no Azure
         component/        — DI wiring, no Azure
         integration/      — live ABFSS read/write (unless --no-integration)
+      .github/workflows/
+        ci.yml           — starter CI for tests + build
       pyproject.toml
 
     \b
@@ -1421,9 +1817,9 @@ def new_project(
     click.echo(f"  cd {cfg.snake_name}")
     click.echo("  poetry install")
     click.echo("  cp .env.example .env  # fill in your credentials, then: source .env")
-    click.echo("  poetry run pytest tests/unit tests/component")
+    click.echo("  poetry run poe test")
     if cfg.integration:
-        click.echo("  poetry run pytest tests/integration  # requires Azure creds in .env")
+        click.echo("  poetry run poe test-integration  # requires Azure creds in .env")
 
 
 def main() -> None:

--- a/packages/kindling_cli/kindling_cli/scaffold.py
+++ b/packages/kindling_cli/kindling_cli/scaffold.py
@@ -161,6 +161,7 @@ def generate_project(cfg: ScaffoldConfig) -> List[Path]:
     _write("pyproject.toml", _render(env, "pyproject.toml.j2", cfg))
     _write(".env.example", _render(env, ".env.example.j2", cfg))
     _write(".gitignore", _render(env, ".gitignore.j2", cfg))
+    _write(".github/workflows/ci.yml", _render(env, ".github/workflows/ci.yml.j2", cfg))
     _write(".devcontainer/Dockerfile", _render(env, ".devcontainer/Dockerfile.j2", cfg))
     _write(
         ".devcontainer/devcontainer.json", _render(env, ".devcontainer/devcontainer.json.j2", cfg)

--- a/packages/kindling_cli/kindling_cli/templates/.github/workflows/ci.yml.j2
+++ b/packages/kindling_cli/kindling_cli/templates/.github/workflows/ci.yml.j2
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v3
+
+      - name: Install dependencies
+        run: poetry install --no-interaction
+
+      - name: Run unit and component tests
+        run: poetry run poe test
+
+      - name: Build wheel
+        run: poetry run poe build

--- a/packages/kindling_cli/kindling_cli/templates/pyproject.toml.j2
+++ b/packages/kindling_cli/kindling_cli/templates/pyproject.toml.j2
@@ -10,16 +10,24 @@ packages = [{include = "{{ snake_name }}", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-# kindling is installed separately — either from the kindling-local wheel
-# or via `pip install -e /path/to/kindling` for source iteration.
-# The manifest does not pin the install path so both workflows are identical.
-kindling = ">=0.8.14"
-pyspark = ">=3.4.0"
-delta-spark = ">=2.4.0"
+# The runtime distribution is published as `spark-kindling`, while imports
+# remain `import kindling`. The standalone extra pulls in local Spark deps.
+spark-kindling = {version = ">=0.9.1", extras = ["standalone"]}
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.0.0"
 pytest-cov = ">=4.0.0"
+poethepoet = ">=0.24.0"
+
+[tool.poe.tasks]
+test-unit = "pytest tests/unit -v"
+test-component = "pytest tests/component -v"
+{% if integration %}
+test-integration = "pytest tests/integration -v"
+test-all = { sequence = ["test-unit", "test-component", "test-integration"] }
+{% endif %}
+test = { sequence = ["test-unit", "test-component"] }
+build = "poetry build"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/packages/kindling_cli/pyproject.toml
+++ b/packages/kindling_cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "spark-kindling-cli"
-version = "0.9.1"
+version = "0.9.2"
 description = "Command-line tooling for Kindling"
 authors = ["SEP Engineering <engineering@sep.com>"]
 license = "MIT"

--- a/packages/kindling_sdk/pyproject.toml
+++ b/packages/kindling_sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "spark-kindling-sdk"
-version = "0.9.1"
+version = "0.9.2"
 description = "Design-time platform SDK for Kindling"
 authors = ["SEP Engineering <engineering@sep.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "spark-kindling"
-version = "0.9.1"
+version = "0.9.2"
 description = "A unified framework for data apps across Fabric, Synapse, and Databricks"
 authors = ["SEP Engineering <engineering@sep.com>"]
 license = "MIT"

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -118,13 +118,20 @@ def download_release_wheels(version: str, repo: str, temp_dir: Path) -> None:
 
 def get_wheels(wheels_dir: Path, platform: Optional[str] = None) -> List[Path]:
     """Get wheel files from directory, optionally filtered to one runtime platform."""
+    combined_runtime_wheels = sorted(wheels_dir.glob("spark_kindling-*.whl"))
+    if combined_runtime_wheels:
+        if platform:
+            return combined_runtime_wheels
+        return sorted(wheels_dir.glob("*.whl"))
+
     if platform:
         pattern = f"kindling_{platform}-*.whl"
         wheels = list(wheels_dir.glob(pattern))
         if not wheels:
             raise FileNotFoundError(
-                f"No {platform} wheel found in {wheels_dir}. "
-                f"Available platforms: synapse, databricks, fabric"
+                f"No runtime wheel found in {wheels_dir}. "
+                "Expected spark_kindling-*.whl or legacy "
+                f"kindling_{platform}-*.whl."
             )
         return sorted(wheels)
 

--- a/scripts/upload_to_storage.sh
+++ b/scripts/upload_to_storage.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 # Upload runtime wheels to Azure Storage
-# Usage:
-#   ./scripts/upload_to_storage.sh               # Upload from local dist/ (testing)
-#   ./scripts/upload_to_storage.sh --release     # Upload from GitHub release (production)
-#   ./scripts/upload_to_storage.sh --release 0.2.0  # Upload specific release version
+# Preferred entrypoints:
+#   poetry run poe upload
+#   poetry run poe upload-release
+# Direct script usage:
+#   ./scripts/upload_to_storage.sh
+#   ./scripts/upload_to_storage.sh --release
+#   ./scripts/upload_to_storage.sh --release 0.2.0
 
 set -e
 
@@ -12,7 +15,9 @@ set -e
 # ============================================================================
 STORAGE_ACCOUNT="${AZURE_STORAGE_ACCOUNT}"
 CONTAINER="${AZURE_CONTAINER:-artifacts}"
-BASE_PATH="${AZURE_BASE_PATH:-packages}"
+ROOT_BASE_PATH="${AZURE_BASE_PATH:-}"
+ROOT_BASE_PATH="${ROOT_BASE_PATH%/}"
+PACKAGES_PATH="${ROOT_BASE_PATH:+${ROOT_BASE_PATH}/}packages"
 
 # ============================================================================
 # Script Logic
@@ -68,7 +73,7 @@ if [ "$USE_RELEASE" = true ]; then
         exit 1
     fi
 
-    REPO=$(git remote get-url origin 2>/dev/null | sed 's/.*github.com[:/]\(.*\)\.git//' | sed 's/.*github.com[:/]\(.*\)//')
+    REPO=$(git remote get-url origin 2>/dev/null | sed -E 's#.*github\.com[:/]([^[:space:]]+?)(\.git)?$#\1#')
     if [ -z "$REPO" ]; then
         echo "❌ Error: Could not detect GitHub repository"
         echo "Make sure you're in a git repository with a GitHub remote"
@@ -90,7 +95,7 @@ if [ "$USE_RELEASE" = true ]; then
 
     WHEELS_DIR="$TEMP_DIR"
 else
-    VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"//')
+    VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
     if [ -z "$VERSION" ]; then
         echo "❌ Error: Could not detect version from pyproject.toml"
         exit 1
@@ -141,13 +146,13 @@ fi
 echo "✓ Logged in as: $(az account show --query user.name -o tsv)"
 echo ""
 
-echo "☁️  Uploading to: ${STORAGE_ACCOUNT}/${CONTAINER}/${BASE_PATH}/"
+echo "☁️  Uploading to: ${STORAGE_ACCOUNT}/${CONTAINER}/${PACKAGES_PATH}/"
 echo ""
 
 UPLOAD_COUNT=0
 for wheel in "${WHEELS_TO_UPLOAD[@]}"; do
     wheel_name=$(basename "$wheel")
-    DEST_PATH="${BASE_PATH}/${wheel_name}"
+    DEST_PATH="${PACKAGES_PATH}/${wheel_name}"
 
     echo "  Uploading: ${wheel_name}..."
     az storage blob upload         --account-name "$STORAGE_ACCOUNT"         --container-name "$CONTAINER"         --name "$DEST_PATH"         --file "$wheel"         --overwrite         --auth-mode login         --only-show-errors
@@ -161,10 +166,14 @@ echo ""
 echo "🎉 Upload complete!"
 echo ""
 echo "Storage structure:"
-echo "  ${STORAGE_ACCOUNT}/${CONTAINER}/${BASE_PATH}/"
+echo "  ${STORAGE_ACCOUNT}/${CONTAINER}/${PACKAGES_PATH}/"
 for wheel in "${WHEELS_TO_UPLOAD[@]}"; do
     echo "      ├── $(basename "$wheel")"
 done
 echo ""
 echo "🔗 Bootstrap script can now install from:"
-echo "   artifacts_storage_path: abfss://${CONTAINER}@${STORAGE_ACCOUNT}.dfs.core.windows.net/${BASE_PATH}"
+if [ -n "$ROOT_BASE_PATH" ]; then
+    echo "   artifacts_storage_path: abfss://${CONTAINER}@${STORAGE_ACCOUNT}.dfs.core.windows.net/${ROOT_BASE_PATH}"
+else
+    echo "   artifacts_storage_path: abfss://${CONTAINER}@${STORAGE_ACCOUNT}.dfs.core.windows.net"
+fi

--- a/scripts/upload_to_storage.sh
+++ b/scripts/upload_to_storage.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# Upload wheels to Azure Storage
+# Upload runtime wheels to Azure Storage
 # Usage:
-#   ./scripts/upload_to_storage.sh              # Upload from local dist/ (testing)
-#   ./scripts/upload_to_storage.sh --release    # Upload from GitHub release (production)
+#   ./scripts/upload_to_storage.sh               # Upload from local dist/ (testing)
+#   ./scripts/upload_to_storage.sh --release     # Upload from GitHub release (production)
 #   ./scripts/upload_to_storage.sh --release 0.2.0  # Upload specific release version
 
 set -e
@@ -12,7 +12,7 @@ set -e
 # ============================================================================
 STORAGE_ACCOUNT="${AZURE_STORAGE_ACCOUNT}"
 CONTAINER="${AZURE_CONTAINER:-artifacts}"
-BASE_PATH="${AZURE_BASE_PATH:-packages}"  # Base path in storage: packages/...
+BASE_PATH="${AZURE_BASE_PATH:-packages}"
 
 # ============================================================================
 # Script Logic
@@ -20,7 +20,8 @@ BASE_PATH="${AZURE_BASE_PATH:-packages}"  # Base path in storage: packages/...
 
 USE_RELEASE=false
 VERSION=""
-RUNTIME_PATTERNS=("kindling_synapse-*.whl" "kindling_databricks-*.whl" "kindling_fabric-*.whl")
+COMBINED_PATTERN="spark_kindling-*.whl"
+LEGACY_PATTERNS=("kindling_synapse-*.whl" "kindling_databricks-*.whl" "kindling_fabric-*.whl")
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -41,11 +42,6 @@ echo "======================================"
 echo ""
 
 if [ "$USE_RELEASE" = true ]; then
-    # ========================================================================
-    # RELEASE MODE: Download from GitHub release
-    # ========================================================================
-
-    # Get version from argument or detect latest tag
     if [ -z "$VERSION" ]; then
         VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
         if [ -z "$VERSION" ]; then
@@ -55,42 +51,36 @@ if [ "$USE_RELEASE" = true ]; then
         fi
         echo "📌 Detected latest version: ${VERSION}"
     else
-        # Remove 'v' prefix if provided
         VERSION="${VERSION#v}"
         echo "📌 Using version: ${VERSION}"
     fi
 
     TAG="v${VERSION}"
 
-    # Check if release exists
     if ! git rev-parse "$TAG" >/dev/null 2>&1; then
         echo "❌ Error: Tag ${TAG} not found"
         exit 1
     fi
 
-    # Check GitHub CLI is available
     if ! command -v gh &> /dev/null; then
         echo "❌ Error: GitHub CLI (gh) not found"
         echo "Please install it: https://cli.github.com/"
         exit 1
     fi
 
-    # Detect GitHub repository
-    REPO=$(git remote get-url origin 2>/dev/null | sed 's/.*github.com[:/]\(.*\)\.git/\1/' | sed 's/.*github.com[:/]\(.*\)/\1/')
+    REPO=$(git remote get-url origin 2>/dev/null | sed 's/.*github.com[:/]\(.*\)\.git//' | sed 's/.*github.com[:/]\(.*\)//')
     if [ -z "$REPO" ]; then
         echo "❌ Error: Could not detect GitHub repository"
         echo "Make sure you're in a git repository with a GitHub remote"
         exit 1
     fi
 
-    # Download wheels from GitHub release
     echo "📥 Downloading wheels from GitHub release ${TAG}..."
     echo "📦 Repository: ${REPO}"
 
     TEMP_DIR=$(mktemp -d)
     trap "rm -rf $TEMP_DIR" EXIT
 
-    # Download release assets to temp directory
     gh release download "$TAG" --pattern "*.whl" --repo "$REPO" --dir "$TEMP_DIR" 2>/dev/null || {
         echo "❌ Error: Failed to download wheels from release ${TAG}"
         echo "Make sure the release exists and has wheel attachments"
@@ -100,60 +90,48 @@ if [ "$USE_RELEASE" = true ]; then
 
     WHEELS_DIR="$TEMP_DIR"
 else
-    # ========================================================================
-    # LOCAL MODE: Upload from dist/ (for testing)
-    # ========================================================================
-
-    # Detect version from pyproject.toml
-    VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+    VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"//')
     if [ -z "$VERSION" ]; then
         echo "❌ Error: Could not detect version from pyproject.toml"
         exit 1
     fi
     echo "📌 Using local build version: ${VERSION}"
 
-    # Check if dist/ has runtime wheels
-    runtime_count=0
-    if [ -d "dist" ]; then
-        for pattern in "${RUNTIME_PATTERNS[@]}"; do
-            if ls dist/$pattern >/dev/null 2>&1; then
-                runtime_count=$((runtime_count + 1))
-            fi
-        done
-    fi
-    if [ "$runtime_count" -eq 0 ]; then
-        echo "❌ Error: No runtime wheels found in dist/"
-        echo "Run: bash scripts/build_platform_wheels.sh"
+    if [ ! -d "dist" ]; then
+        echo "❌ Error: dist/ directory not found"
+        echo "Run: poetry run poe build"
         exit 1
     fi
 
     WHEELS_DIR="dist"
-    echo "📦 Using local runtime wheels from: ${WHEELS_DIR}"
+    echo "📦 Using local wheels from: ${WHEELS_DIR}"
 fi
 
 echo ""
 
-# Build runtime wheel list
 WHEELS_TO_UPLOAD=()
-for pattern in "${RUNTIME_PATTERNS[@]}"; do
-    for wheel in "$WHEELS_DIR"/$pattern; do
-        if [ -f "$wheel" ]; then
-            WHEELS_TO_UPLOAD+=("$wheel")
-        fi
+if ls "$WHEELS_DIR"/$COMBINED_PATTERN >/dev/null 2>&1; then
+    for wheel in "$WHEELS_DIR"/$COMBINED_PATTERN; do
+        [ -f "$wheel" ] && WHEELS_TO_UPLOAD+=("$wheel")
     done
-done
+else
+    for pattern in "${LEGACY_PATTERNS[@]}"; do
+        for wheel in "$WHEELS_DIR"/$pattern; do
+            [ -f "$wheel" ] && WHEELS_TO_UPLOAD+=("$wheel")
+        done
+    done
+fi
 
 if [ ${#WHEELS_TO_UPLOAD[@]} -eq 0 ]; then
     echo "❌ Error: No runtime wheels found to upload in ${WHEELS_DIR}"
+    echo "Expected ${COMBINED_PATTERN} or legacy kindling_<platform>-*.whl files"
     exit 1
 fi
 
-# List wheels to upload
 echo "📦 Runtime wheels to upload:"
 ls -lh "${WHEELS_TO_UPLOAD[@]}"
 echo ""
 
-# Check Azure CLI authentication
 echo "🔑 Using Azure CLI authentication..."
 if ! az account show &>/dev/null; then
     echo "❌ Error: Not logged in to Azure CLI"
@@ -163,7 +141,6 @@ fi
 echo "✓ Logged in as: $(az account show --query user.name -o tsv)"
 echo ""
 
-# Upload wheels to storage
 echo "☁️  Uploading to: ${STORAGE_ACCOUNT}/${CONTAINER}/${BASE_PATH}/"
 echo ""
 
@@ -173,28 +150,21 @@ for wheel in "${WHEELS_TO_UPLOAD[@]}"; do
     DEST_PATH="${BASE_PATH}/${wheel_name}"
 
     echo "  Uploading: ${wheel_name}..."
-    az storage blob upload \
-        --account-name "$STORAGE_ACCOUNT" \
-        --container-name "$CONTAINER" \
-        --name "$DEST_PATH" \
-        --file "$wheel" \
-        --overwrite \
-        --auth-mode login \
-        --only-show-errors
+    az storage blob upload         --account-name "$STORAGE_ACCOUNT"         --container-name "$CONTAINER"         --name "$DEST_PATH"         --file "$wheel"         --overwrite         --auth-mode login         --only-show-errors
 
     UPLOAD_COUNT=$((UPLOAD_COUNT + 1))
 done
 
 echo ""
-echo "✅ Successfully uploaded ${UPLOAD_COUNT} wheels"
+echo "✅ Successfully uploaded ${UPLOAD_COUNT} wheel(s)"
 echo ""
 echo "🎉 Upload complete!"
 echo ""
 echo "Storage structure:"
 echo "  ${STORAGE_ACCOUNT}/${CONTAINER}/${BASE_PATH}/"
-echo "      ├── kindling_databricks-${VERSION}-py3-none-any.whl"
-echo "      ├── kindling_fabric-${VERSION}-py3-none-any.whl"
-echo "      └── kindling_synapse-${VERSION}-py3-none-any.whl"
+for wheel in "${WHEELS_TO_UPLOAD[@]}"; do
+    echo "      ├── $(basename "$wheel")"
+done
 echo ""
 echo "🔗 Bootstrap script can now install from:"
 echo "   artifacts_storage_path: abfss://${CONTAINER}@${STORAGE_ACCOUNT}.dfs.core.windows.net/${BASE_PATH}"

--- a/tests/local-project/pyproject.toml
+++ b/tests/local-project/pyproject.toml
@@ -11,17 +11,22 @@ packages = [{include = "sales_ops", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-# kindling is installed separately — either from the kindling-local wheel
-# (dist/kindling_local-*.whl) or via `pip install -e /workspaces/kindling`
-# for inner-loop source iteration. The manifest does not pin the install path
-# so both workflows use the same package definition.
-kindling = ">=0.8.14"
-pyspark = ">=3.4.0"
-delta-spark = ">=2.4.0"
+# The runtime distribution is published as `spark-kindling`, while imports
+# remain `import kindling`. The standalone extra pulls in local Spark deps.
+spark-kindling = {version = ">=0.9.1", extras = ["standalone"]}
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.0.0"
 pytest-cov = ">=4.0.0"
+poethepoet = ">=0.24.0"
+
+[tool.poe.tasks]
+test-unit = "pytest tests/unit -v"
+test-component = "pytest tests/component -v"
+test-integration = "pytest tests/integration -v"
+test-all = { sequence = ["test-unit", "test-component", "test-integration"] }
+test = { sequence = ["test-unit", "test-component"] }
+build = "poetry build"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,11 +1,14 @@
 import base64
 import json
+import zipfile
 from pathlib import Path
 
+import pytest
 import yaml
 from click.testing import CliRunner
 from kindling_cli.cli import (
     _build_fabric_notebook_payload,
+    _find_wheels,
     _generate_bootstrap_notebook,
     _generate_sample_notebook,
     _render_environment_bootstrap_source,
@@ -388,6 +391,109 @@ def test_render_starter_notebook_source_points_to_environment_bootstrap():
     assert 'logger.info("Kindling starter notebook ready")' in source
     assert 'BOOTSTRAP_CONFIG["app_name"]' in source
     assert '"extensions": ["kindling-otel-azure>=0.3.0"]' in source
+
+
+# ---------------------------------------------------------------------------
+# runtime artifact + remote lifecycle commands
+# ---------------------------------------------------------------------------
+
+
+def test_find_wheels_prefers_combined_runtime_wheel(tmp_path):
+    combined = tmp_path / "spark_kindling-0.9.1-py3-none-any.whl"
+    legacy = tmp_path / "kindling_synapse-0.9.1-py3-none-any.whl"
+    combined.write_text("", encoding="utf-8")
+    legacy.write_text("", encoding="utf-8")
+
+    assert _find_wheels(tmp_path, "synapse") == [combined]
+
+
+def test_find_wheels_falls_back_to_legacy_platform_wheel(tmp_path):
+    legacy = tmp_path / "kindling_fabric-0.9.1-py3-none-any.whl"
+    legacy.write_text("", encoding="utf-8")
+
+    assert _find_wheels(tmp_path, "fabric") == [legacy]
+
+
+def test_app_package_creates_kda_archive():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        app_dir = Path("demo_app")
+        (app_dir / "nested").mkdir(parents=True)
+        (app_dir / "app.py").write_text("print('hello')\n", encoding="utf-8")
+        (app_dir / "nested" / "settings.yaml").write_text("name: demo\n", encoding="utf-8")
+
+        result = runner.invoke(cli, ["app", "package", str(app_dir)])
+
+        assert result.exit_code == 0, result.output
+        package_path = Path("dist/demo_app.kda")
+        assert package_path.exists()
+        with zipfile.ZipFile(package_path, "r") as archive:
+            assert sorted(archive.namelist()) == ["app.py", "nested/settings.yaml"]
+
+
+def test_app_deploy_uses_platform_sdk(monkeypatch):
+    class FakeAPI:
+        def __init__(self):
+            self.calls = []
+
+        def deploy_app(self, app_name, app_files):
+            self.calls.append((app_name, app_files))
+            return "abfss://artifacts@acct.dfs.core.windows.net/dev/data-apps/demo"
+
+    fake_api = FakeAPI()
+    monkeypatch.setattr(
+        "kindling_cli.cli._create_platform_api",
+        lambda platform: (fake_api, platform),
+    )
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        app_dir = Path("demo_app")
+        (app_dir / "pipelines").mkdir(parents=True)
+        (app_dir / "app.py").write_text("print('hello')\n", encoding="utf-8")
+        (app_dir / "pipelines" / "job.yml").write_text("job_name: demo\n", encoding="utf-8")
+
+        result = runner.invoke(cli, ["app", "deploy", str(app_dir), "--platform", "fabric"])
+
+        assert result.exit_code == 0, result.output
+        assert fake_api.calls[0][0] == "demo_app"
+        assert sorted(fake_api.calls[0][1]) == ["app.py", "pipelines/job.yml"]
+        assert "Deployed app `demo_app`" in result.output
+
+
+def test_job_create_loads_yaml_and_prints_structured_result(monkeypatch):
+    class FakeAPI:
+        def create_job(self, job_name, job_config):
+            assert job_name == "nightly-demo"
+            assert job_config["schedule"] == "0 0 * * *"
+            return {"job_id": "job-123", "job_name": job_name}
+
+    monkeypatch.setattr(
+        "kindling_cli.cli._create_platform_api",
+        lambda platform: (FakeAPI(), platform),
+    )
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("job.yaml").write_text(
+            "job_name: nightly-demo\nschedule: '0 0 * * *'\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(cli, ["job", "create", "job.yaml", "--platform", "synapse"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["job_id"] == "job-123"
+        assert payload["job_name"] == "nightly-demo"
+
+
+def test_job_logs_stream_requires_job_id():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["job", "logs", "run-123", "--stream", "--platform", "fabric"])
+
+    assert result.exit_code != 0
+    assert "--job-id is required when --stream is used." in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3,7 +3,6 @@ import json
 import zipfile
 from pathlib import Path
 
-import pytest
 import yaml
 from click.testing import CliRunner
 from kindling_cli.cli import (
@@ -429,6 +428,19 @@ def test_app_package_creates_kda_archive():
         assert package_path.exists()
         with zipfile.ZipFile(package_path, "r") as archive:
             assert sorted(archive.namelist()) == ["app.py", "nested/settings.yaml"]
+
+
+def test_app_deploy_rejects_unsafe_kda_paths():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        package_path = Path("demo_app.kda")
+        with zipfile.ZipFile(package_path, "w") as archive:
+            archive.writestr("../escape.py", "print('nope')\n")
+
+        result = runner.invoke(cli, ["app", "deploy", str(package_path), "--platform", "fabric"])
+
+        assert result.exit_code != 0
+        assert "unsafe relative path traversal" in result.output
 
 
 def test_app_deploy_uses_platform_sdk(monkeypatch):

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -55,6 +55,7 @@ INVARIANT_FILES = [
     "pyproject.toml",
     ".env.example",
     ".gitignore",
+    ".github/workflows/ci.yml",
     ".devcontainer/Dockerfile",
     ".devcontainer/devcontainer.json",
     ".devcontainer/docker-compose.yml",
@@ -170,6 +171,18 @@ def test_pyproject_uses_kebab_name(tmp_path):
     assert 'name = "my-project"' in pyproject
 
 
+def test_pyproject_uses_spark_kindling_dependency_and_poe_tasks(tmp_path):
+    cfg = ScaffoldConfig(name="proj", integration=True, output_dir=tmp_path)
+    generate_project(cfg)
+
+    pyproject = (tmp_path / "proj" / "pyproject.toml").read_text()
+    assert 'spark-kindling = {version = ">=0.9.1", extras = ["standalone"]}' in pyproject
+    assert 'poethepoet = ">=0.24.0"' in pyproject
+    assert 'test = { sequence = ["test-unit", "test-component"] }' in pyproject
+    assert 'test-integration = "pytest tests/integration -v"' in pyproject
+    assert 'build = "poetry build"' in pyproject
+
+
 def test_conftest_has_oauth_vars(tmp_path):
     cfg = ScaffoldConfig(name="proj", auth="oauth", output_dir=tmp_path)
     generate_project(cfg)
@@ -271,6 +284,16 @@ def test_gitignore_excludes_dotenv(tmp_path):
 
     gitignore = (tmp_path / "proj" / ".gitignore").read_text()
     assert ".env" in gitignore
+
+
+def test_generated_ci_workflow_runs_poe_test_and_build(tmp_path):
+    cfg = ScaffoldConfig(name="proj", output_dir=tmp_path)
+    generate_project(cfg)
+
+    workflow = (tmp_path / "proj" / ".github" / "workflows" / "ci.yml").read_text()
+    assert "name: CI" in workflow
+    assert "poetry run poe test" in workflow
+    assert "poetry run poe build" in workflow
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- polish the local domain development workflow and CLI lifecycle commands
- add stable latest-release alias assets for GitHub release installs
- bump package versions to 0.9.2

## Testing
- poetry run pytest tests/unit/test_cli.py tests/unit/test_scaffold.py -q
- python -m compileall packages/kindling_cli/kindling_cli scripts
- python - <<'PY'
import yaml
from pathlib import Path
yaml.safe_load(Path(".github/workflows/ci.yml").read_text())
print("YAML OK")
PY