### PR TITLE
Add portable CLI test runner commands

### DIFF
--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -25,6 +25,7 @@ WORKDIR /workspace
 
 # Copy dependency files first (for better caching)
 COPY pyproject.toml poetry.lock ./
+COPY packages/kindling_cli ./packages/kindling_cli
 
 # Install dependencies (this layer will be cached unless poetry.lock changes)
 RUN poetry install --with dev --no-root

--- a/packages/kindling_cli/kindling_cli/cli.py
+++ b/packages/kindling_cli/kindling_cli/cli.py
@@ -2064,6 +2064,167 @@ def job_delete(job_id: str, platform: Optional[str], json_output: bool) -> None:
     )
 
 
+@cli.group("test")
+def test_group() -> None:
+    """Run Kindling project test suites."""
+
+
+@test_group.command("run")
+@click.option(
+    "--suite",
+    type=click.Choice(["unit", "component", "integration", "system", "extension", "all"]),
+    default="unit",
+    show_default=True,
+    help="Logical test suite. Used for defaults and CI report names.",
+)
+@click.option(
+    "--path",
+    "paths",
+    multiple=True,
+    type=click.Path(path_type=Path, exists=False),
+    help="Pytest path to run. Repeatable. Defaults to tests/<suite> when omitted.",
+)
+@click.option("--platform", type=click.Choice(SUPPORTED_PLATFORMS), default=None)
+@click.option(
+    "--test",
+    "test_filter",
+    default=None,
+    help="Pytest -k expression for selecting tests.",
+)
+@click.option(
+    "--marker",
+    default=None,
+    help="Pytest -m expression for selecting markers.",
+)
+@click.option("--ci", is_flag=True, help="Emit junit/json reports and fail fast.")
+@click.option(
+    "--results-dir",
+    default="test-results",
+    show_default=True,
+    type=click.Path(path_type=Path, file_okay=False),
+)
+@click.option(
+    "--workers",
+    default=None,
+    help="Optional pytest-xdist worker count. CI has platform-aware defaults.",
+)
+@click.option(
+    "--coverage",
+    multiple=True,
+    help="Coverage target to pass as --cov=<target>. Repeatable.",
+)
+@click.option("--no-cov", is_flag=True, help="Pass --no-cov to pytest.")
+@click.option(
+    "--preflight",
+    type=click.Choice(["none", "local", "system"]),
+    default="none",
+    show_default=True,
+    help="Optional preflight check before pytest.",
+)
+@click.option(
+    "--dotenv",
+    "dotenv_paths",
+    multiple=True,
+    type=click.Path(path_type=Path, dir_okay=False),
+    help="Dotenv file to load before running tests. Repeatable. Defaults to .env.",
+)
+@click.option(
+    "--no-dotenv",
+    is_flag=True,
+    help="Do not load .env before running tests.",
+)
+@click.option(
+    "--pytest-arg",
+    "pytest_args",
+    multiple=True,
+    help="Extra argument passed through to pytest. Repeatable.",
+)
+def test_run(
+    suite: str,
+    paths: Tuple[Path, ...],
+    platform: Optional[str],
+    test_filter: Optional[str],
+    marker: Optional[str],
+    ci: bool,
+    results_dir: Path,
+    workers: Optional[str],
+    coverage: Tuple[str, ...],
+    no_cov: bool,
+    preflight: str,
+    dotenv_paths: Tuple[Path, ...],
+    no_dotenv: bool,
+    pytest_args: Tuple[str, ...],
+) -> None:
+    """Run pytest through Kindling's portable test wrapper.
+
+    Project-specific layouts should pass --path from Poe, Make, or CI tasks.
+    The CLI intentionally does not require a Kindling test config file.
+    """
+    from kindling_cli.test_runner import TestRunOptions, flatten_pytest_args, run_tests
+
+    resolved_dotenvs: Tuple[Path, ...]
+    if no_dotenv:
+        resolved_dotenvs = ()
+    elif dotenv_paths:
+        resolved_dotenvs = dotenv_paths
+    else:
+        resolved_dotenvs = (Path(".env"),)
+
+    options = TestRunOptions(
+        suite=suite,
+        paths=paths,
+        platform=platform,
+        test_filter=test_filter,
+        marker=marker,
+        ci=ci,
+        results_dir=results_dir,
+        workers=workers,
+        coverage=coverage,
+        no_cov=no_cov,
+        preflight=preflight,
+        dotenv_paths=resolved_dotenvs,
+        pytest_args=flatten_pytest_args(pytest_args),
+    )
+
+    try:
+        exit_code = run_tests(options)
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    raise click.exceptions.Exit(exit_code)
+
+
+@test_group.command("check")
+@click.option(
+    "--preflight",
+    type=click.Choice(["local", "system"]),
+    default="local",
+    show_default=True,
+    help="Preflight type to run.",
+)
+@click.option("--platform", type=click.Choice(SUPPORTED_PLATFORMS), default=None)
+def test_check(preflight: str, platform: Optional[str]) -> None:
+    """Run a Kindling test preflight check without pytest."""
+    from kindling_cli.test_runner import run_preflight
+
+    exit_code = run_preflight(preflight, platform)
+    raise click.exceptions.Exit(exit_code)
+
+
+@test_group.command("cleanup")
+@click.option("--platform", type=click.Choice(SUPPORTED_PLATFORMS), default=None)
+@click.option("--all", "all_platforms", is_flag=True, help="Clean all configured platforms.")
+@click.option("--skip-packages", is_flag=True, help="Skip cleanup of old package artifacts.")
+def test_cleanup(platform: Optional[str], all_platforms: bool, skip_packages: bool) -> None:
+    """Run project cleanup hooks for system-test resources."""
+    from kindling_cli.test_runner import run_cleanup
+
+    exit_code = run_cleanup(platform, all_platforms=all_platforms, skip_packages=skip_packages)
+    raise click.exceptions.Exit(exit_code)
+
+
 @cli.group("repo")
 def repo_group() -> None:
     """Scaffold and manage multi-package Kindling repos."""

--- a/packages/kindling_cli/kindling_cli/templates/pyproject.toml.j2
+++ b/packages/kindling_cli/kindling_cli/templates/pyproject.toml.j2
@@ -18,12 +18,13 @@ spark-kindling = {version = ">=0.9.2", extras = ["standalone"]}
 pytest = ">=7.0.0"
 pytest-cov = ">=4.0.0"
 poethepoet = ">=0.24.0"
+spark-kindling-cli = ">=0.9.3"
 
 [tool.poe.tasks]
-test-unit = "pytest tests/unit -v"
-test-component = "pytest tests/component -v"
+test-unit = "kindling test run --suite unit --path tests/unit"
+test-component = "kindling test run --suite component --path tests/component"
 {% if integration %}
-test-integration = "pytest tests/integration -v"
+test-integration = "kindling test run --suite integration --path tests/integration --preflight local"
 test-all = { sequence = ["test-unit", "test-component", "test-integration"] }
 {% endif %}
 test = { sequence = ["test-unit", "test-component"] }

--- a/packages/kindling_cli/kindling_cli/test_runner.py
+++ b/packages/kindling_cli/kindling_cli/test_runner.py
@@ -1,0 +1,249 @@
+"""Reusable test command helpers for Kindling projects."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from importlib.util import find_spec
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence
+
+SUPPORTED_SUITES = ("unit", "component", "integration", "system", "extension", "all")
+
+
+@dataclass(frozen=True)
+class TestRunOptions:
+    suite: str
+    paths: Sequence[Path]
+    platform: Optional[str] = None
+    test_filter: Optional[str] = None
+    marker: Optional[str] = None
+    ci: bool = False
+    results_dir: Path = Path("test-results")
+    workers: Optional[str] = None
+    coverage: Sequence[str] = ()
+    no_cov: bool = False
+    preflight: str = "none"
+    dotenv_paths: Sequence[Path] = (Path(".env"),)
+    pytest_args: Sequence[str] = ()
+
+
+def load_dotenv(path: Path) -> None:
+    """Best-effort loader for simple KEY=value dotenv files."""
+    if os.environ.get("KINDLING_SKIP_DOTENV", "").strip().lower() in {"1", "true", "yes"}:
+        return
+
+    if not path.exists():
+        return
+
+    try:
+        for raw_line in path.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("export "):
+                line = line[len("export ") :].strip()
+            if "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            key = key.strip()
+            value = value.strip()
+            if not key or key in os.environ:
+                continue
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+                value = value[1:-1]
+            os.environ[key] = value
+    except (OSError, UnicodeDecodeError):
+        return
+
+
+def default_paths_for_suite(suite: str) -> List[Path]:
+    """Return conventional test paths for a suite when the caller omits --path."""
+    if suite == "all":
+        candidates = [Path("tests")]
+    elif suite == "extension":
+        candidates = [Path("tests/system/extensions")]
+    else:
+        candidates = [Path("tests") / suite]
+
+    existing = [path for path in candidates if path.exists()]
+    return existing or candidates
+
+
+def normalize_paths(suite: str, paths: Sequence[Path]) -> List[Path]:
+    return list(paths) if paths else default_paths_for_suite(suite)
+
+
+def resolve_workers(platform: Optional[str], explicit_workers: Optional[str], ci: bool) -> str:
+    """Resolve pytest-xdist worker count for local and CI runs."""
+    if explicit_workers:
+        return explicit_workers.strip()
+
+    if ci:
+        default_workers_by_platform = {
+            "synapse": "2",
+            "fabric": "4",
+            "databricks": "4",
+        }
+        return (
+            os.getenv("KINDLING_SYSTEM_TEST_CI_WORKERS")
+            or default_workers_by_platform.get(platform or "", "")
+        ).strip()
+
+    return (os.getenv("KINDLING_SYSTEM_TEST_WORKERS") or "").strip()
+
+
+def ensure_xdist_available(workers: str) -> None:
+    """Fail fast when multiple xdist workers are requested but unavailable."""
+    if not workers or workers in {"0", "1"}:
+        return
+    if find_spec("xdist") is not None:
+        return
+    raise RuntimeError(
+        "pytest-xdist is required for distributed test execution "
+        f"(requested workers={workers}). Install dev dependencies first."
+    )
+
+
+def set_system_coverage_file(platform: Optional[str]) -> None:
+    """Avoid coverage sqlite collisions across concurrent system-test runs."""
+    if os.environ.get("COVERAGE_FILE"):
+        return
+    suffix = platform or "all"
+    os.environ["COVERAGE_FILE"] = f".coverage.system.{suffix}.{os.getpid()}"
+
+
+def build_pytest_args(options: TestRunOptions) -> List[str]:
+    """Build pytest arguments from explicit CLI options."""
+    paths = normalize_paths(options.suite, options.paths)
+    args = ["pytest", *[str(path) for path in paths], "-v", "-s"]
+
+    if options.platform:
+        args.extend(["--platform", options.platform])
+    if options.test_filter:
+        args.extend(["-k", options.test_filter])
+    if options.marker:
+        args.extend(["-m", options.marker])
+
+    if options.ci:
+        junit_name, json_name = _report_file_names(options.suite, options.platform)
+        args.extend(
+            [
+                f"--junit-xml={options.results_dir / junit_name}",
+                "--json-report",
+                f"--json-report-file={options.results_dir / json_name}",
+                "--maxfail=1",
+            ]
+        )
+
+    if options.no_cov:
+        args.append("--no-cov")
+    else:
+        for target in options.coverage:
+            args.append(f"--cov={target}")
+
+    workers = resolve_workers(options.platform, options.workers, options.ci)
+    if workers and workers not in {"0", "1"}:
+        ensure_xdist_available(workers)
+        args.extend(["-n", workers])
+
+    args.extend(options.pytest_args)
+    return args
+
+
+def _report_file_names(suite: str, platform: Optional[str]) -> tuple[str, str]:
+    """Return CI report filenames compatible with existing Kindling workflows."""
+    if suite == "unit":
+        return "unit-test-results.xml", "unit-test-report.json"
+    if suite == "integration":
+        return "integration-test-results.xml", "integration-test-report.json"
+    if suite == "system":
+        suffix = platform or "all"
+        return f"system-test-results-{suffix}.xml", f"system-test-report-{suffix}.json"
+
+    suffix = platform or suite
+    return f"{suite}-test-results-{suffix}.xml", f"{suite}-test-report-{suffix}.json"
+
+
+def run_preflight(mode: str, platform: Optional[str]) -> int:
+    """Run optional preflight checks before pytest."""
+    if mode == "none":
+        return 0
+
+    if mode == "local":
+        cmd = ["kindling", "env", "check", "--local"]
+        return subprocess.run(cmd).returncode
+
+    if mode == "system":
+        auth_check = Path("tests/system/auth_check.py")
+        if not auth_check.exists():
+            print(f"Skipping system preflight; {auth_check} was not found.")
+            return 0
+        cmd = [sys.executable, str(auth_check)]
+        if platform:
+            cmd.extend(["--platform", platform])
+        return subprocess.run(cmd).returncode
+
+    raise ValueError(f"Unknown preflight mode: {mode}")
+
+
+def run_tests(options: TestRunOptions) -> int:
+    """Run pytest using Kindling's shared test conventions."""
+    for dotenv_path in options.dotenv_paths:
+        load_dotenv(dotenv_path)
+
+    if options.ci:
+        options.results_dir.mkdir(parents=True, exist_ok=True)
+
+    if options.suite == "system":
+        set_system_coverage_file(options.platform)
+
+    preflight_rc = run_preflight(options.preflight, options.platform)
+    if preflight_rc != 0:
+        return preflight_rc
+
+    args = build_pytest_args(options)
+    print(f"Running: {' '.join(args)}")
+    print()
+    return subprocess.run(args).returncode
+
+
+def run_cleanup(
+    platform: Optional[str],
+    *,
+    all_platforms: bool = False,
+    skip_packages: bool = False,
+) -> int:
+    """Run repository-provided cleanup script when present."""
+    cleanup_script = Path("scripts/cleanup_test_resources.py")
+    if not cleanup_script.exists():
+        print(f"Cleanup script not found: {cleanup_script}")
+        return 1
+
+    cmd = [sys.executable, str(cleanup_script)]
+    if platform:
+        cmd.extend(["--platform", platform])
+    elif all_platforms:
+        cmd.append("--all")
+
+    print(f"Running: {' '.join(cmd)}")
+    print()
+    result = subprocess.run(cmd)
+    if result.returncode != 0 or platform or skip_packages:
+        return result.returncode
+
+    package_cleanup = Path("scripts/cleanup_old_packages.py")
+    if not package_cleanup.exists():
+        return result.returncode
+
+    package_cmd = [sys.executable, str(package_cleanup)]
+    print(f"Running: {' '.join(package_cmd)}")
+    print()
+    return subprocess.run(package_cmd).returncode
+
+
+def flatten_pytest_args(values: Iterable[str]) -> List[str]:
+    """Normalize repeated --pytest-arg values into a plain list."""
+    return [value for value in values if value]

--- a/poetry.lock
+++ b/poetry.lock
@@ -4202,6 +4202,28 @@ files = [
 ]
 
 [[package]]
+name = "spark-kindling-cli"
+version = "0.9.3"
+description = "Command-line tooling for Kindling"
+optional = false
+python-versions = "^3.10"
+groups = ["dev"]
+files = []
+develop = true
+
+[package.dependencies]
+click = ">=8.1.0"
+jinja2 = ">=3.1.0"
+pyyaml = ">=6.0"
+
+[package.extras]
+deploy = ["azure-identity (>=1.15.0)", "azure-storage-blob (>=12.14.0)", "requests (>=2.31.0)"]
+
+[package.source]
+type = "directory"
+url = "packages/kindling_cli"
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 description = "Extract data from python stack frames and tracebacks for informative displays"
@@ -4531,4 +4553,4 @@ synapse = ["azure-synapse-artifacts"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "3ce0d98f468d6a07d69ad0fa47e049ebc30d04f34346f53333d1f77dd1e8024c"
+content-hash = "cd43f853f9cadef6b8bb29ccfa1c1841c239649fec024d171944c20312e33ee2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ jupyter = ">=1.0.0"
 poethepoet = ">=0.24.0"
 requests = ">=2.31.0"
 azure-mgmt-storage = "22.1.0"
+spark-kindling-cli = {path = "packages/kindling_cli", develop = true}
 # Platform SDKs needed by dev/CI tooling — they're also runtime deps under
 # the corresponding extras, but we install them unconditionally in the dev
 # env because scripts/databricks_uc_preflight.py, scripts/manage_uc_volumes.py,
@@ -124,18 +125,18 @@ publish-github-secrets = { script = "scripts.test_runner:run_setup_github_secret
 auth-secret-fingerprints = { cmd = "python scripts/auth_secret_fingerprints.py" }
 
 # Testing tasks
-test = "pytest tests/ -v"
-test-unit = "pytest tests/unit/ -v"
-test-unit-ci = { script = "scripts.test_runner:run_unit_tests_ci" }
-test-integration = "pytest tests/integration/ -v"
-test-integration-ci = { script = "scripts.test_runner:run_integration_tests_ci" }
-test-local = "pytest tests/local-project/ -v"
-test-system = { script = "scripts.test_runner:run_system_tests", help = "Run system tests. Use --platform and/or --test to filter", args = [{name = "platform", default = "", positional = false, help = "Platform to test (fabric, synapse, databricks). If not specified, runs all platforms"}, {name = "test", default = "", positional = false, help = "Specific test name or pattern to run. If not specified, runs all tests"}, {name = "workers", default = "", positional = false, help = "Optional pytest-xdist worker count for local runs. If omitted, local runs stay serial unless KINDLING_SYSTEM_TEST_WORKERS is set"}] }
-test-system-ci = { script = "scripts.test_runner:run_system_tests_ci", help = "Run system tests with CI reporting. Use --platform and/or --test to filter", args = [{name = "platform", default = "", positional = false, help = "Platform to test (fabric, synapse, databricks). If not specified, runs all platforms"}, {name = "test", default = "", positional = false, help = "Specific test name or pattern to run. If not specified, runs all tests"}, {name = "workers", default = "", positional = false, help = "Optional pytest-xdist worker count override for CI runs"}] }
-test-extension = { script = "scripts.test_runner:run_extension_tests", help = "Run extension tests", args = [{name = "extension", default = "azure-monitor", positional = false, help = "Extension name to test (e.g., azure-monitor)"}, {name = "platform", default = "", positional = false, help = "Platform to test (fabric, synapse, databricks). If not specified, runs all platforms"}] }
-test-quick = "pytest tests/unit/ tests/integration/ -v"
-test-coverage = "pytest tests/ -v --cov=kindling --cov-report=html --cov-report=term"
-cleanup = { script = "scripts.test_runner:run_cleanup", help = "Clean up test resources. Use --platform to filter", args = [{name = "platform", default = "", positional = false, help = "Platform to clean (fabric, synapse, databricks). If not specified, cleans all platforms"}, {name = "skip-packages", default = false, positional = false, help = "Skip cleanup of old packages"}] }
+test = "kindling test run --suite all --path tests"
+test-unit = "kindling test run --suite unit --path tests/unit"
+test-unit-ci = "kindling test run --suite unit --path tests/unit --ci --coverage packages/kindling --pytest-arg=--cov-report=xml"
+test-integration = "kindling test run --suite integration --path tests/integration"
+test-integration-ci = "kindling test run --suite integration --path tests/integration --ci --no-cov"
+test-local = "kindling test run --suite all --path tests/local-project"
+test-system = { shell = "kindling test run --suite system --path tests/system/core ${platform:+--platform \"$platform\"} ${test:+--test \"$test\"} ${workers:+--workers \"$workers\"}", help = "Run system tests. Use --platform and/or --test to filter", args = [{name = "platform", default = "", positional = false, help = "Platform to test (fabric, synapse, databricks). If not specified, runs all platforms"}, {name = "test", default = "", positional = false, help = "Specific test name or pattern to run. If not specified, runs all tests"}, {name = "workers", default = "", positional = false, help = "Optional pytest-xdist worker count for local runs. If omitted, local runs stay serial unless KINDLING_SYSTEM_TEST_WORKERS is set"}] }
+test-system-ci = { shell = "kindling test run --suite system --path tests/system/core --ci --preflight system ${platform:+--platform \"$platform\"} ${test:+--test \"$test\"} ${workers:+--workers \"$workers\"}", help = "Run system tests with CI reporting. Use --platform and/or --test to filter", args = [{name = "platform", default = "", positional = false, help = "Platform to test (fabric, synapse, databricks). If not specified, runs all platforms"}, {name = "test", default = "", positional = false, help = "Specific test name or pattern to run. If not specified, runs all tests"}, {name = "workers", default = "", positional = false, help = "Optional pytest-xdist worker count override for CI runs"}] }
+test-extension = { shell = "kindling test run --suite extension --path tests/system/extensions/$extension ${platform:+--platform \"$platform\"}", help = "Run extension tests", args = [{name = "extension", default = "azure-monitor", positional = false, help = "Extension name to test (e.g., azure-monitor)"}, {name = "platform", default = "", positional = false, help = "Platform to test (fabric, synapse, databricks). If not specified, runs all platforms"}] }
+test-quick = "kindling test run --suite all --path tests/unit --path tests/integration"
+test-coverage = "kindling test run --suite all --path tests --coverage kindling --pytest-arg=--cov-report=html --pytest-arg=--cov-report=term"
+cleanup = { shell = "if [ -n \"$platform\" ]; then kindling test cleanup --platform \"$platform\" $(if [ \"$skip_packages\" = \"true\" ] || [ \"$skip_packages\" = \"True\" ]; then printf '%s' --skip-packages; fi); else kindling test cleanup --all $(if [ \"$skip_packages\" = \"true\" ] || [ \"$skip_packages\" = \"True\" ]; then printf '%s' --skip-packages; fi); fi", help = "Clean up test resources. Use --platform to filter", args = [{name = "platform", default = "", positional = false, help = "Platform to clean (fabric, synapse, databricks). If not specified, cleans all platforms"}, {name = "skip-packages", type = "boolean", default = false, positional = false, help = "Skip cleanup of old packages"}] }
 
 # Code quality tasks
 format = "black packages/ tests/ scripts/"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -68,6 +68,50 @@ def test_env_check_passes_for_generated_settings_file():
         assert "Environment check passed." in result.output
 
 
+def test_test_run_passes_explicit_layout_to_runner(monkeypatch):
+    captured = {}
+
+    def fake_run_tests(options):
+        captured["options"] = options
+        return 0
+
+    monkeypatch.setattr("kindling_cli.test_runner.run_tests", fake_run_tests)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "test",
+            "run",
+            "--suite",
+            "system",
+            "--path",
+            "custom/system",
+            "--platform",
+            "fabric",
+            "--test",
+            "name_mapper",
+            "--ci",
+            "--preflight",
+            "system",
+            "--workers",
+            "4",
+            "--pytest-arg",
+            "--tb=short",
+        ],
+    )
+
+    assert result.exit_code == 0
+    options = captured["options"]
+    assert options.suite == "system"
+    assert [str(path) for path in options.paths] == ["custom/system"]
+    assert options.platform == "fabric"
+    assert options.test_filter == "name_mapper"
+    assert options.ci is True
+    assert options.preflight == "system"
+    assert options.workers == "4"
+    assert options.pytest_args == ["--tb=short"]
+
+
 # ---------------------------------------------------------------------------
 # config set
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -211,8 +211,12 @@ def test_package_pyproject_uses_spark_kindling_dependency_and_poe_tasks(tmp_path
     pyproject = (_package_root(repo_root, "proj") / "pyproject.toml").read_text()
     assert 'spark-kindling = {version = ">=0.9.2", extras = ["standalone"]}' in pyproject
     assert 'poethepoet = ">=0.24.0"' in pyproject
+    assert 'spark-kindling-cli = ">=0.9.3"' in pyproject
     assert 'test = { sequence = ["test-unit", "test-component"] }' in pyproject
-    assert 'test-integration = "pytest tests/integration -v"' in pyproject
+    assert (
+        'test-integration = "kindling test run --suite integration --path tests/integration --preflight local"'
+        in pyproject
+    )
     assert 'build = "poetry build"' in pyproject
 
 

--- a/tests/unit/test_test_runner.py
+++ b/tests/unit/test_test_runner.py
@@ -1,14 +1,14 @@
 import os
 from unittest.mock import MagicMock
 
-from scripts import test_runner
+from kindling_cli import test_runner
 
 
 def test_set_system_coverage_file_uses_platform_and_pid(monkeypatch):
     monkeypatch.delenv("COVERAGE_FILE", raising=False)
     monkeypatch.setattr(test_runner.os, "getpid", lambda: 4242)
 
-    test_runner._set_system_coverage_file("synapse")
+    test_runner.set_system_coverage_file("synapse")
 
     assert os.environ["COVERAGE_FILE"] == ".coverage.system.synapse.4242"
 
@@ -16,7 +16,7 @@ def test_set_system_coverage_file_uses_platform_and_pid(monkeypatch):
 def test_set_system_coverage_file_respects_existing_override(monkeypatch):
     monkeypatch.setenv("COVERAGE_FILE", ".coverage.preconfigured")
 
-    test_runner._set_system_coverage_file("fabric")
+    test_runner.set_system_coverage_file("fabric")
 
     assert os.environ["COVERAGE_FILE"] == ".coverage.preconfigured"
 
@@ -24,43 +24,43 @@ def test_set_system_coverage_file_respects_existing_override(monkeypatch):
 def test_resolve_system_test_workers_local_defaults_to_serial(monkeypatch):
     monkeypatch.delenv("KINDLING_SYSTEM_TEST_WORKERS", raising=False)
 
-    assert test_runner._resolve_system_test_workers("synapse", ci=False) == ""
+    assert test_runner.resolve_workers("synapse", explicit_workers=None, ci=False) == ""
 
 
 def test_resolve_system_test_workers_local_uses_env_override(monkeypatch):
     monkeypatch.setenv("KINDLING_SYSTEM_TEST_WORKERS", "3")
 
-    assert test_runner._resolve_system_test_workers("synapse", ci=False) == "3"
+    assert test_runner.resolve_workers("synapse", explicit_workers=None, ci=False) == "3"
 
 
 def test_resolve_system_test_workers_ci_uses_platform_defaults(monkeypatch):
     monkeypatch.delenv("KINDLING_SYSTEM_TEST_CI_WORKERS", raising=False)
 
-    assert test_runner._resolve_system_test_workers("synapse", ci=True) == "2"
-    assert test_runner._resolve_system_test_workers("fabric", ci=True) == "4"
+    assert test_runner.resolve_workers("synapse", explicit_workers=None, ci=True) == "2"
+    assert test_runner.resolve_workers("fabric", explicit_workers=None, ci=True) == "4"
 
 
 def test_ensure_xdist_available_allows_serial_workers(monkeypatch):
     monkeypatch.setattr(test_runner, "find_spec", lambda name: None)
 
-    test_runner._ensure_xdist_available("1")
+    test_runner.ensure_xdist_available("1")
 
 
 def test_ensure_xdist_available_raises_clear_error_when_missing(monkeypatch):
     monkeypatch.setattr(test_runner, "find_spec", lambda name: None)
 
     try:
-        test_runner._ensure_xdist_available("2")
-    except SystemExit as exc:
+        test_runner.ensure_xdist_available("2")
+    except RuntimeError as exc:
         assert "pytest-xdist is required" in str(exc)
     else:
-        raise AssertionError("Expected SystemExit when xdist is missing")
+        raise AssertionError("Expected RuntimeError when xdist is missing")
 
 
 def test_ensure_xdist_available_accepts_installed_plugin(monkeypatch):
     monkeypatch.setattr(test_runner, "find_spec", lambda name: object())
 
-    test_runner._ensure_xdist_available("2")
+    test_runner.ensure_xdist_available("2")
 
 
 def test_run_system_tests_adds_local_workers_when_requested(monkeypatch):
@@ -70,18 +70,25 @@ def test_run_system_tests_adds_local_workers_when_requested(monkeypatch):
         captured["args"] = args
         return MagicMock(returncode=0)
 
-    monkeypatch.setattr(test_runner, "_load_dotenv", lambda: None)
-    monkeypatch.setattr(test_runner, "_set_system_coverage_file", lambda platform: None)
+    monkeypatch.setattr(test_runner, "load_dotenv", lambda path: None)
+    monkeypatch.setattr(test_runner, "set_system_coverage_file", lambda platform: None)
     monkeypatch.setattr(test_runner.subprocess, "run", fake_run)
 
-    try:
-        test_runner.run_system_tests(platform="synapse", test="name_mapper", workers="3")
-    except SystemExit as exc:
-        assert exc.code == 0
+    result = test_runner.run_tests(
+        test_runner.TestRunOptions(
+            suite="system",
+            paths=["tests/system/core"],
+            platform="synapse",
+            test_filter="name_mapper",
+            workers="3",
+        )
+    )
+
+    assert result == 0
 
     assert captured["args"] == [
         "pytest",
-        "tests/system/core/",
+        "tests/system/core",
         "-v",
         "-s",
         "--platform",
@@ -101,19 +108,27 @@ def test_run_system_tests_ci_adds_reports_preflight_and_workers(monkeypatch, tmp
         return MagicMock(returncode=0)
 
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(test_runner, "_load_dotenv", lambda: None)
-    monkeypatch.setattr(test_runner, "_set_system_coverage_file", lambda platform: None)
-    monkeypatch.setattr(test_runner, "_run_system_test_preflight", lambda platform: 0)
+    monkeypatch.setattr(test_runner, "load_dotenv", lambda path: None)
+    monkeypatch.setattr(test_runner, "set_system_coverage_file", lambda platform: None)
+    monkeypatch.setattr(test_runner, "run_preflight", lambda mode, platform: 0)
     monkeypatch.setattr(test_runner.subprocess, "run", fake_run)
 
-    try:
-        test_runner.run_system_tests_ci(platform="fabric", test="name_mapper")
-    except SystemExit as exc:
-        assert exc.code == 0
+    result = test_runner.run_tests(
+        test_runner.TestRunOptions(
+            suite="system",
+            paths=["tests/system/core"],
+            platform="fabric",
+            test_filter="name_mapper",
+            ci=True,
+            preflight="system",
+        )
+    )
+
+    assert result == 0
 
     assert captured["args"] == [
         "pytest",
-        "tests/system/core/",
+        "tests/system/core",
         "-v",
         "-s",
         "--platform",
@@ -126,4 +141,28 @@ def test_run_system_tests_ci_adds_reports_preflight_and_workers(monkeypatch, tmp
         "--maxfail=1",
         "-n",
         "4",
+    ]
+
+
+def test_build_pytest_args_supports_explicit_paths_and_passthrough():
+    args = test_runner.build_pytest_args(
+        test_runner.TestRunOptions(
+            suite="unit",
+            paths=["pkg/tests/unit", "shared/tests"],
+            marker="unit and not slow",
+            coverage=("kindling",),
+            pytest_args=("--tb=short",),
+        )
+    )
+
+    assert args == [
+        "pytest",
+        "pkg/tests/unit",
+        "shared/tests",
+        "-v",
+        "-s",
+        "-m",
+        "unit and not slow",
+        "--cov=kindling",
+        "--tb=short",
     ]


### PR DESCRIPTION
## Summary
- add `kindling test run/check/cleanup` commands with explicit path-based test execution
- move reusable pytest orchestration into `kindling_cli.test_runner`
- point Kindling repo Poe test tasks and generated domain project Poe tasks at the CLI instead of repo-only pytest commands/helpers

## Verification
- `poetry install`
- `poetry check` (passes with existing Poetry metadata deprecation warnings)
- `poetry run pytest tests/unit/test_test_runner.py tests/unit/test_cli.py -q`
- `poetry run kindling test run --suite unit --path tests/unit/test_test_runner.py --no-cov --pytest-arg=-q`
- `poetry run poe test-unit` (1005 passed)
