### PR TITLE
Improve Spark JDBC URL normalization

### DIFF
--- a/packages/kindling/spark_jdbc.py
+++ b/packages/kindling/spark_jdbc.py
@@ -1,37 +1,146 @@
-def createJdbcUrl(server: str, database: str) -> str:
-    return f"jdbc:sqlserver://{server};databaseName={database};encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.database.windows.net;loginTimeout=10"
+def _normalize_server_host(server: str) -> str:
+    server_host = server.strip().lower()
+
+    if server_host.startswith("tcp:"):
+        server_host = server_host[4:]
+
+    if "," in server_host:
+        server_host = server_host.split(",", 1)[0]
+
+    if ":" in server_host:
+        server_host = server_host.split(":", 1)[0]
+
+    return server_host
 
 
-def createJdbcConnection(server: str, database: str):
-    url = createJdbcUrl(server, database)
+def _normalize_server_for_jdbc(server: str) -> str:
+    normalized_server = server.strip()
+
+    if normalized_server.lower().startswith("tcp:"):
+        normalized_server = normalized_server[4:]
+
+    if "," in normalized_server:
+        server_host, server_port = normalized_server.split(",", 1)
+        normalized_server = f"{server_host}:{server_port}"
+
+    if ":" in normalized_server:
+        server_host, server_port = normalized_server.rsplit(":", 1)
+        normalized_host = _normalize_server_host(server_host)
+
+        if server_port == "1443" and (
+            normalized_host.endswith(".sql.azuresynapse.net")
+            or normalized_host.endswith(".sql.azuresynapse.usgovcloudapi.net")
+            or normalized_host.endswith(".database.windows.net")
+            or normalized_host.endswith(".database.usgovcloudapi.net")
+        ):
+            normalized_server = f"{server_host}:1433"
+
+    return normalized_server
+
+
+def _get_host_name_in_certificate(server: str) -> str:
+    normalized_host = _normalize_server_host(server)
+
+    wildcard_certificate_suffixes = (
+        ".sql.azuresynapse.net",
+        ".sql.azuresynapse.usgovcloudapi.net",
+        ".database.windows.net",
+        ".database.usgovcloudapi.net",
+    )
+
+    for certificate_suffix in wildcard_certificate_suffixes:
+        if normalized_host.endswith(certificate_suffix):
+            return f"*{certificate_suffix}"
+
+    return normalized_host
+
+
+def createJdbcUrl_ex(server: str, database: str, trust_server_certificate: bool = False) -> str:
+    normalized_server = _normalize_server_for_jdbc(server)
+    trust_server_certificate_value = str(trust_server_certificate).lower()
+    jdbc_url = (
+        f"jdbc:sqlserver://{normalized_server};databaseName={database};"
+        f"encrypt=true;trustServerCertificate={trust_server_certificate_value};"
+        "loginTimeout=10"
+    )
+
+    if not trust_server_certificate:
+        host_name_in_certificate = _get_host_name_in_certificate(normalized_server)
+        jdbc_url = f"{jdbc_url};hostNameInCertificate={host_name_in_certificate}"
+
+    return jdbc_url
+
+
+def createJdbcConnection_ex(server: str, database: str, trust_server_certificate: bool = False):
+    url = createJdbcUrl_ex(server, database, trust_server_certificate=trust_server_certificate)
     driver_manager = spark._sc._gateway.jvm.java.sql.DriverManager
     properties = spark._sc._gateway.jvm.java.util.Properties()
     token = mssparkutils.credentials.getToken("DW")
     properties.setProperty("accessToken", token)
+    properties.setProperty("trustServerCertificate", str(trust_server_certificate).lower())
 
     return driver_manager.getConnection(url, properties)
 
 
-def createConnectionProperties():
+def _extract_server_from_jdbc_uri(jdbcUri: str) -> str:
+    jdbc_prefix = "jdbc:sqlserver://"
+
+    if jdbcUri.startswith(jdbc_prefix):
+        server_definition = jdbcUri[len(jdbc_prefix) :].split(";", 1)[0]
+        return _normalize_server_for_jdbc(server_definition)
+
+    return jdbcUri
+
+
+def _extract_trust_server_certificate_from_jdbc_uri(jdbcUri: str):
+    trust_setting = "trustServerCertificate="
+
+    for jdbc_property in jdbcUri.split(";"):
+        if jdbc_property.startswith(trust_setting):
+            return jdbc_property[len(trust_setting) :].strip().lower() == "true"
+
+    return None
+
+
+def createConnectionProperties_ex(server: str = None, trust_server_certificate: bool = False):
     token = mssparkutils.credentials.getToken("DW")
-    return {
+    properties = {
         "driver": "com.microsoft.sqlserver.jdbc.SQLServerDriver",
         "accessToken": token,
         "encrypt": "true",
-        "trustServerCertificate": "false",
+        "trustServerCertificate": str(trust_server_certificate).lower(),
     }
 
+    if server and not trust_server_certificate:
+        properties["hostNameInCertificate"] = _get_host_name_in_certificate(server)
 
-def spark_jdbc_read(jdbcUri, table):
-    return spark.read.jdbc(jdbcUri, table=table, properties=createConnectionProperties())
+    return properties
 
 
-def execute_ddl(connection, ddl_statement: str):
+def spark_jdbc_read_ex(jdbcUri, table, trust_server_certificate=None):
+    server = _extract_server_from_jdbc_uri(jdbcUri)
+    if trust_server_certificate is None:
+        trust_server_certificate = _extract_trust_server_certificate_from_jdbc_uri(jdbcUri)
+
+    if trust_server_certificate is None:
+        trust_server_certificate = False
+
+    return spark.read.jdbc(
+        jdbcUri,
+        table=table,
+        properties=createConnectionProperties_ex(
+            server,
+            trust_server_certificate=trust_server_certificate,
+        ),
+    )
+
+
+def execute_ddl_ex(connection, ddl_statement: str):
     exec_statement = connection.prepareCall(ddl_statement)
     exec_statement.execute()
 
 
-def create_external_table(connection, location, schema, table):
+def create_external_table_ex(connection, location, schema, table):
     create_table_statement = f"""
     CREATE EXTERNAL TABLE [{dest_schema}].[{view_name}{slot_suffix}]
     WITH
@@ -48,7 +157,7 @@ def create_external_table(connection, location, schema, table):
     exec_statement.execute()
 
 
-def create_sql_database(connection, dbname):
+def create_sql_database_ex(connection, dbname):
 
     create_schema_statement = f"""
     IF (NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '{dbname}'))
@@ -57,13 +166,13 @@ def create_sql_database(connection, dbname):
     END
     """
 
-    execute_ddl(connection, create_schema_statement)
+    execute_ddl_ex(connection, create_schema_statement)
 
 
-def create_view(connection, schema, view_name, view_statement: str):
+def create_view_ex(connection, schema, view_name, view_statement: str):
     create_view_statement = f"""
     CREATE OR ALTER VIEW [{schema}].{view_name}
     AS
     {view_statement}
     """
-    execute_ddl(connection, create_view_statement)
+    execute_ddl_ex(connection, create_view_statement)

--- a/packages/kindling/spark_jdbc.py
+++ b/packages/kindling/spark_jdbc.py
@@ -24,10 +24,14 @@ def _normalize_server_for_jdbc(server: str) -> str:
 
     if "," in normalized_server:
         server_host, server_port = normalized_server.split(",", 1)
+        server_host = server_host.strip()
+        server_port = server_port.strip()
         normalized_server = f"{server_host}:{server_port}"
 
     if ":" in normalized_server:
         server_host, server_port = normalized_server.rsplit(":", 1)
+        server_host = server_host.strip()
+        server_port = server_port.strip()
         normalized_host = _normalize_server_host(server_host)
 
         if server_port == "1443" and (
@@ -97,11 +101,13 @@ def _extract_server_from_jdbc_uri(jdbcUri: str) -> str:
 
 
 def _extract_trust_server_certificate_from_jdbc_uri(jdbcUri: str):
-    trust_setting = "trustServerCertificate="
+    trust_setting = "trustservercertificate="
 
     for jdbc_property in jdbcUri.split(";"):
-        if jdbc_property.startswith(trust_setting):
-            return jdbc_property[len(trust_setting) :].strip().lower() == "true"
+        normalized_property = jdbc_property.strip()
+
+        if normalized_property.lower().startswith(trust_setting):
+            return normalized_property[len(trust_setting) :].strip().lower() == "true"
 
     return None
 
@@ -145,12 +151,23 @@ def execute_ddl(connection, ddl_statement: str):
     exec_statement.execute()
 
 
+def _escape_sql_identifier(identifier: str) -> str:
+    return identifier.replace("]", "]]")
+
+
+def _escape_sql_string_literal(value: str) -> str:
+    return value.replace("'", "''")
+
+
 def create_external_table(connection, location, schema, table):
+    escaped_schema = _escape_sql_identifier(schema)
+    escaped_table = _escape_sql_identifier(table)
+    escaped_location = _escape_sql_string_literal(location)
     create_table_statement = f"""
-    CREATE EXTERNAL TABLE [{schema}].[{table}]
+    CREATE EXTERNAL TABLE [{escaped_schema}].[{escaped_table}]
     WITH
     (
-        LOCATION = '{location}',
+        LOCATION = '{escaped_location}',
         DATA_SOURCE = [DatalakeCurated],
         FILE_FORMAT = [ParquetFormat]
     )

--- a/packages/kindling/spark_jdbc.py
+++ b/packages/kindling/spark_jdbc.py
@@ -1,3 +1,6 @@
+from kindling.spark_session import get_or_create_spark_session
+
+
 def _normalize_server_host(server: str) -> str:
     server_host = server.strip().lower()
 
@@ -55,7 +58,7 @@ def _get_host_name_in_certificate(server: str) -> str:
     return normalized_host
 
 
-def createJdbcUrl_ex(server: str, database: str, trust_server_certificate: bool = False) -> str:
+def createJdbcUrl(server: str, database: str, trust_server_certificate: bool = False) -> str:
     normalized_server = _normalize_server_for_jdbc(server)
     trust_server_certificate_value = str(trust_server_certificate).lower()
     jdbc_url = (
@@ -71,10 +74,11 @@ def createJdbcUrl_ex(server: str, database: str, trust_server_certificate: bool 
     return jdbc_url
 
 
-def createJdbcConnection_ex(server: str, database: str, trust_server_certificate: bool = False):
-    url = createJdbcUrl_ex(server, database, trust_server_certificate=trust_server_certificate)
-    driver_manager = spark._sc._gateway.jvm.java.sql.DriverManager
-    properties = spark._sc._gateway.jvm.java.util.Properties()
+def createJdbcConnection(server: str, database: str, trust_server_certificate: bool = False):
+    spark_session = get_or_create_spark_session()
+    url = createJdbcUrl(server, database, trust_server_certificate=trust_server_certificate)
+    driver_manager = spark_session._sc._gateway.jvm.java.sql.DriverManager
+    properties = spark_session._sc._gateway.jvm.java.util.Properties()
     token = mssparkutils.credentials.getToken("DW")
     properties.setProperty("accessToken", token)
     properties.setProperty("trustServerCertificate", str(trust_server_certificate).lower())
@@ -102,7 +106,7 @@ def _extract_trust_server_certificate_from_jdbc_uri(jdbcUri: str):
     return None
 
 
-def createConnectionProperties_ex(server: str = None, trust_server_certificate: bool = False):
+def createConnectionProperties(server: str = None, trust_server_certificate: bool = False):
     token = mssparkutils.credentials.getToken("DW")
     properties = {
         "driver": "com.microsoft.sqlserver.jdbc.SQLServerDriver",
@@ -117,7 +121,8 @@ def createConnectionProperties_ex(server: str = None, trust_server_certificate: 
     return properties
 
 
-def spark_jdbc_read_ex(jdbcUri, table, trust_server_certificate=None):
+def spark_jdbc_read(jdbcUri, table, trust_server_certificate=None):
+    spark_session = get_or_create_spark_session()
     server = _extract_server_from_jdbc_uri(jdbcUri)
     if trust_server_certificate is None:
         trust_server_certificate = _extract_trust_server_certificate_from_jdbc_uri(jdbcUri)
@@ -125,39 +130,36 @@ def spark_jdbc_read_ex(jdbcUri, table, trust_server_certificate=None):
     if trust_server_certificate is None:
         trust_server_certificate = False
 
-    return spark.read.jdbc(
+    return spark_session.read.jdbc(
         jdbcUri,
         table=table,
-        properties=createConnectionProperties_ex(
+        properties=createConnectionProperties(
             server,
             trust_server_certificate=trust_server_certificate,
         ),
     )
 
 
-def execute_ddl_ex(connection, ddl_statement: str):
+def execute_ddl(connection, ddl_statement: str):
     exec_statement = connection.prepareCall(ddl_statement)
     exec_statement.execute()
 
 
-def create_external_table_ex(connection, location, schema, table):
+def create_external_table(connection, location, schema, table):
     create_table_statement = f"""
-    CREATE EXTERNAL TABLE [{dest_schema}].[{view_name}{slot_suffix}]
+    CREATE EXTERNAL TABLE [{schema}].[{table}]
     WITH
     (
-        LOCATION = '/{dest_schema}/{view_name}{slot_suffix}',
+        LOCATION = '{location}',
         DATA_SOURCE = [DatalakeCurated],
         FILE_FORMAT = [ParquetFormat]
     )
-    AS
-    select * from [{src_db}].[{src_schema}].{view_name}
     """
 
-    exec_statement = connection.prepareCall(create_table_statement)
-    exec_statement.execute()
+    execute_ddl(connection, create_table_statement)
 
 
-def create_sql_database_ex(connection, dbname):
+def create_sql_database(connection, dbname):
 
     create_schema_statement = f"""
     IF (NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '{dbname}'))
@@ -166,13 +168,13 @@ def create_sql_database_ex(connection, dbname):
     END
     """
 
-    execute_ddl_ex(connection, create_schema_statement)
+    execute_ddl(connection, create_schema_statement)
 
 
-def create_view_ex(connection, schema, view_name, view_statement: str):
+def create_view(connection, schema, view_name, view_statement: str):
     create_view_statement = f"""
     CREATE OR ALTER VIEW [{schema}].{view_name}
     AS
     {view_statement}
     """
-    execute_ddl_ex(connection, create_view_statement)
+    execute_ddl(connection, create_view_statement)

--- a/tests/unit/test_spark_jdbc.py
+++ b/tests/unit/test_spark_jdbc.py
@@ -25,6 +25,12 @@ def test_create_jdbc_url_normalizes_tcp_prefix_and_comma_port():
     assert url.startswith("jdbc:sqlserver://server.database.windows.net:1433;")
 
 
+def test_create_jdbc_url_strips_port_whitespace():
+    url = spark_jdbc.createJdbcUrl("server.database.windows.net, 1443", "warehouse")
+
+    assert url.startswith("jdbc:sqlserver://server.database.windows.net:1433;")
+
+
 def test_create_jdbc_url_corrects_azure_1443_port_to_1433():
     url = spark_jdbc.createJdbcUrl("server.database.windows.net:1443", "warehouse")
 
@@ -83,6 +89,23 @@ def test_spark_jdbc_read_gets_or_creates_spark_session(monkeypatch):
     )
 
 
+def test_spark_jdbc_read_parses_trust_server_certificate_case_and_space(monkeypatch):
+    mssparkutils = Mock()
+    mssparkutils.credentials.getToken.return_value = "token"
+    spark = Mock()
+    monkeypatch.setattr(spark_jdbc, "mssparkutils", mssparkutils, raising=False)
+    monkeypatch.setattr(spark_jdbc, "get_or_create_spark_session", lambda: spark)
+
+    spark_jdbc.spark_jdbc_read(
+        "jdbc:sqlserver://server.database.windows.net; TRUSTSERVERCERTIFICATE=true",
+        "dbo.orders",
+    )
+
+    properties = spark.read.jdbc.call_args.kwargs["properties"]
+    assert properties["trustServerCertificate"] == "true"
+    assert "hostNameInCertificate" not in properties
+
+
 def test_create_jdbc_connection_gets_or_creates_spark_session(monkeypatch):
     mssparkutils = Mock()
     mssparkutils.credentials.getToken.return_value = "token"
@@ -126,6 +149,21 @@ def test_create_external_table_uses_supplied_arguments():
     assert "DATA_SOURCE = [DatalakeCurated]" in statement
     assert "FILE_FORMAT = [ParquetFormat]" in statement
     connection.prepareCall.return_value.execute.assert_called_once_with()
+
+
+def test_create_external_table_escapes_identifiers_and_location():
+    connection = Mock()
+
+    spark_jdbc.create_external_table(
+        connection,
+        "curated/customer's orders",
+        "sales]ops",
+        "orders]current",
+    )
+
+    statement = connection.prepareCall.call_args.args[0]
+    assert "CREATE EXTERNAL TABLE [sales]]ops].[orders]]current]" in statement
+    assert "LOCATION = 'curated/customer''s orders'" in statement
 
 
 def test_create_view_uses_execute_ddl():

--- a/tests/unit/test_spark_jdbc.py
+++ b/tests/unit/test_spark_jdbc.py
@@ -1,0 +1,139 @@
+from unittest.mock import Mock
+
+from kindling import spark_jdbc
+
+
+def test_create_jdbc_url_uses_azure_sql_certificate_wildcard():
+    url = spark_jdbc.createJdbcUrl("server.database.windows.net", "warehouse")
+
+    assert url == (
+        "jdbc:sqlserver://server.database.windows.net;databaseName=warehouse;"
+        "encrypt=true;trustServerCertificate=false;loginTimeout=10;"
+        "hostNameInCertificate=*.database.windows.net"
+    )
+
+
+def test_create_jdbc_url_uses_synapse_gov_certificate_wildcard():
+    url = spark_jdbc.createJdbcUrl("pool.sql.azuresynapse.usgovcloudapi.net", "warehouse")
+
+    assert "hostNameInCertificate=*.sql.azuresynapse.usgovcloudapi.net" in url
+
+
+def test_create_jdbc_url_normalizes_tcp_prefix_and_comma_port():
+    url = spark_jdbc.createJdbcUrl("tcp:server.database.windows.net,1433", "warehouse")
+
+    assert url.startswith("jdbc:sqlserver://server.database.windows.net:1433;")
+
+
+def test_create_jdbc_url_corrects_azure_1443_port_to_1433():
+    url = spark_jdbc.createJdbcUrl("server.database.windows.net:1443", "warehouse")
+
+    assert url.startswith("jdbc:sqlserver://server.database.windows.net:1433;")
+
+
+def test_create_jdbc_url_trust_server_certificate_suppresses_host_name_in_certificate():
+    url = spark_jdbc.createJdbcUrl(
+        "server.database.windows.net",
+        "warehouse",
+        trust_server_certificate=True,
+    )
+
+    assert "trustServerCertificate=true" in url
+    assert "hostNameInCertificate" not in url
+
+
+def test_create_connection_properties_uses_token_and_certificate_host(monkeypatch):
+    mssparkutils = Mock()
+    mssparkutils.credentials.getToken.return_value = "token"
+    monkeypatch.setattr(spark_jdbc, "mssparkutils", mssparkutils, raising=False)
+
+    properties = spark_jdbc.createConnectionProperties("server.database.windows.net")
+
+    assert properties == {
+        "driver": "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+        "accessToken": "token",
+        "encrypt": "true",
+        "trustServerCertificate": "false",
+        "hostNameInCertificate": "*.database.windows.net",
+    }
+
+
+def test_spark_jdbc_read_gets_or_creates_spark_session(monkeypatch):
+    mssparkutils = Mock()
+    mssparkutils.credentials.getToken.return_value = "token"
+    spark = Mock()
+    monkeypatch.setattr(spark_jdbc, "mssparkutils", mssparkutils, raising=False)
+    monkeypatch.setattr(spark_jdbc, "get_or_create_spark_session", lambda: spark)
+
+    spark_jdbc.spark_jdbc_read(
+        "jdbc:sqlserver://server.database.windows.net;databaseName=warehouse",
+        "dbo.orders",
+    )
+
+    spark.read.jdbc.assert_called_once_with(
+        "jdbc:sqlserver://server.database.windows.net;databaseName=warehouse",
+        table="dbo.orders",
+        properties={
+            "driver": "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+            "accessToken": "token",
+            "encrypt": "true",
+            "trustServerCertificate": "false",
+            "hostNameInCertificate": "*.database.windows.net",
+        },
+    )
+
+
+def test_create_jdbc_connection_gets_or_creates_spark_session(monkeypatch):
+    mssparkutils = Mock()
+    mssparkutils.credentials.getToken.return_value = "token"
+    properties = Mock()
+    driver_manager = Mock()
+    driver_manager.getConnection.return_value = "connection"
+    spark = Mock()
+    spark._sc._gateway.jvm.java.util.Properties.return_value = properties
+    spark._sc._gateway.jvm.java.sql.DriverManager = driver_manager
+    monkeypatch.setattr(spark_jdbc, "mssparkutils", mssparkutils, raising=False)
+    monkeypatch.setattr(spark_jdbc, "get_or_create_spark_session", lambda: spark)
+
+    connection = spark_jdbc.createJdbcConnection("server.database.windows.net", "warehouse")
+
+    assert connection == "connection"
+    properties.setProperty.assert_any_call("accessToken", "token")
+    properties.setProperty.assert_any_call("trustServerCertificate", "false")
+    driver_manager.getConnection.assert_called_once_with(
+        (
+            "jdbc:sqlserver://server.database.windows.net;databaseName=warehouse;"
+            "encrypt=true;trustServerCertificate=false;loginTimeout=10;"
+            "hostNameInCertificate=*.database.windows.net"
+        ),
+        properties,
+    )
+
+
+def test_create_external_table_uses_supplied_arguments():
+    connection = Mock()
+
+    spark_jdbc.create_external_table(
+        connection,
+        "curated/orders",
+        "sales",
+        "orders",
+    )
+
+    statement = connection.prepareCall.call_args.args[0]
+    assert "CREATE EXTERNAL TABLE [sales].[orders]" in statement
+    assert "LOCATION = 'curated/orders'" in statement
+    assert "DATA_SOURCE = [DatalakeCurated]" in statement
+    assert "FILE_FORMAT = [ParquetFormat]" in statement
+    connection.prepareCall.return_value.execute.assert_called_once_with()
+
+
+def test_create_view_uses_execute_ddl():
+    connection = Mock()
+
+    spark_jdbc.create_view(connection, "sales", "orders_v", "SELECT * FROM sales.orders")
+
+    statement = connection.prepareCall.call_args.args[0]
+    assert "CREATE OR ALTER VIEW [sales].orders_v" in statement
+    assert "SELECT * FROM sales.orders" in statement
+    connection.prepareCall.return_value.execute.assert_called_once_with()


### PR DESCRIPTION
## Summary
- preserve the existing spark_jdbc public API while adding Azure SQL/Synapse server normalization
- derive hostNameInCertificate for commercial and US Gov Azure SQL/Synapse hosts
- use get_or_create_spark_session() instead of assuming a global spark
- fix create_external_table() to use and escape its supplied arguments
- address Copilot review edge cases for whitespace/case-tolerant parsing

## Tests
- poetry run poe test-unit