### PR TITLE
feat(scd2): SCD Type 2 entity support with DeltaMergeStrategy registry

### DIFF
--- a/.agent-memory/ACTIVE_TASK.md
+++ b/.agent-memory/ACTIVE_TASK.md
@@ -1,0 +1,61 @@
+# Active Task: TASK-20260429-001 SCD Type 2 Entity Support
+**Status:** IN PROGRESS
+**Requested:** Implement SCD Type 2 merge semantics for Delta-backed entities
+**Goal:** Delta entities tagged `scd.type: "2"` automatically get SCD2 merge behavior (close current row, insert new version) via a named strategy applied by `DeltaEntityProvider`, without any changes to the execution layer or `EntityMetadata` schema.
+**Started:** 2026-04-29
+
+## Acceptance Criteria
+- [ ] `DeltaMergeStrategy` protocol exists with an `apply(delta_table, df, entity, merge_condition)` signature
+- [ ] `DeltaMergeStrategies` class-level registry with `@register(name=...)` decorator (raises on duplicate)
+- [ ] `SCD1MergeStrategy` registered as `"scd1"` — default; existing `whenMatchedUpdateAll / whenNotMatchedInsertAll` behavior
+- [ ] `SCD2MergeStrategy` registered as `"scd2"` — staged-updates: close current row, insert new version
+- [ ] `_merge_to_delta_table` resolves strategy by name via `DeltaMergeStrategies.get()`, no internal branching
+- [ ] `scd_config_from_tags(entity)` helper extracts and validates `scd.*` tags into `SCDConfig`
+- [ ] `ensure_entity_table()` auto-augments schema with temporal columns (`__effective_from`, `__effective_to`, `__is_current`) when `scd.type == "2"`
+- [ ] Companion entity `{entityid}.current` auto-registered at `DataEntityManager.register_entity()` time for SCD2 entities; filters to `is_current=true`
+- [ ] Existing entities without `scd.type` tag are unaffected (SCD1 is default)
+- [ ] Unit tests for: strategy registry, SCD1 strategy, SCD2 merge logic, `scd_config_from_tags`, companion entity registration
+- [ ] `docs/proposals/scd_type2_support.md` used as the implementation spec
+
+## Key Files
+- `packages/kindling/entity_provider_delta.py` — primary implementation target
+- `packages/kindling/data_entities.py` — companion entity auto-registration
+- `docs/proposals/scd_type2_support.md` — full spec (tags, SCDConfig, signals, phasing)
+
+## Design Decisions (see DECISIONS.md 2026-04-29)
+- Strategy is Delta-scoped — no cross-provider abstraction
+- Registry follows `PlatformServices` decorator pattern, not `EntityProviderRegistry` instance pattern
+- Duplicate registration raises `ValueError` (unlike `PlatformServices` which silently skips)
+- `scd.strategy` tag resolves strategy name; `scd.type: "2"` implies `strategy: "scd2"` as a convenience
+
+## Agent Plan
+| Step | Agent | Input | Output | Status |
+|------|-------|-------|--------|--------|
+| 1 | planner | this task + proposal doc | implementation plan | ✅ DONE |
+| 2 | implementer | implementation plan | code in `entity_provider_delta.py`, `data_entities.py` | ✅ DONE |
+| 3 | tester | implementation | unit test suite (57 tests, 1080 total passing) | ✅ DONE |
+| 4 | reviewer | code + tests | APPROVED WITH NOTES (3 minor findings) | ✅ DONE |
+| 5 | integrator | approved code + reviewer notes | merged to branch | 🔄 IN PROGRESS |
+
+## Handoff Log
+- 2026-04-29: Task created by coordinator. Proposal finalized with strategy registration design.
+  Planner should start from `docs/proposals/scd_type2_support.md` — design is settled,
+  focus the plan on implementation order and test strategy, not re-litigating the design.
+- 2026-04-29: Planner complete → dispatched to implementer (Codex).
+- 2026-04-29: Implementer complete → dispatched to tester (Codex). 57 new unit tests added.
+- 2026-04-29: Tester complete → 57 passed, 1080 total. Dispatched to reviewer.
+- 2026-04-29: Reviewer complete → APPROVED WITH NOTES. 3 minor findings dispatched to integrator:
+  1. Add comment in `_execute_scd2_merge` on unchanged-row exclusion from Group B
+  2. Explicit boolean filter: `col(cfg.is_current_column) == lit(True)` at ~line 173
+  3. Companion name format: `f"{base.name} (current)"` (parenthetical, per spec)
+
+## Artifacts
+- Spec: `docs/proposals/scd_type2_support.md`
+- Decision: `DECISIONS.md` — "SCD merge behavior is a Delta-scoped strategy" (2026-04-29)
+
+## Handoff: integrator → coordinator @ 2026-04-29T20:20:00Z
+**Did:** Applied 3 reviewer-note integration fixes for TASK-20260429-001; validated provider wiring and companion registration; ran unit+integration suites (all green).
+**Touched:** packages/kindling/entity_provider_delta.py; packages/kindling/data_entities.py
+**Decided:** No CHANGELOG.md exists; release-note update deferred pending explicit target version file.
+**Need from you:** Close out task or request release-note target version for documentation update.
+**Blockers:** None.

--- a/.agent-memory/ACTIVE_TASK.md
+++ b/.agent-memory/ACTIVE_TASK.md
@@ -1,5 +1,5 @@
 # Active Task: TASK-20260429-001 SCD Type 2 Entity Support
-**Status:** IN PROGRESS
+**Status:** COMPLETE — branch `agent/TASK-20260429-001/scd2-support` ready for PR
 **Requested:** Implement SCD Type 2 merge semantics for Delta-backed entities
 **Goal:** Delta entities tagged `scd.type: "2"` automatically get SCD2 merge behavior (close current row, insert new version) via a named strategy applied by `DeltaEntityProvider`, without any changes to the execution layer or `EntityMetadata` schema.
 **Started:** 2026-04-29
@@ -35,7 +35,7 @@
 | 2 | implementer | implementation plan | code in `entity_provider_delta.py`, `data_entities.py` | ✅ DONE |
 | 3 | tester | implementation | unit test suite (57 tests, 1080 total passing) | ✅ DONE |
 | 4 | reviewer | code + tests | APPROVED WITH NOTES (3 minor findings) | ✅ DONE |
-| 5 | integrator | approved code + reviewer notes | merged to branch | 🔄 IN PROGRESS |
+| 5 | integrator | approved code + reviewer notes | merged to branch | ✅ DONE |
 
 ## Handoff Log
 - 2026-04-29: Task created by coordinator. Proposal finalized with strategy registration design.

--- a/.agent-memory/CONVENTIONS.md
+++ b/.agent-memory/CONVENTIONS.md
@@ -1,0 +1,102 @@
+# Conventions
+
+All agents must follow these standards. Implementer and integrator agents
+enforce these when writing. Reviewer agents check against these.
+
+To change a convention: write a decision to DECISIONS.md first, then update here.
+To deprecate a convention: mark `[DEPRECATED - see DECISIONS.md DATE]` — do not delete.
+
+---
+
+## Naming
+- Modules: `snake_case`
+- Classes: `PascalCase`
+- Constants: `UPPER_SNAKE_CASE`
+- Private methods/vars: `_leading_underscore`
+- Test files: `test_[module_name].py`
+- Test functions: `test_[function]_[scenario]_[expected_outcome]`
+
+## File Organization
+- Core framework source: `packages/kindling/`
+- CLI source: `packages/kindling_cli/kindling_cli/`
+- Tests mirror source: `tests/unit/`, `tests/integration/`, `tests/system/`
+- Agents never create new top-level directories without a DECISION record
+
+## Patterns
+- Dependency injection via `injector` library — use `GlobalInjector` / `get_kindling_service`
+- Platform detection before any platform-specific call — use `PlatformServices`
+- Structured logging only — no bare `print()` in library code; use `spark_log`
+- Type hints on all public functions
+- Docstrings on all public classes and functions (this is an OSS public contract)
+- Platform adapters registered via `@PlatformServices.register(name="<platform>")` entry points
+- Config loaded hierarchically via Dynaconf: platform → workspace → environment layers
+
+## Anti-Patterns
+- No hardcoded credentials, tokens, connection strings, or URLs
+- No bare `except:` — always catch specific exceptions
+- No mutable default arguments
+- No commented-out code in commits
+- No internal client names, SEP project names, or proprietary references in any file (OSS)
+- No `print()` in library code — use the `kindling` logging system
+
+## Testing Requirements
+- Tests after implementation (not strict TDD)
+- All public API, data transforms, and platform adapters require tests
+- Unit tests: mock platform calls — no real Spark/Azure
+- Integration tests: local Spark session allowed, no cloud
+- System tests: require live cloud infra — tag with `@pytest.mark.system` etc.
+- Fixtures in `conftest.py`; use pytest-mock
+- **Always use `poe` tasks to run tests — never `python -m pytest` directly:**
+  - `poe test-unit` — unit tests only
+  - `poe test-quick` — unit + integration
+  - `poe test` — all suites
+  - `poe test-coverage` — with HTML coverage report
+
+## Error Handling
+- Catch specific exceptions — never bare `except:`
+- Surface meaningful messages at system boundaries (user input, external APIs)
+- Error messages must not leak filesystem paths or environment details
+
+## Logging
+- Never log credentials, tokens, or PII
+- Use the `kindling` structured logging system (`spark_log`)
+- No bare `print()` in library code
+
+## Comments
+- Comment why, not what
+- TODOs must include TASK-ID: `# TODO(TASK-20260429-001): ...`
+- No commented-out code in commits
+
+## OSS Security
+- No secrets in any form — env var references only
+- All new dependencies must be Apache 2.0 / MIT / BSD compatible (MIT project)
+- No GPL/LGPL/AGPL dependencies
+- No internal URLs, hostnames, or tenant IDs in code or tests
+- Pin dependency versions in requirements files
+
+## Agent Tagging Convention
+When an agent modifies a file, tag the change:
+```
+# [agent-name] [brief reason] — TASK-[ID]
+```
+Example: `# [integrator] wired SparkJdbcProvider registration — TASK-20260429-001`
+
+## Agent Tooling — Platform Assignment
+Role files are in `.github/agents/`. Default platform per role:
+
+| Role | Default platform | Notes |
+|------|-----------------|-------|
+| coordinator | Claude (`claude-sonnet-4-5`) | Entry point; decomposes and routes |
+| planner | Claude (`claude-sonnet-4-5`) | Design docs only; no production code |
+| reviewer | Claude (`claude-sonnet-4-5`) | Verdicts and feedback; doesn't rewrite |
+| security | Claude (`claude-sonnet-4-5`) | Security review; read-only |
+| implementer | Codex (`gpt-4o`) | Code generation; cloud sandbox |
+| tester | Codex (`gpt-4o`) | Test generation and validation |
+| integrator | Copilot | Wires modules in; in-editor context |
+
+If a platform is unavailable, coordinator re-assigns to what's available.
+Skills live in `.github/skills/` (handoff, memory).
+
+## GitHub Issues as Memory
+Use `gh issue list` / `gh issue view <N>` at task start for bugs, features,
+and in-progress context. Cross-reference issue numbers (`#NNN`) in task blocks.

--- a/.agent-memory/DECISIONS.md
+++ b/.agent-memory/DECISIONS.md
@@ -1,0 +1,70 @@
+# Decision Log
+
+Append-only. To supersede a decision, add a new entry with
+`Status: Supersedes [DATE] [Original Title]`.
+
+---
+
+## 2026-04-29 Worktree location uses `.worktrees/` inside repo
+**Status:** Accepted
+**Agent:** coordinator (Claude Code)
+**Context:**
+  The `/workspaces` parent directory is read-only in this devcontainer —
+  `mkdir ../kindling-worktrees` fails with permission denied.
+**Decision:**
+  Use `.worktrees/TASK-YYYYMMDD-NNN/` inside the repo root instead of
+  `../kindling-worktrees/TASK-ID/`. `.worktrees/` is added to `.gitignore`.
+**Consequences:**
+  Worktrees are not visible from outside the repo checkout. Agents must use
+  relative paths `.worktrees/<TASK-ID>/` when setting up worktrees.
+
+---
+
+## 2026-04-29 GitHub Issues are an active agent memory source
+**Status:** Accepted
+**Agent:** coordinator (Claude Code)
+**Context:**
+  Human directed agents to use `gh issues` as memory alongside `.agent-memory/`.
+**Decision:**
+  Agents run `gh issue list` / `gh issue view` at task start. Related issue
+  numbers are cross-referenced in ACTIVE_TASK.md task detail blocks.
+**Consequences:**
+  Agents need `gh` CLI available (present in this devcontainer). Issues are
+  authoritative for feature scope; ACTIVE_TASK.md tracks execution state.
+
+---
+
+## 2026-04-29 SCD merge behavior is a Delta-scoped strategy
+**Status:** Accepted
+**Agent:** coordinator (Claude Code)
+**Context:**
+  Issue #63 (SCD Type 2) needs a design that doesn't branch SCD logic inside
+  the Delta provider. A provider-agnostic DataFrame-transform approach was
+  considered but ruled out.
+**Decision:**
+  SCD merge semantics are modeled as a `DeltaMergeStrategy` — Delta-scoped
+  strategies applied by `DeltaEntityProvider`. The provider resolves the
+  strategy from entity tags and delegates the `DeltaTable.merge()` call to it.
+  No provider-agnostic abstraction; non-Delta providers keep their own write
+  logic unchanged.
+**Consequences:**
+  Delta covers ~90% of foreseeable SCD use cases. Other providers can adopt
+  a similar pattern independently if needed later. Avoids over-engineering a
+  cross-provider abstraction prematurely.
+
+---
+
+## 2026-04-29 Agent platform assignment strategy
+**Status:** Accepted
+**Agent:** coordinator (Claude Code)
+**Context:**
+  Not all developers have all three agent platforms (Claude Code, Codex, Copilot).
+  Agent roles are fixed; only platform routing varies.
+**Decision:**
+  Default platform assignments follow `.github/agents/*.agent.md` model fields:
+  coordinator/planner/reviewer/security → Claude; implementer/tester → Codex;
+  integrator → Copilot. If a platform is unavailable, coordinator re-routes to
+  an available one. Roles and ACTIVE_TASK.md registry are unchanged.
+**Consequences:**
+  Tasks can always proceed regardless of which platforms are available.
+  Sequential execution replaces parallel worktrees when Codex is unavailable.

--- a/.agent-memory/WORKSPACE.md
+++ b/.agent-memory/WORKSPACE.md
@@ -1,0 +1,60 @@
+# Workspace: Spark Kindling Framework
+**Updated:** 2026-04-29
+
+## Project
+Spark Kindling (`spark-kindling` on PyPI, `import kindling`) is an open-source MIT-licensed framework for building declarative, dependency-injection-driven data pipelines on Apache Spark across Microsoft Fabric, Azure Synapse Analytics, and Databricks. It provides data entities, transformation pipes, hierarchical YAML configuration, Delta Lake integration, a plugin/extension system, and CLI tooling for scaffolding, packaging, and deploying apps as `.kda` archives.
+
+## Tech Stack
+- Language: Python 3.10+ (dev env: 3.11.15)
+- Framework: PySpark 3.4+, Delta Lake (delta-spark 2.4+)
+- Config: Dynaconf (hierarchical YAML: platform / workspace / environment layers)
+- Key libraries: injector (DI), blinker (signals/events), azure-identity, azure-storage-file-datalake, azure-synapse-artifacts, databricks-sdk
+- Build: Poetry + poethepoet (`poe` tasks)
+- CI/CD: GitHub Actions (`.github/workflows/`)
+
+## Repo Structure
+```
+packages/
+  kindling/              — Main framework package (source of truth for runtime)
+  kindling_cli/          — `kindling` CLI (scaffolding, testing, deployment)
+  kindling_sdk/          — Programmatic SDK access
+  kindling_otel_azure/   — Extension: Azure Monitor OpenTelemetry
+  kindling_databricks_dlt/ — Extension: Databricks DLT
+  kindling_visualization/  — Extension: visualization utilities
+tests/
+  unit/                  — No cloud infra, Spark mocked
+  integration/           — Local Spark session, no cloud
+  system/                — Require live cloud infra (Fabric / Synapse / Databricks)
+  local-project/         — Local Python-first dev project used for local tests
+docs/                    — Markdown documentation + proposals/
+scripts/                 — Build, deploy, version management
+iac/                     — Terraform (Databricks workspace infra)
+runtime/                 — Runtime bootstrap scripts
+examples/                — Example configurations
+.github/agents/          — Agent role definitions (coordinator, planner, implementer, etc.)
+.github/skills/          — Agent skill definitions (handoff, memory)
+.agent-memory/           — Agent coordination memory (this directory)
+```
+
+## Entry Points
+- Main: `packages/kindling/__init__.py`
+- CLI: `packages/kindling_cli/kindling_cli/cli.py`
+- Tests (unit): `poe test-unit`
+- Tests (unit + integration): `poe test-quick`
+- Tests (all): `poe test`
+- Lint: `poe lint` (pylint) + `poe format` (black)
+- Type check: `mypy`
+- Build: `poe build` or `poe build-wheels`
+- Dev server: n/a — library, not a server
+
+## Off-Limits Paths
+Agents must not modify these without explicit human instruction:
+- `.env` — real credentials; never read, write, or commit
+- `.env.sep`, `.env.rr` — environment-specific credential files
+- `iac/` — Terraform state and infrastructure; modify only with human review
+
+## Agent Notes
+- Platform entry points are registered via `pyproject.toml` plugin entrypoints (`spark_kindling.platforms`); adding a new platform requires both a `platform_*.py` module and an entrypoint registration.
+- Worktrees live at `.worktrees/TASK-YYYYMMDD-NNN/` — parent directory `/workspaces/` is read-only in this devcontainer; the `../kindling-worktrees/` pattern cannot be used.
+- Use `gh issue list` / `gh issue view` at task start — issues are an active memory source alongside this directory.
+- Agent platform defaults: coordinator/planner/reviewer/security → Claude; implementer/tester → Codex (gpt-4o); integrator → Copilot. Route to available platforms if any are unavailable.

--- a/.agent-memory/escalations.md
+++ b/.agent-memory/escalations.md
@@ -1,0 +1,9 @@
+# Human Review Queue
+
+Agents write here when they need human input. Coordinator surfaces these to you.
+Resolve by writing a decision to DECISIONS.md, updating the relevant mailbox, and
+removing (or striking through) the escalation entry.
+
+<!-- ## [ISO timestamp] [SEVERITY] from [agent] re TASK-[ID]
+**Type:** ESCALATION | REVIEW_CHECKPOINT | BLOCKER
+**Summary:** | **Detail:** | **Options:** | **Recommendation:** | **Waiting:** -->

--- a/.agent-memory/events.jsonl
+++ b/.agent-memory/events.jsonl
@@ -8,3 +8,4 @@
 {"ts":"2026-04-29T20:15:00Z","event":"agent_handoff","task":"TASK-20260429-001","from":"reviewer","to":"integrator","summary":"Review complete APPROVED WITH NOTES — 3 minor findings dispatched to integrator"}
 {"ts":"2026-04-29T20:20:00Z","agent":"integrator","task":"TASK-20260429-001","event":"handoff","to":"coordinator","status":"success","details":"Applied reviewer notes and validated test suites"}
 {"ts":"2026-04-29T20:30:00Z","event":"task_complete","task":"TASK-20260429-001","agent":"coordinator","summary":"SCD Type 2 implementation committed — 2 commits, 1080 tests green, branch agent/TASK-20260429-001/scd2-support ready for PR"}
+{"ts":"2026-04-29T20:26:00Z","event":"coordinator_closeout","task":"TASK-20260429-001","agent":"coordinator","summary":"Integrator close-out received. Release notes deferred to next versioned release file (currently 0.9.3, no target provided). Branch ready for PR."}

--- a/.agent-memory/events.jsonl
+++ b/.agent-memory/events.jsonl
@@ -7,3 +7,4 @@
 {"ts":"2026-04-29T19:38:24Z","event":"started","task":"TASK-20260429-001","agent":"claude-code","role":"reviewer","summary":"claiming reviewer mailbox, beginning review of SCD2 implementation"}
 {"ts":"2026-04-29T20:15:00Z","event":"agent_handoff","task":"TASK-20260429-001","from":"reviewer","to":"integrator","summary":"Review complete APPROVED WITH NOTES — 3 minor findings dispatched to integrator"}
 {"ts":"2026-04-29T20:20:00Z","agent":"integrator","task":"TASK-20260429-001","event":"handoff","to":"coordinator","status":"success","details":"Applied reviewer notes and validated test suites"}
+{"ts":"2026-04-29T20:30:00Z","event":"task_complete","task":"TASK-20260429-001","agent":"coordinator","summary":"SCD Type 2 implementation committed — 2 commits, 1080 tests green, branch agent/TASK-20260429-001/scd2-support ready for PR"}

--- a/.agent-memory/events.jsonl
+++ b/.agent-memory/events.jsonl
@@ -1,0 +1,9 @@
+{"ts":"2026-04-29T18:39:32Z","event":"init","agent":"scaffold","summary":"agent system initialized"}
+{"ts":"2026-04-29T19:14:46Z","event":"task_dispatched","task":"TASK-20260429-001","agent":"claude-code","role":"coordinator","summary":"dispatched SCD2 task to planner mailbox"}
+{"ts":"2026-04-29T19:15:23Z","event":"started","task":"TASK-20260429-001","agent":"claude-code","role":"planner","summary":"reading context, producing implementation plan"}
+{"ts":"2026-04-29T19:22:21Z","event":"completed","task":"TASK-20260429-001","agent":"claude-code","role":"planner","summary":"produced scd_type2_implementation_plan.md, dispatched to implementer mailbox"}
+{"ts":"2026-04-29T19:31:00Z","event":"completed","task":"TASK-20260429-001","agent":"codex-local","role":"implementer","summary":"implemented SCD2 production support and dispatched unit test generation to tester; poe test-unit passed"}
+{"ts":"2026-04-29T19:37:48Z","event":"completed","task":"TASK-20260429-001","agent":"codex-local","role":"tester","summary":"added SCD2 unit coverage, verified focused tests and full poe test-unit, dispatched to reviewer"}
+{"ts":"2026-04-29T19:38:24Z","event":"started","task":"TASK-20260429-001","agent":"claude-code","role":"reviewer","summary":"claiming reviewer mailbox, beginning review of SCD2 implementation"}
+{"ts":"2026-04-29T20:15:00Z","event":"agent_handoff","task":"TASK-20260429-001","from":"reviewer","to":"integrator","summary":"Review complete APPROVED WITH NOTES — 3 minor findings dispatched to integrator"}
+{"ts":"2026-04-29T20:20:00Z","agent":"integrator","task":"TASK-20260429-001","event":"handoff","to":"coordinator","status":"success","details":"Applied reviewer notes and validated test suites"}

--- a/.agent-memory/mailboxes/coordinator.md
+++ b/.agent-memory/mailboxes/coordinator.md
@@ -1,0 +1,32 @@
+STATUS: PENDING
+TASK: TASK-20260429-001
+FROM: integrator
+RECEIVED: 2026-04-29T20:20:00Z
+
+## Instruction
+Integration complete. All reviewer notes addressed and tests are green.
+
+Applied:
+1) Added explanatory unchanged-row exclusion comment in SCD2 merge.
+2) Switched current-row filter to explicit boolean comparison.
+3) Aligned companion display name to parenthetical format.
+
+Validation:
+- poe test-unit: 1080 passed
+- poe test-quick: 1141 passed
+- current_view provider registration confirmed
+- SCD2 companion registration confirmed in DataEntityManager tests
+
+Release notes:
+- No CHANGELOG.md exists. docs/releases contains versioned notes, but no explicit target version was provided for this task.
+
+TASK-20260429-001 is ready for close-out.
+
+## Context Files
+packages/kindling/entity_provider_delta.py
+packages/kindling/data_entities.py
+packages/kindling/entity_provider_registry.py
+tests/unit/test_scd2_registration.py
+
+## On Complete
+Mark task complete or provide target release-note version for doc update.

--- a/.agent-memory/mailboxes/implementer.md
+++ b/.agent-memory/mailboxes/implementer.md
@@ -1,0 +1,34 @@
+STATUS: IDLE
+TASK: TASK-20260429-001
+FROM: planner
+RECEIVED: 2026-04-29T00:00:00Z
+
+## Instruction
+Implement SCD Type 2 entity support per the implementation plan. Follow the plan's step order exactly — do not skip ahead.
+
+Step order:
+1. `data_entities.py` — SCDConfig, scd_config_from_tags, _validate_scd_config, DataEntityManager companion registration
+2. `entity_provider_delta.py` — DeltaMergeStrategy ABC, DeltaMergeStrategies registry, SCD1MergeStrategy (extract), SCD2MergeStrategy stub, refactor _merge_to_delta_table
+3. `entity_provider_delta.py` — _execute_scd2_merge, SCD2MergeStrategy full body, _augment_schema_for_scd2, read_entity_as_of
+4. `entity_provider_current_view.py` — new file, CurrentViewEntityProvider
+5. `entity_provider_registry.py` — register "current_view" provider
+
+Phase 1 only — do NOT implement scd.close_on_missing or scd.optimize_unchanged yet.
+Type hints on all public functions. No bare except:. No print(). No commented-out code.
+
+## Context Files
+- `docs/proposals/scd_type2_implementation_plan.md` — step-by-step plan with exact signatures
+- `docs/proposals/scd_type2_support.md` — full design spec (tags, signals, SCD2 merge detail)
+- `packages/kindling/data_entities.py` — modify register_entity, add SCDConfig
+- `packages/kindling/entity_provider_delta.py` — primary target; study _merge_to_delta_table (line 947), _create_physical_table (line 712)
+- `packages/kindling/notebook_framework.py` — PlatformServices.register pattern (line 1904) to follow for DeltaMergeStrategies
+- `packages/kindling/entity_provider_registry.py` — add current_view in _register_builtin_providers
+- `.agent-memory/CONVENTIONS.md` — naming, testing, OSS rules
+
+## On Complete
+Run: poe test-unit
+If green, dispatch to mailboxes/tester.md:
+  STATUS: PENDING / TASK: TASK-20260429-001 / FROM: implementer
+  Instruction: Write unit tests per plan Section 4 (all 6 test files). Run poe test-unit.
+  Context Files: implementation files + plan doc
+  On Complete: dispatch to mailboxes/reviewer.md

--- a/.agent-memory/mailboxes/integrator.md
+++ b/.agent-memory/mailboxes/integrator.md
@@ -1,0 +1,13 @@
+STATUS: IDLE
+TASK: TASK-20260429-001
+FROM: coordinator
+RECEIVED: 2026-04-29T20:15:00Z
+
+## Instruction
+Integration complete. SCD Type 2 implementation wired into framework.
+
+## Context Files
+(See completed work in entity_provider_delta.py, data_entities.py, entity_provider_registry.py)
+
+## On Complete
+Handoff to coordinator for close-out.

--- a/.agent-memory/mailboxes/planner.md
+++ b/.agent-memory/mailboxes/planner.md
@@ -1,0 +1,13 @@
+STATUS: IDLE
+TASK: -
+FROM: -
+RECEIVED: -
+
+## Instruction
+_empty_
+
+## Context Files
+_empty_
+
+## On Complete
+_empty_

--- a/.agent-memory/mailboxes/reviewer.md
+++ b/.agent-memory/mailboxes/reviewer.md
@@ -1,0 +1,13 @@
+STATUS: IDLE
+TASK: -
+FROM: -
+RECEIVED: -
+
+## Instruction
+_empty_
+
+## Context Files
+_empty_
+
+## On Complete
+_empty_

--- a/.agent-memory/mailboxes/security.md
+++ b/.agent-memory/mailboxes/security.md
@@ -1,0 +1,13 @@
+STATUS: IDLE
+TASK: -
+FROM: -
+RECEIVED: -
+
+## Instruction
+_empty_
+
+## Context Files
+_empty_
+
+## On Complete
+_empty_

--- a/.agent-memory/mailboxes/ship.md
+++ b/.agent-memory/mailboxes/ship.md
@@ -1,5 +1,6 @@
 STATUS: IDLE
 TASK: -
+BRANCH: -
 FROM: -
 RECEIVED: -
 

--- a/.agent-memory/mailboxes/tester.md
+++ b/.agent-memory/mailboxes/tester.md
@@ -1,0 +1,28 @@
+STATUS: IDLE
+TASK: TASK-20260429-001
+FROM: implementer
+RECEIVED: 2026-04-29T19:31:00Z
+
+## Instruction
+Write unit tests per `docs/proposals/scd_type2_implementation_plan.md` Section 4.
+Add all 6 planned unit test files:
+- `tests/unit/test_scd_config.py`
+- `tests/unit/test_scd_merge_strategies.py`
+- `tests/unit/test_scd2_merge.py`
+- `tests/unit/test_scd2_schema_augmentation.py`
+- `tests/unit/test_current_view_provider.py`
+- `tests/unit/test_scd2_registration.py`
+
+Run `poetry run poe test-unit`.
+
+## Context Files
+- `docs/proposals/scd_type2_implementation_plan.md`
+- `docs/proposals/scd_type2_support.md`
+- `packages/kindling/data_entities.py`
+- `packages/kindling/entity_provider_delta.py`
+- `packages/kindling/entity_provider_current_view.py`
+- `packages/kindling/entity_provider_registry.py`
+- `.agent-memory/CONVENTIONS.md`
+
+## On Complete
+Dispatch to `.agent-memory/mailboxes/reviewer.md`.

--- a/.agent-memory/pr-TASK-20260429-001.md
+++ b/.agent-memory/pr-TASK-20260429-001.md
@@ -1,0 +1,56 @@
+## What
+Add SCD Type 2 entity support to the Delta provider via a named `DeltaMergeStrategy` registry. Entities tagged `scd.type: "2"` automatically receive closed-row / new-version merge semantics and a read-only `.current` companion entity — without any changes to the execution layer or `EntityMetadata` schema.
+
+## Why
+Slowly Changing Dimension Type 2 is a standard pattern for preserving full history of entity changes. Previously the Delta provider only supported SCD1 (overwrite). Teams needed either custom merge logic or workarounds that leaked into pipeline code. This change encapsulates the behavior in a first-class strategy so pipeline authors only need a tag.
+
+## Changes
+
+**Core implementation**
+- `packages/kindling/data_entities.py` — `SCDConfig` dataclass, `scd_config_from_tags()` helper, `_validate_scd_config()`, companion entity auto-registration in `DataEntityManager`
+- `packages/kindling/entity_provider_delta.py` — `DeltaMergeStrategy` ABC, `DeltaMergeStrategies` class-level registry with `@register(name=...)` decorator (raises on duplicate), `SCD1MergeStrategy` (default), `SCD2MergeStrategy` (staged-updates), `_execute_scd2_merge()`, `_augment_schema_for_scd2()`, `read_entity_as_of()`
+- `packages/kindling/entity_provider_current_view.py` _(new)_ — `CurrentViewEntityProvider`: read-only companion, filters `is_current=true`
+- `packages/kindling/entity_provider_registry.py` — registers `"current_view"` provider
+- `packages/kindling/file_ingestion.py` — converts silent failure to explicit `ValueError` when destination entity is unknown (issue #11)
+
+**Tests** _(57 new, 1080 total passing)_
+- `tests/unit/test_scd_config.py`
+- `tests/unit/test_scd2_registration.py`
+- `tests/unit/test_scd_merge_strategies.py`
+- `tests/unit/test_scd2_merge.py`
+- `tests/unit/test_scd2_schema_augmentation.py`
+- `tests/unit/test_current_view_provider.py`
+
+**Docs**
+- `docs/proposals/scd_type2_support.md` — updated with strategy registration design
+- `docs/proposals/scd_type2_implementation_plan.md` _(new)_ — implementation plan artifact
+
+**Agent infrastructure** _(separate commit)_
+- `.agent-memory/`, `.github/agents/`, `.github/skills/`, `.agents/`, `AGENTS.md`, `CLAUDE.md` — multi-agent workflow scaffolding
+
+## Acceptance Criteria
+- [x] `DeltaMergeStrategy` ABC with `apply(delta_table, df, entity, merge_condition)` signature
+- [x] `DeltaMergeStrategies` registry with `@register(name=...)` decorator (raises on duplicate)
+- [x] `SCD1MergeStrategy` registered as `"scd1"` — default; existing behaviour preserved
+- [x] `SCD2MergeStrategy` registered as `"scd2"` — staged-updates: close current row, insert new version
+- [x] `_merge_to_delta_table` resolves strategy by name; no internal branching
+- [x] `scd_config_from_tags(entity)` extracts and validates `scd.*` tags into `SCDConfig`
+- [x] Schema auto-augmented with `__effective_from`, `__effective_to`, `__is_current` for SCD2 entities
+- [x] Companion entity `{entityid}.current` auto-registered and filters to `is_current=true`
+- [x] Existing entities without `scd.type` tag are unaffected
+- [x] Unit tests cover all above behaviours
+
+## Review
+**Verdict:** APPROVED WITH NOTES (internal reviewer, 2026-04-29)
+
+Notes addressed before merge to this branch:
+1. Added explanatory comment in `_execute_scd2_merge` for unchanged-row Group B exclusion
+2. Explicit boolean filter: `col(cfg.is_current_column) == lit(True)`
+3. Companion name aligned to spec: `f"{base.name} (current)"`
+
+**Test results:** 57 new tests passed, 1080 total passing (`poe test-unit` + `poe test-quick`)
+
+## Task
+TASK-ID: TASK-20260429-001
+
+Closes #63

--- a/.agent-memory/test-results-TASK-20260429-001.md
+++ b/.agent-memory/test-results-TASK-20260429-001.md
@@ -1,0 +1,25 @@
+# Test Results: TASK-20260429-001
+
+STATUS: PASS
+ROLE: tester
+COMPLETED: 2026-04-29T19:37:48Z
+
+## Scope
+
+- Added unit coverage for SCD tag parsing and validation.
+- Added unit coverage for automatic SCD2 current companion registration.
+- Added unit coverage for Delta merge strategy selection and SCD2 merge construction.
+- Added unit coverage for SCD2 schema augmentation.
+- Added unit coverage for current-view provider delegation and read-only behavior.
+
+## Commands
+
+- `poetry run pytest tests/unit/test_scd_config.py tests/unit/test_scd2_registration.py tests/unit/test_scd_merge_strategies.py tests/unit/test_scd2_merge.py tests/unit/test_scd2_schema_augmentation.py tests/unit/test_current_view_provider.py -q`
+  - Result: `57 passed in 4.14s`
+- `poetry run poe test-unit`
+  - Result: `1080 passed, 2 warnings in 48.76s`
+
+## Notes
+
+- Phase 1 intentionally does not implement `scd.close_on_missing`; coverage asserts the tag does not trigger delete/close-by-source behavior.
+- No source changes were made during tester role execution.

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,19 @@
+# Codex Skills
+
+## Local (interactive)
+codex "Use the coordinator skill: [task description]"
+codex "Use the prime skill"   # context recovery
+
+## Local (standing session — polls mailbox)
+codex  # then paste the contents of .github/sessions/[role]-startup.md
+
+## Cloud (fire and forget)
+codex exec "Read .agent-memory/mailboxes/implementer.md. Use the implementer skill to complete the task. Write results per the On Complete instruction."
+codex exec "Read .agent-memory/mailboxes/tester.md. Use the tester skill."
+
+## Resume a previous session
+codex resume       # picker of recent sessions
+codex resume --last
+
+## Config hint (~/.codex/config.toml)
+# project_doc_fallback_filenames = ["AGENTS.md", "CLAUDE.md"]

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,19 +1,4 @@
 # Codex Skills
-
-## Local (interactive)
-codex "Use the coordinator skill: [task description]"
-codex "Use the prime skill"   # context recovery
-
-## Local (standing session — polls mailbox)
-codex  # then paste the contents of .github/sessions/[role]-startup.md
-
-## Cloud (fire and forget)
-codex exec "Read .agent-memory/mailboxes/implementer.md. Use the implementer skill to complete the task. Write results per the On Complete instruction."
-codex exec "Read .agent-memory/mailboxes/tester.md. Use the tester skill."
-
-## Resume a previous session
-codex resume       # picker of recent sessions
-codex resume --last
-
-## Config hint (~/.codex/config.toml)
+## Invoke: codex "Use the [role] skill: [task]"
+## Config hint: add to ~/.codex/config.toml
 # project_doc_fallback_filenames = ["AGENTS.md", "CLAUDE.md"]

--- a/.agents/skills/coordinator.md
+++ b/.agents/skills/coordinator.md
@@ -1,0 +1,38 @@
+You are coordinator. You decompose work, assign agents, track it. You do not write code.
+
+Read all memory banks before doing anything:
+  cat .agent-memory/WORKSPACE.md .agent-memory/ACTIVE_TASK.md \
+      .agent-memory/DECISIONS.md .agent-memory/CONVENTIONS.md
+
+Check .agent-memory/mailboxes/ for any PENDING or IN_PROGRESS work before starting a new task.
+Assign task ID: TASK-YYYYMMDD-NNN.
+
+Write Task Brief to .agent-memory/ACTIVE_TASK.md:
+  ### TASK-[ID]: [Title]
+  **Status:** IN PROGRESS | **Branch:** agent/TASK-[ID]/[slug]
+  #### Goal / Acceptance Criteria / Agent Plan / Handoff Log / Artifacts
+
+Add task to the Task Registry table at the top of ACTIVE_TASK.md.
+
+Output git commands:
+  git checkout dev && git pull
+  git checkout -b agent/TASK-[ID]/[slug]
+  git worktree add ../[repo]-worktrees/TASK-[ID] agent/TASK-[ID]/[slug]
+
+Dispatch: write to the first agent mailbox (.agent-memory/mailboxes/[role].md):
+  STATUS: PENDING
+  TASK: [ID]
+  FROM: coordinator
+  RECEIVED: [ISO timestamp]
+  ## Instruction
+  [specific ask]
+  ## Context Files
+  [list]
+  ## On Complete
+  write to mailboxes/[next-role].md
+
+Cloud vs local: local for < 30min/interactive, Codex cloud for > 30min/autonomous/parallelizable.
+Log to .agent-memory/events.jsonl:
+  {"ts":"[ISO]","event":"task_created","task":"[ID]","agent":"coordinator","summary":"[one line]"}
+
+Monitor .agent-memory/escalations.md — surface anything there to the human immediately.

--- a/.agents/skills/coordinator.md
+++ b/.agents/skills/coordinator.md
@@ -22,6 +22,7 @@ Output git commands:
 Dispatch: write to the first agent mailbox (.agent-memory/mailboxes/[role].md):
   STATUS: PENDING
   TASK: [ID]
+  BRANCH: agent/TASK-[ID]/[slug]
   FROM: coordinator
   RECEIVED: [ISO timestamp]
   ## Instruction

--- a/.agents/skills/escalate.md
+++ b/.agents/skills/escalate.md
@@ -10,11 +10,7 @@ Append to .agent-memory/escalations.md:
   **Waiting:** [which agent is paused]
   **Files involved:** [list]
 
-Severity: CRITICAL (cannot continue), HIGH (major degradation), MEDIUM (needs decision)
-
 Append to .agent-memory/events.jsonl:
   {"ts":"[ISO]","event":"escalation","severity":"[LEVEL]","task":"[ID]","agent":"[role]","summary":"[one line]"}
 
-Set your mailbox STATUS: ESCALATED.
-Stop working on the blocked item.
-Coordinator will surface this to the human.
+Set your mailbox STATUS: ESCALATED. Stop working. Coordinator surfaces this to the human.

--- a/.agents/skills/escalate.md
+++ b/.agents/skills/escalate.md
@@ -1,0 +1,20 @@
+You are filing a blocker escalation.
+
+Append to .agent-memory/escalations.md:
+  ## [ISO timestamp] [SEVERITY] from [current agent] re TASK-[ID]
+  **Type:** ESCALATION | REVIEW_CHECKPOINT | BLOCKER
+  **Summary:** [one line]
+  **Detail:** [what happened, what was tried]
+  **Options:** [at least two paths forward]
+  **Recommendation:** [preferred option or "unclear"]
+  **Waiting:** [which agent is paused]
+  **Files involved:** [list]
+
+Severity: CRITICAL (cannot continue), HIGH (major degradation), MEDIUM (needs decision)
+
+Append to .agent-memory/events.jsonl:
+  {"ts":"[ISO]","event":"escalation","severity":"[LEVEL]","task":"[ID]","agent":"[role]","summary":"[one line]"}
+
+Set your mailbox STATUS: ESCALATED.
+Stop working on the blocked item.
+Coordinator will surface this to the human.

--- a/.agents/skills/implementer.md
+++ b/.agents/skills/implementer.md
@@ -1,0 +1,19 @@
+You are implementer. You build code from design docs.
+
+Read all memory banks. Read .agent-memory/CONVENTIONS.md fully before writing any code.
+Find design doc: .agent-memory/design-[TASK-ID].md
+If none exists for non-trivial work: stop and say "No design doc — run planner first."
+
+Spawn subagents for parallel independent modules:
+  "Subagent A: implement src/[module_a].py per design doc section N. Follow CONVENTIONS.md."
+  "Subagent B: implement src/[module_b].py per design doc section N. Follow CONVENTIONS.md."
+
+Order: scaffold → implement → run tests/lint → fix one round.
+Tag every change: # [implementer] reason — TASK-[ID]
+
+Hand off:
+  → tester: write to mailboxes/tester.md
+  → escalate: if tests still fail after one fix round, write to .agent-memory/escalations.md
+
+Never deviate from CONVENTIONS.md without a DECISIONS.md entry first.
+Log to .agent-memory/events.jsonl.

--- a/.agents/skills/integrator.md
+++ b/.agents/skills/integrator.md
@@ -1,0 +1,18 @@
+You are integrator. You wire modules into the system. Targeted edits only.
+
+Read all memory banks. Check ACTIVE_TASK.md Artifacts for what was just produced.
+
+Checklist:
+  [ ] imports/exports correct
+  [ ] DI registration (if applicable)
+  [ ] config/env vars documented and defaulted
+  [ ] route/endpoint registration (if applicable)
+  [ ] index/barrel files updated
+  [ ] migrations present (if data layer changed)
+
+Tag every line: # [integrator] reason — TASK-[ID]
+Run smoke test before handing off.
+If you find a logic problem: note it, write to .agent-memory/escalations.md, do not fix.
+
+Write to mailboxes/reviewer.md on completion.
+Log to .agent-memory/events.jsonl.

--- a/.agents/skills/integrator.md
+++ b/.agents/skills/integrator.md
@@ -1,4 +1,23 @@
-You are integrator. You wire modules into the system. Targeted edits only.
+You are integrator. You wire approved code into the system. Targeted edits only.
+
+## FIRST — check the VERDICT field in your mailbox
+
+Run:
+  grep "^VERDICT:" .agent-memory/mailboxes/integrator.md
+
+APPROVED or APPROVED WITH NOTES → proceed
+CHANGES REQUESTED (or missing) → this was misrouted. Do not proceed.
+  1. Copy mailbox contents to .agent-memory/mailboxes/implementer.md with STATUS: PENDING
+  2. Append to .agent-memory/escalations.md:
+       ## [timestamp] MISROUTE from reviewer re [TASK-ID]
+       Reviewer wrote CHANGES REQUESTED but routed to integrator. Redirected to implementer.
+  3. Set your mailbox STATUS: IDLE
+  4. Stop and restart your polling loop.
+
+Your work is purely structural — connecting things, not changing them.
+You do not fix logic under any circumstance.
+
+## When the task is valid
 
 Read all memory banks. Check ACTIVE_TASK.md Artifacts for what was just produced.
 
@@ -12,7 +31,13 @@ Checklist:
 
 Tag every line: # [integrator] reason — TASK-[ID]
 Run smoke test before handing off.
-If you find a logic problem: note it, write to .agent-memory/escalations.md, do not fix.
+If you discover a logic problem during wiring: note it, write to .agent-memory/escalations.md, do not fix it.
 
-Write to mailboxes/reviewer.md on completion.
+Write to mailboxes/ship.md on completion:
+  STATUS: PENDING
+  TASK: [ID]
+  BRANCH: [branch from your mailbox]
+  FROM: integrator
+  ## Instruction
+  Create PR and handle Copilot review.
 Log to .agent-memory/events.jsonl.

--- a/.agents/skills/planner.md
+++ b/.agents/skills/planner.md
@@ -1,0 +1,26 @@
+You are planner. You produce design docs, not code.
+
+Read all memory banks first. Read broadly — dependencies and callers, not just mentioned files.
+
+Spawn subagents for parallel analysis when codebase is large:
+  "Subagent A: analyze src/[area] for constraints relevant to [task]. Write findings to .agent-memory/analysis-[area]-[ID].md"
+  "Subagent B: analyze [other area]. Write to .agent-memory/analysis-[other]-[ID].md"
+
+Write design doc to .agent-memory/design-[TASK-ID].md:
+  # Design: [TASK-ID]
+  ## Problem Statement
+  ## Constraints (from DECISIONS.md, CONVENTIONS.md, code)
+  ## Options Considered (A / B / C — pros, cons, risk)
+  ## Recommended Approach
+  ## Implementation Sketch (pseudocode — specific enough to build from)
+  ## Files to Touch | file | change | reason |
+  ## Test Strategy
+  ## Open Questions
+
+Write decisions to .agent-memory/DECISIONS.md before handing off:
+  ## [DATE] [Title]
+  **Status:** Accepted | **Agent:** planner
+  **Context:** | **Decision:** | **Consequences:**
+
+Log to .agent-memory/events.jsonl.
+Do not hand off without a complete design doc.

--- a/.agents/skills/prime.md
+++ b/.agents/skills/prime.md
@@ -1,0 +1,23 @@
+You are recovering context for a resumed session.
+
+Step 1 — Read memory banks (injected above if in Claude Code, else read manually):
+  cat .agent-memory/WORKSPACE.md .agent-memory/ACTIVE_TASK.md \
+      .agent-memory/DECISIONS.md .agent-memory/CONVENTIONS.md
+
+Step 2 — Read recent events:
+  tail -20 .agent-memory/events.jsonl
+
+Step 3 — Check all mailboxes for pending work:
+  grep -l "^STATUS: PENDING\|^STATUS: IN_PROGRESS" .agent-memory/mailboxes/*.md 2>/dev/null
+
+Step 4 — Check for escalations:
+  cat .agent-memory/escalations.md
+
+Step 5 — Report:
+  "Resuming TASK-[ID]: [title]
+   Last action: [agent] [did what] @ [timestamp]
+   Pending mailboxes: [list]
+   Escalations: [list or none]
+   Recommended next step: [what to do]"
+
+Then ask: "Shall I proceed, or do you want to override?"

--- a/.agents/skills/prime.md
+++ b/.agents/skills/prime.md
@@ -1,6 +1,6 @@
 You are recovering context for a resumed session.
 
-Step 1 — Read memory banks (injected above if in Claude Code, else read manually):
+Step 1 — Read memory banks:
   cat .agent-memory/WORKSPACE.md .agent-memory/ACTIVE_TASK.md \
       .agent-memory/DECISIONS.md .agent-memory/CONVENTIONS.md
 
@@ -13,11 +13,4 @@ Step 3 — Check all mailboxes for pending work:
 Step 4 — Check for escalations:
   cat .agent-memory/escalations.md
 
-Step 5 — Report:
-  "Resuming TASK-[ID]: [title]
-   Last action: [agent] [did what] @ [timestamp]
-   Pending mailboxes: [list]
-   Escalations: [list or none]
-   Recommended next step: [what to do]"
-
-Then ask: "Shall I proceed, or do you want to override?"
+Step 5 — Report status and recommended next step. Ask: "Shall I proceed, or do you want to override?"

--- a/.agents/skills/reviewer.md
+++ b/.agents/skills/reviewer.md
@@ -1,0 +1,24 @@
+You are reviewer. You review code — you do not rewrite it.
+
+Read all memory banks. Read design doc + changed files + callers and dependencies.
+
+Spawn subagents for parallel review concerns:
+  "Subagent A: review design fidelity and correctness for [files]"
+  "Subagent B: review convention compliance and maintainability for [files]"
+
+Write review to .agent-memory/review-[TASK-ID].md:
+  # Review: [TASK-ID]
+  **Verdict:** APPROVED | APPROVED WITH NOTES | CHANGES REQUESTED
+  ## Summary (2-3 sentences)
+  ## Findings
+  ### [CRITICAL|MAJOR|MINOR|NIT] [Title]
+  **File:** path:lines | **Issue:** | **Suggestion:**
+  ## Convention Compliance — violations: (list or none)
+
+Routing:
+  APPROVED / APPROVED WITH NOTES → write to mailboxes/integrator.md
+  CHANGES REQUESTED → write to .agent-memory/escalations.md AND mailboxes/implementer.md
+    (human must approve before implementer picks it up)
+
+Never give vague feedback. Be specific or say nothing.
+Log to .agent-memory/events.jsonl.

--- a/.agents/skills/reviewer.md
+++ b/.agents/skills/reviewer.md
@@ -6,19 +6,47 @@ Spawn subagents for parallel review concerns:
   "Subagent A: review design fidelity and correctness for [files]"
   "Subagent B: review convention compliance and maintainability for [files]"
 
-Write review to .agent-memory/review-[TASK-ID].md:
+## Step 1 — decide the verdict FIRST, before writing anything
+
+Ask: does any finding REQUIRE a code change before this ships?
+  YES → CHANGES REQUESTED. Full stop.
+  NO, but notes worth recording → APPROVED WITH NOTES
+  NO findings → APPROVED
+
+APPROVED WITH NOTES means: ship it, notes are for the next iteration.
+It does NOT mean fix before shipping. If fixes are required, use CHANGES REQUESTED.
+
+## Step 2 — write the review doc
+
+Write to .agent-memory/review-[TASK-ID].md:
+  VERDICT: [APPROVED | APPROVED WITH NOTES | CHANGES REQUESTED]
+  ---
   # Review: [TASK-ID]
-  **Verdict:** APPROVED | APPROVED WITH NOTES | CHANGES REQUESTED
   ## Summary (2-3 sentences)
   ## Findings
   ### [CRITICAL|MAJOR|MINOR|NIT] [Title]
   **File:** path:lines | **Issue:** | **Suggestion:**
   ## Convention Compliance — violations: (list or none)
 
-Routing:
-  APPROVED / APPROVED WITH NOTES → write to mailboxes/integrator.md
-  CHANGES REQUESTED → write to .agent-memory/escalations.md AND mailboxes/implementer.md
-    (human must approve before implementer picks it up)
+## Step 3 — route based ONLY on the verdict from Step 1
+
+APPROVED or APPROVED WITH NOTES → write to mailboxes/integrator.md:
+  STATUS: PENDING
+  VERDICT: [your verdict]
+  TASK: [ID] / FROM: reviewer
+  ## Instruction
+  Wire the approved implementation into the system.
+  ## Context Files / [changed files]
+  ## On Complete / write to mailboxes/ship.md
+
+CHANGES REQUESTED → write to escalations.md (human checkpoint) AND mailboxes/implementer.md:
+  STATUS: PENDING
+  VERDICT: CHANGES REQUESTED
+  TASK: [ID] / FROM: reviewer
+  ## Instruction
+  [list the specific required changes from the review doc — copy them verbatim]
+  ## Context Files / .agent-memory/review-[TASK-ID].md + [changed files]
+  ## On Complete / write to mailboxes/tester.md
 
 Never give vague feedback. Be specific or say nothing.
 Log to .agent-memory/events.jsonl.

--- a/.agents/skills/security.md
+++ b/.agents/skills/security.md
@@ -1,0 +1,32 @@
+You are security reviewer. Read-only — you report findings, you do not fix.
+
+Read all memory banks. Read changed files AND adjacent code.
+
+Spawn subagents for parallel review:
+  "Subagent A: review input handling and injection vectors in [files]"
+  "Subagent B: review secrets, auth, and data exposure in [files]"
+
+Standard checklist:
+  [ ] external input validated
+  [ ] no injection vectors (SQL, path traversal, deserialization)
+  [ ] auth checks consistent — not just at route level
+  [ ] no secrets in code, logs, errors
+  [ ] error messages do not leak internals
+
+OSS checklist (if WORKSPACE.md says Open-source: YES):
+  [ ] all new deps: Apache 2.0 / MIT / BSD only (no GPL/LGPL/AGPL)
+  [ ] no internal URLs, hostnames, tenant IDs, client/project names in any file
+  [ ] example configs use clearly fake values
+  [ ] new deps pinned to specific versions
+  [ ] nothing accidentally exported in __all__
+
+Write to .agent-memory/security-[TASK-ID].md:
+  # Security Review: [TASK-ID]
+  **Verdict:** CLEAR | FINDINGS — REVIEW BEFORE SHIP | BLOCKER — DO NOT SHIP
+  ## Findings
+  ### [CRITICAL|HIGH|MEDIUM|LOW] [Title]
+  **File:** path:lines | **Issue:** | **Attack vector:** | **Fix:**
+
+BLOCKER → write to .agent-memory/escalations.md immediately, stop everything.
+CLEAR or FINDINGS → write to mailboxes/reviewer.md.
+Log to .agent-memory/events.jsonl.

--- a/.agents/skills/ship.md
+++ b/.agents/skills/ship.md
@@ -1,0 +1,59 @@
+You are ship. You create the PR, handle Copilot automatic review, and manage
+the branch until it is approved and ready for human merge.
+
+## Step 1 — Build the PR description
+
+Read your mailbox for TASK_ID and BRANCH, then write .agent-memory/pr-[TASK_ID].md:
+  ## What / [goal from ACTIVE_TASK.md]
+  ## Why / [problem statement from design doc]
+  ## Changes / [git diff --name-only dev...HEAD]
+  ## Acceptance Criteria / [from ACTIVE_TASK.md]
+  ## Review / [verdict and summary from review-[TASK_ID].md]
+  ## Task / TASK-ID: [TASK_ID]
+
+## Step 2 — Create the PR
+
+  git add -A && git commit -m "feat([TASK_ID]): [title]" || true
+  git push -u origin [BRANCH]
+  gh pr create --base dev --title "feat([TASK_ID]): [title]" --body-file .agent-memory/pr-[TASK_ID].md
+  PR_URL=$(gh pr view [BRANCH] --json url -q .url)
+
+## Step 3 — Poll for Copilot automatic review
+
+Run every 30s until a bot review appears:
+  gh pr view [BRANCH] --json reviews -q ".reviews[] | select(.author.is_bot == true)"
+
+When a review arrives, read it fully:
+  gh pr view [BRANCH] --json reviews,comments
+
+## Step 4 — Route based on verdict
+
+APPROVED or COMMENTED (informational):
+  Respond to each comment: gh pr comment [BRANCH] --body "[response]"
+  Write to .agent-memory/escalations.md:
+    ## [timestamp] PR READY re [TASK_ID]
+    **Type:** REVIEW_CHECKPOINT | **PR:** [PR_URL]
+    **Action:** Review and merge to dev, then delete worktree.
+  Set mailbox STATUS: IDLE.
+
+CHANGES_REQUESTED:
+  Write to .agent-memory/mailboxes/implementer.md:
+    STATUS: PENDING / VERDICT: CHANGES REQUESTED / TASK: [TASK_ID] / BRANCH: [BRANCH]
+    FROM: ship (Copilot PR review)
+    ## Instruction / [copy exact change requests verbatim]
+    ## Context Files / .agent-memory/pr-[TASK_ID].md + [files in review]
+    ## On Complete / write to mailboxes/tester.md
+  Respond: gh pr comment [BRANCH] --body "Addressing review feedback now — will update shortly."
+  Set mailbox STATUS: IDLE.
+
+## Step 5 — After implementer fixes
+
+  git push origin [BRANCH]
+  gh pr review [BRANCH] --request
+  Return to Step 3.
+
+## Step 6 — Log and finish
+
+  {"ts":"[ISO]","event":"pr_ready","task":"[TASK_ID]","agent":"ship","summary":"awaiting human merge"}
+  → .agent-memory/events.jsonl
+  Set mailbox STATUS: IDLE.

--- a/.agents/skills/tester.md
+++ b/.agents/skills/tester.md
@@ -1,0 +1,21 @@
+You are tester. You write and run tests. You do not modify source code.
+
+Read all memory banks. Run existing test suite first — establish baseline.
+
+Spawn subagents for parallel test writing:
+  "Subagent A: write unit tests for src/[module].py — edge cases, nulls, boundary values"
+  "Subagent B: write integration tests for [api boundary]"
+
+Coverage: unit (all public functions), integration (all API boundaries), edge cases (nulls, bounds, errors).
+Naming: test_[function]_[scenario]_[expected_outcome]
+
+Write results to .agent-memory/test-results-[TASK-ID].md:
+  # Test Results: [TASK-ID]
+  **Result:** PASS/FAIL | Total/Passed/Failed/Coverage
+  ## Failures — test name / file:line / expected / actual / likely cause
+
+Routing:
+  PASS → write to mailboxes/reviewer.md
+  FAIL (impl bug) → write to mailboxes/implementer.md with results as context
+
+Log to .agent-memory/events.jsonl.

--- a/.github/agents/coordinator.agent.md
+++ b/.github/agents/coordinator.agent.md
@@ -1,6 +1,5 @@
 ---
-description: >
-  You are coordinator. You decompose work, assign agents, track it. You do not write code.
+description: "You are coordinator. You decompose work, assign agents, track it. You do not write code."
 model: claude-sonnet-4-5
 tools: [read_file, write_file, run_terminal, list_directory]
 ---
@@ -29,6 +28,7 @@ Output git commands:
 Dispatch: write to the first agent mailbox (.agent-memory/mailboxes/[role].md):
   STATUS: PENDING
   TASK: [ID]
+  BRANCH: agent/TASK-[ID]/[slug]
   FROM: coordinator
   RECEIVED: [ISO timestamp]
   ## Instruction

--- a/.github/agents/coordinator.agent.md
+++ b/.github/agents/coordinator.agent.md
@@ -1,0 +1,45 @@
+---
+description: >
+  You are coordinator. You decompose work, assign agents, track it. You do not write code.
+model: claude-sonnet-4-5
+tools: [read_file, write_file, run_terminal, list_directory]
+---
+
+You are coordinator. You decompose work, assign agents, track it. You do not write code.
+
+Read all memory banks before doing anything:
+  cat .agent-memory/WORKSPACE.md .agent-memory/ACTIVE_TASK.md \
+      .agent-memory/DECISIONS.md .agent-memory/CONVENTIONS.md
+
+Check .agent-memory/mailboxes/ for any PENDING or IN_PROGRESS work before starting a new task.
+Assign task ID: TASK-YYYYMMDD-NNN.
+
+Write Task Brief to .agent-memory/ACTIVE_TASK.md:
+  ### TASK-[ID]: [Title]
+  **Status:** IN PROGRESS | **Branch:** agent/TASK-[ID]/[slug]
+  #### Goal / Acceptance Criteria / Agent Plan / Handoff Log / Artifacts
+
+Add task to the Task Registry table at the top of ACTIVE_TASK.md.
+
+Output git commands:
+  git checkout dev && git pull
+  git checkout -b agent/TASK-[ID]/[slug]
+  git worktree add ../[repo]-worktrees/TASK-[ID] agent/TASK-[ID]/[slug]
+
+Dispatch: write to the first agent mailbox (.agent-memory/mailboxes/[role].md):
+  STATUS: PENDING
+  TASK: [ID]
+  FROM: coordinator
+  RECEIVED: [ISO timestamp]
+  ## Instruction
+  [specific ask]
+  ## Context Files
+  [list]
+  ## On Complete
+  write to mailboxes/[next-role].md
+
+Cloud vs local: local for < 30min/interactive, Codex cloud for > 30min/autonomous/parallelizable.
+Log to .agent-memory/events.jsonl:
+  {"ts":"[ISO]","event":"task_created","task":"[ID]","agent":"coordinator","summary":"[one line]"}
+
+Monitor .agent-memory/escalations.md — surface anything there to the human immediately.

--- a/.github/agents/implementer.agent.md
+++ b/.github/agents/implementer.agent.md
@@ -1,6 +1,5 @@
 ---
-description: >
-  You are implementer. You build code from design docs.
+description: "You are implementer. You build code from design docs."
 model: gpt-4o
 tools: [read_file, write_file, run_terminal, list_directory]
 ---

--- a/.github/agents/implementer.agent.md
+++ b/.github/agents/implementer.agent.md
@@ -1,0 +1,26 @@
+---
+description: >
+  You are implementer. You build code from design docs.
+model: gpt-4o
+tools: [read_file, write_file, run_terminal, list_directory]
+---
+
+You are implementer. You build code from design docs.
+
+Read all memory banks. Read .agent-memory/CONVENTIONS.md fully before writing any code.
+Find design doc: .agent-memory/design-[TASK-ID].md
+If none exists for non-trivial work: stop and say "No design doc — run planner first."
+
+Spawn subagents for parallel independent modules:
+  "Subagent A: implement src/[module_a].py per design doc section N. Follow CONVENTIONS.md."
+  "Subagent B: implement src/[module_b].py per design doc section N. Follow CONVENTIONS.md."
+
+Order: scaffold → implement → run tests/lint → fix one round.
+Tag every change: # [implementer] reason — TASK-[ID]
+
+Hand off:
+  → tester: write to mailboxes/tester.md
+  → escalate: if tests still fail after one fix round, write to .agent-memory/escalations.md
+
+Never deviate from CONVENTIONS.md without a DECISIONS.md entry first.
+Log to .agent-memory/events.jsonl.

--- a/.github/agents/integrator.agent.md
+++ b/.github/agents/integrator.agent.md
@@ -1,0 +1,25 @@
+---
+description: >
+  You are integrator. You wire modules into the system. Targeted edits only.
+model: copilot
+tools: [read_file, write_file, run_terminal, list_directory]
+---
+
+You are integrator. You wire modules into the system. Targeted edits only.
+
+Read all memory banks. Check ACTIVE_TASK.md Artifacts for what was just produced.
+
+Checklist:
+  [ ] imports/exports correct
+  [ ] DI registration (if applicable)
+  [ ] config/env vars documented and defaulted
+  [ ] route/endpoint registration (if applicable)
+  [ ] index/barrel files updated
+  [ ] migrations present (if data layer changed)
+
+Tag every line: # [integrator] reason — TASK-[ID]
+Run smoke test before handing off.
+If you find a logic problem: note it, write to .agent-memory/escalations.md, do not fix.
+
+Write to mailboxes/reviewer.md on completion.
+Log to .agent-memory/events.jsonl.

--- a/.github/agents/integrator.agent.md
+++ b/.github/agents/integrator.agent.md
@@ -1,11 +1,29 @@
 ---
-description: >
-  You are integrator. You wire modules into the system. Targeted edits only.
+description: "You are integrator. You wire approved code into the system. Targeted edits only."
 model: copilot
 tools: [read_file, write_file, run_terminal, list_directory]
 ---
 
-You are integrator. You wire modules into the system. Targeted edits only.
+You are integrator. You wire approved code into the system. Targeted edits only.
+
+## FIRST — check the VERDICT field in your mailbox
+
+Run:
+  grep "^VERDICT:" .agent-memory/mailboxes/integrator.md
+
+APPROVED or APPROVED WITH NOTES → proceed
+CHANGES REQUESTED (or missing) → this was misrouted. Do not proceed.
+  1. Copy mailbox contents to .agent-memory/mailboxes/implementer.md with STATUS: PENDING
+  2. Append to .agent-memory/escalations.md:
+       ## [timestamp] MISROUTE from reviewer re [TASK-ID]
+       Reviewer wrote CHANGES REQUESTED but routed to integrator. Redirected to implementer.
+  3. Set your mailbox STATUS: IDLE
+  4. Stop and restart your polling loop.
+
+Your work is purely structural — connecting things, not changing them.
+You do not fix logic under any circumstance.
+
+## When the task is valid
 
 Read all memory banks. Check ACTIVE_TASK.md Artifacts for what was just produced.
 
@@ -19,7 +37,13 @@ Checklist:
 
 Tag every line: # [integrator] reason — TASK-[ID]
 Run smoke test before handing off.
-If you find a logic problem: note it, write to .agent-memory/escalations.md, do not fix.
+If you discover a logic problem during wiring: note it, write to .agent-memory/escalations.md, do not fix it.
 
-Write to mailboxes/reviewer.md on completion.
+Write to mailboxes/ship.md on completion:
+  STATUS: PENDING
+  TASK: [ID]
+  BRANCH: [branch from your mailbox]
+  FROM: integrator
+  ## Instruction
+  Create PR and handle Copilot review.
 Log to .agent-memory/events.jsonl.

--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -1,6 +1,5 @@
 ---
-description: >
-  You are planner. You produce design docs, not code.
+description: "You are planner. You produce design docs, not code."
 model: claude-sonnet-4-5
 tools: [read_file, write_file, run_terminal, list_directory]
 ---

--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -1,0 +1,33 @@
+---
+description: >
+  You are planner. You produce design docs, not code.
+model: claude-sonnet-4-5
+tools: [read_file, write_file, run_terminal, list_directory]
+---
+
+You are planner. You produce design docs, not code.
+
+Read all memory banks first. Read broadly — dependencies and callers, not just mentioned files.
+
+Spawn subagents for parallel analysis when codebase is large:
+  "Subagent A: analyze src/[area] for constraints relevant to [task]. Write findings to .agent-memory/analysis-[area]-[ID].md"
+  "Subagent B: analyze [other area]. Write to .agent-memory/analysis-[other]-[ID].md"
+
+Write design doc to .agent-memory/design-[TASK-ID].md:
+  # Design: [TASK-ID]
+  ## Problem Statement
+  ## Constraints (from DECISIONS.md, CONVENTIONS.md, code)
+  ## Options Considered (A / B / C — pros, cons, risk)
+  ## Recommended Approach
+  ## Implementation Sketch (pseudocode — specific enough to build from)
+  ## Files to Touch | file | change | reason |
+  ## Test Strategy
+  ## Open Questions
+
+Write decisions to .agent-memory/DECISIONS.md before handing off:
+  ## [DATE] [Title]
+  **Status:** Accepted | **Agent:** planner
+  **Context:** | **Decision:** | **Consequences:**
+
+Log to .agent-memory/events.jsonl.
+Do not hand off without a complete design doc.

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -1,0 +1,31 @@
+---
+description: >
+  You are reviewer. You review code — you do not rewrite it.
+model: claude-sonnet-4-5
+tools: [read_file, write_file, run_terminal, list_directory]
+---
+
+You are reviewer. You review code — you do not rewrite it.
+
+Read all memory banks. Read design doc + changed files + callers and dependencies.
+
+Spawn subagents for parallel review concerns:
+  "Subagent A: review design fidelity and correctness for [files]"
+  "Subagent B: review convention compliance and maintainability for [files]"
+
+Write review to .agent-memory/review-[TASK-ID].md:
+  # Review: [TASK-ID]
+  **Verdict:** APPROVED | APPROVED WITH NOTES | CHANGES REQUESTED
+  ## Summary (2-3 sentences)
+  ## Findings
+  ### [CRITICAL|MAJOR|MINOR|NIT] [Title]
+  **File:** path:lines | **Issue:** | **Suggestion:**
+  ## Convention Compliance — violations: (list or none)
+
+Routing:
+  APPROVED / APPROVED WITH NOTES → write to mailboxes/integrator.md
+  CHANGES REQUESTED → write to .agent-memory/escalations.md AND mailboxes/implementer.md
+    (human must approve before implementer picks it up)
+
+Never give vague feedback. Be specific or say nothing.
+Log to .agent-memory/events.jsonl.

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -1,6 +1,5 @@
 ---
-description: >
-  You are reviewer. You review code — you do not rewrite it.
+description: "You are reviewer. You review code — you do not rewrite it."
 model: claude-sonnet-4-5
 tools: [read_file, write_file, run_terminal, list_directory]
 ---
@@ -13,19 +12,47 @@ Spawn subagents for parallel review concerns:
   "Subagent A: review design fidelity and correctness for [files]"
   "Subagent B: review convention compliance and maintainability for [files]"
 
-Write review to .agent-memory/review-[TASK-ID].md:
+## Step 1 — decide the verdict FIRST, before writing anything
+
+Ask: does any finding REQUIRE a code change before this ships?
+  YES → CHANGES REQUESTED. Full stop.
+  NO, but notes worth recording → APPROVED WITH NOTES
+  NO findings → APPROVED
+
+APPROVED WITH NOTES means: ship it, notes are for the next iteration.
+It does NOT mean fix before shipping. If fixes are required, use CHANGES REQUESTED.
+
+## Step 2 — write the review doc
+
+Write to .agent-memory/review-[TASK-ID].md:
+  VERDICT: [APPROVED | APPROVED WITH NOTES | CHANGES REQUESTED]
+  ---
   # Review: [TASK-ID]
-  **Verdict:** APPROVED | APPROVED WITH NOTES | CHANGES REQUESTED
   ## Summary (2-3 sentences)
   ## Findings
   ### [CRITICAL|MAJOR|MINOR|NIT] [Title]
   **File:** path:lines | **Issue:** | **Suggestion:**
   ## Convention Compliance — violations: (list or none)
 
-Routing:
-  APPROVED / APPROVED WITH NOTES → write to mailboxes/integrator.md
-  CHANGES REQUESTED → write to .agent-memory/escalations.md AND mailboxes/implementer.md
-    (human must approve before implementer picks it up)
+## Step 3 — route based ONLY on the verdict from Step 1
+
+APPROVED or APPROVED WITH NOTES → write to mailboxes/integrator.md:
+  STATUS: PENDING
+  VERDICT: [your verdict]
+  TASK: [ID] / FROM: reviewer
+  ## Instruction
+  Wire the approved implementation into the system.
+  ## Context Files / [changed files]
+  ## On Complete / write to mailboxes/ship.md
+
+CHANGES REQUESTED → write to escalations.md (human checkpoint) AND mailboxes/implementer.md:
+  STATUS: PENDING
+  VERDICT: CHANGES REQUESTED
+  TASK: [ID] / FROM: reviewer
+  ## Instruction
+  [list the specific required changes from the review doc — copy them verbatim]
+  ## Context Files / .agent-memory/review-[TASK-ID].md + [changed files]
+  ## On Complete / write to mailboxes/tester.md
 
 Never give vague feedback. Be specific or say nothing.
 Log to .agent-memory/events.jsonl.

--- a/.github/agents/security.agent.md
+++ b/.github/agents/security.agent.md
@@ -1,0 +1,39 @@
+---
+description: >
+  You are security reviewer. Read-only — you report findings, you do not fix.
+model: claude-sonnet-4-5
+tools: [read_file, write_file, run_terminal, list_directory]
+---
+
+You are security reviewer. Read-only — you report findings, you do not fix.
+
+Read all memory banks. Read changed files AND adjacent code.
+
+Spawn subagents for parallel review:
+  "Subagent A: review input handling and injection vectors in [files]"
+  "Subagent B: review secrets, auth, and data exposure in [files]"
+
+Standard checklist:
+  [ ] external input validated
+  [ ] no injection vectors (SQL, path traversal, deserialization)
+  [ ] auth checks consistent — not just at route level
+  [ ] no secrets in code, logs, errors
+  [ ] error messages do not leak internals
+
+OSS checklist (if WORKSPACE.md says Open-source: YES):
+  [ ] all new deps: Apache 2.0 / MIT / BSD only (no GPL/LGPL/AGPL)
+  [ ] no internal URLs, hostnames, tenant IDs, client/project names in any file
+  [ ] example configs use clearly fake values
+  [ ] new deps pinned to specific versions
+  [ ] nothing accidentally exported in __all__
+
+Write to .agent-memory/security-[TASK-ID].md:
+  # Security Review: [TASK-ID]
+  **Verdict:** CLEAR | FINDINGS — REVIEW BEFORE SHIP | BLOCKER — DO NOT SHIP
+  ## Findings
+  ### [CRITICAL|HIGH|MEDIUM|LOW] [Title]
+  **File:** path:lines | **Issue:** | **Attack vector:** | **Fix:**
+
+BLOCKER → write to .agent-memory/escalations.md immediately, stop everything.
+CLEAR or FINDINGS → write to mailboxes/reviewer.md.
+Log to .agent-memory/events.jsonl.

--- a/.github/agents/security.agent.md
+++ b/.github/agents/security.agent.md
@@ -1,6 +1,5 @@
 ---
-description: >
-  You are security reviewer. Read-only — you report findings, you do not fix.
+description: "You are security reviewer. Read-only — you report findings, you do not fix."
 model: claude-sonnet-4-5
 tools: [read_file, write_file, run_terminal, list_directory]
 ---

--- a/.github/agents/ship.agent.md
+++ b/.github/agents/ship.agent.md
@@ -1,0 +1,59 @@
+You are ship. You create the PR, handle Copilot automatic review, and manage
+the branch until it is approved and ready for human merge.
+
+## Step 1 — Build the PR description
+
+Read your mailbox for TASK_ID and BRANCH, then write .agent-memory/pr-[TASK_ID].md:
+  ## What / [goal from ACTIVE_TASK.md]
+  ## Why / [problem statement from design doc]
+  ## Changes / [git diff --name-only dev...HEAD]
+  ## Acceptance Criteria / [from ACTIVE_TASK.md]
+  ## Review / [verdict and summary from review-[TASK_ID].md]
+  ## Task / TASK-ID: [TASK_ID]
+
+## Step 2 — Create the PR
+
+  git add -A && git commit -m "feat([TASK_ID]): [title]" || true
+  git push -u origin [BRANCH]
+  gh pr create --base dev --title "feat([TASK_ID]): [title]" --body-file .agent-memory/pr-[TASK_ID].md
+  PR_URL=$(gh pr view [BRANCH] --json url -q .url)
+
+## Step 3 — Poll for Copilot automatic review
+
+Run every 30s until a bot review appears:
+  gh pr view [BRANCH] --json reviews -q ".reviews[] | select(.author.is_bot == true)"
+
+When a review arrives, read it fully:
+  gh pr view [BRANCH] --json reviews,comments
+
+## Step 4 — Route based on verdict
+
+APPROVED or COMMENTED (informational):
+  Respond to each comment: gh pr comment [BRANCH] --body "[response]"
+  Write to .agent-memory/escalations.md:
+    ## [timestamp] PR READY re [TASK_ID]
+    **Type:** REVIEW_CHECKPOINT | **PR:** [PR_URL]
+    **Action:** Review and merge to dev, then delete worktree.
+  Set mailbox STATUS: IDLE.
+
+CHANGES_REQUESTED:
+  Write to .agent-memory/mailboxes/implementer.md:
+    STATUS: PENDING / VERDICT: CHANGES REQUESTED / TASK: [TASK_ID] / BRANCH: [BRANCH]
+    FROM: ship (Copilot PR review)
+    ## Instruction / [copy exact change requests verbatim]
+    ## Context Files / .agent-memory/pr-[TASK_ID].md + [files in review]
+    ## On Complete / write to mailboxes/tester.md
+  Respond: gh pr comment [BRANCH] --body "Addressing review feedback now — will update shortly."
+  Set mailbox STATUS: IDLE.
+
+## Step 5 — After implementer fixes
+
+  git push origin [BRANCH]
+  gh pr review [BRANCH] --request
+  Return to Step 3.
+
+## Step 6 — Log and finish
+
+  {"ts":"[ISO]","event":"pr_ready","task":"[TASK_ID]","agent":"ship","summary":"awaiting human merge"}
+  → .agent-memory/events.jsonl
+  Set mailbox STATUS: IDLE.

--- a/.github/agents/tester.agent.md
+++ b/.github/agents/tester.agent.md
@@ -1,0 +1,28 @@
+---
+description: >
+  You are tester. You write and run tests. You do not modify source code.
+model: gpt-4o
+tools: [read_file, write_file, run_terminal, list_directory]
+---
+
+You are tester. You write and run tests. You do not modify source code.
+
+Read all memory banks. Run existing test suite first — establish baseline.
+
+Spawn subagents for parallel test writing:
+  "Subagent A: write unit tests for src/[module].py — edge cases, nulls, boundary values"
+  "Subagent B: write integration tests for [api boundary]"
+
+Coverage: unit (all public functions), integration (all API boundaries), edge cases (nulls, bounds, errors).
+Naming: test_[function]_[scenario]_[expected_outcome]
+
+Write results to .agent-memory/test-results-[TASK-ID].md:
+  # Test Results: [TASK-ID]
+  **Result:** PASS/FAIL | Total/Passed/Failed/Coverage
+  ## Failures — test name / file:line / expected / actual / likely cause
+
+Routing:
+  PASS → write to mailboxes/reviewer.md
+  FAIL (impl bug) → write to mailboxes/implementer.md with results as context
+
+Log to .agent-memory/events.jsonl.

--- a/.github/agents/tester.agent.md
+++ b/.github/agents/tester.agent.md
@@ -1,6 +1,5 @@
 ---
-description: >
-  You are tester. You write and run tests. You do not modify source code.
+description: "You are tester. You write and run tests. You do not modify source code."
 model: gpt-4o
 tools: [read_file, write_file, run_terminal, list_directory]
 ---

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,27 +1,12 @@
 # Global Agent Instructions
 
-## Mandatory — every session
-
 Read memory banks before starting any task:
-  .agent-memory/WORKSPACE.md
-  .agent-memory/ACTIVE_TASK.md
-  .agent-memory/DECISIONS.md
-  .agent-memory/CONVENTIONS.md
+  .agent-memory/WORKSPACE.md / ACTIVE_TASK.md / DECISIONS.md / CONVENTIONS.md
 
 Check .agent-memory/mailboxes/[your-role].md for pending work.
 
-## Handoff format
+Mailbox dispatch format:
+  STATUS: PENDING / TASK: / BRANCH: / FROM: / RECEIVED:
+  ## Instruction / ## Context Files / ## On Complete
 
-Append to .agent-memory/ACTIVE_TASK.md when handing off:
-  ## Handoff: [from] → [to] @ [timestamp]
-  **Did:** | **Touched:** | **Decided:** | **Need from you:** | **Blockers:**
-
-## Mailbox dispatch
-
-Write to next agent mailbox:
-  STATUS: PENDING
-  TASK: / FROM: / RECEIVED: / ## Instruction / ## Context Files / ## On Complete
-
-## Conventions
-
-Never deviate from .agent-memory/CONVENTIONS.md without a DECISIONS.md entry first.
+Never deviate from CONVENTIONS.md without a DECISIONS.md entry first.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,177 +1,27 @@
----
-description: Kindling framework code review guidelines
-name: kindling-review
-applies_to: pull_requests
----
+# Global Agent Instructions
 
-# Code Review Guidelines for Kindling Framework
+## Mandatory — every session
 
-## Overview
+Read memory banks before starting any task:
+  .agent-memory/WORKSPACE.md
+  .agent-memory/ACTIVE_TASK.md
+  .agent-memory/DECISIONS.md
+  .agent-memory/CONVENTIONS.md
 
-Kindling is a multi-platform Spark data lakehouse framework supporting Azure Synapse Analytics, Databricks, and Microsoft Fabric. The framework uses dependency injection, platform abstraction patterns, and notebook-based orchestration.
+Check .agent-memory/mailboxes/[your-role].md for pending work.
 
-## Critical Focus Areas
+## Handoff format
 
-### 1. Platform Compatibility
-- **Platform-agnostic code**: All framework features must work on Fabric, Synapse, and Databricks
-- **Platform services pattern**: Use dependency injection and `PlatformServiceProvider` instead of if/else platform conditionals
-- **No platform-specific imports**: Platform-specific code belongs in `platform_*.py` modules only
-- **Test on all platforms**: System tests must pass on all three platforms
+Append to .agent-memory/ACTIVE_TASK.md when handing off:
+  ## Handoff: [from] → [to] @ [timestamp]
+  **Did:** | **Touched:** | **Decided:** | **Need from you:** | **Blockers:**
 
-### 2. Poe Task Usage (CRITICAL)
-⚠️ **NEVER call scripts directly** - always use poe tasks:
-- ✅ `poe build` not `poetry build`
-- ✅ `poe deploy --platform fabric` not `python scripts/deploy.py`
-- ✅ `poe test-system --platform fabric` not `pytest -m fabric`
-- ✅ `poe version --bump_type alpha --platform fabric` for version bump + build + deploy workflow
+## Mailbox dispatch
 
-### 3. Dependency Injection
-- **Use `@inject` decorator**: All services requiring dependencies must use DI
-- **`@GlobalInjector.singleton_autobind()`**: For framework services
-- **Service provider pattern**: Platform-specific logic goes in service implementations
-- **No manual instantiation**: Services should be obtained via `get_kindling_service()`
+Write to next agent mailbox:
+  STATUS: PENDING
+  TASK: / FROM: / RECEIVED: / ## Instruction / ## Context Files / ## On Complete
 
-### 4. Error Handling & Logging
-- **SparkLogger supports `exc_info`**: Use `logger.error(msg, exc_info=True)` for stack traces
-- **Structured logging**: Include context in log messages
-- **Exception context**: Use `raise ... from e` to preserve exception chains
-- **Fail fast**: Don't swallow exceptions in framework code
+## Conventions
 
-### 5. Version Management
-- **Alpha versions for dev**: Use `poe version --bump_type alpha` to bust pip caching during development
-- **Semantic versioning**: major.minor.patch for releases, add `aN` suffix for alpha
-- **One-command workflow**: `poe version --bump_type alpha --platform fabric` handles version bump, build, and deployment
-
-### 6. System Testing
-- **Platform deployment pattern**: System tests deploy actual Spark jobs to cloud platforms
-- **Test markers validation**: Tests must log structured markers for validation
-- **Stdout monitoring**: Tests validate execution through stdout log streaming
-- **Resource cleanup**: Tests must clean up jobs and data-apps after execution
-
-### 7. Module Organization
-- **Utilities stay in context**: Extract utilities within the module that uses them
-- **Service vs utility**: Services use DI, utilities are pure functions with explicit parameters
-- **Keep interfaces minimal**: Avoid over-abstraction
-
-## Code Patterns to Watch For
-
-### ❌ Anti-Patterns
-
-```python
-# DON'T: Platform conditionals
-if platform == "fabric":
-    do_fabric_thing()
-elif platform == "synapse":
-    do_synapse_thing()
-
-# DON'T: Direct script execution
-subprocess.run(["python", "scripts/deploy.py"])
-
-# DON'T: Manual service instantiation
-platform_service = FabricService(config, logger)
-
-# DON'T: Logger without exc_info
-try:
-    ...
-except Exception as e:
-    logger.error(f"Error: {e}")  # Missing stack trace!
-```
-
-### ✅ Correct Patterns
-
-```python
-# DO: Platform service pattern
-platform_service = get_kindling_service(PlatformServiceProvider)
-platform_service.deploy_spark_job(app_files, config)
-
-# DO: Use poe tasks
-subprocess.run(["poe", "deploy", "--platform", "fabric"])
-
-# DO: Dependency injection
-@inject
-class MyService:
-    def __init__(self, platform: PlatformServiceProvider, logger: SparkLoggerProvider):
-        self.platform = platform
-        self.logger = logger.get_logger(__name__)
-
-# DO: Logger with exc_info
-try:
-    ...
-except Exception as e:
-    logger.error(f"Error: {e}", exc_info=True)  # Includes stack trace
-```
-
-## Testing Requirements
-
-### System Tests
-- Must use `poe test-system` command
-- Must test on actual platforms (not just local Spark)
-- Must validate via stdout markers (format: `TEST_ID={id} test={name} status={PASSED|FAILED}`)
-- Must include cleanup in `finally` blocks
-
-### Unit/Integration Tests
-- Run with `poe test-unit` or `poe test-integration`
-- Mock external dependencies appropriately
-- Test both success and failure paths
-
-## Documentation Standards
-
-- **Docstrings**: Required for public APIs and complex functions
-- **Type hints**: Use where they add clarity
-- **Comments**: Explain "why", not "what"
-- **Markdown**: All docs in markdown format
-- **Examples**: Include usage examples for non-trivial features
-
-## Architecture Principles
-
-1. **Platform abstraction**: Framework code must never import platform-specific modules
-2. **Dependency injection**: Services compose through DI, not direct instantiation
-3. **Single responsibility**: Each module/class has one clear purpose
-4. **Extensibility**: Easy to add new platforms by implementing interfaces
-5. **Testability**: All components can be tested in isolation with mocks
-
-## File Organization
-
-```
-packages/kindling/
-├── platform_provider.py          # Platform service interfaces
-├── platform_fabric.py            # Fabric implementation
-├── platform_synapse.py           # Synapse implementation
-├── platform_databricks.py        # Databricks implementation
-├── streaming_*.py                # Streaming components
-├── injection.py                  # DI infrastructure
-└── ...
-
-tests/
-├── unit/                         # Fast, isolated tests
-├── integration/                  # Multi-component tests
-└── system/                       # Platform deployment tests
-    └── data-apps/                # Test applications
-```
-
-## Common Review Checklist
-
-- [ ] No direct platform conditionals (use service pattern)
-- [ ] All script calls use poe tasks
-- [ ] Services use dependency injection
-- [ ] Error logging includes `exc_info=True` where appropriate
-- [ ] System tests validate via stdout markers
-- [ ] Resources cleaned up in finally blocks
-- [ ] Version bumps use alpha for development iterations
-- [ ] Code works on all three platforms
-- [ ] Tests pass on CI/CD
-- [ ] Documentation updated if API changes
-
-## Questions to Ask in Review
-
-1. Does this code work identically on Fabric, Synapse, and Databricks?
-2. Are platform-specific operations delegated to platform services?
-3. Are poe tasks used instead of direct script execution?
-4. Will pip caching issues require a version bump?
-5. Do system tests properly clean up resources?
-6. Are exceptions logged with full stack traces?
-7. Is the dependency injection pattern used correctly?
-
----
-
-For more details, see [project.instructions.md](../instructions/project.instructions.md)
+Never deviate from .agent-memory/CONVENTIONS.md without a DECISIONS.md entry first.

--- a/.github/skills/escalate/SKILL.md
+++ b/.github/skills/escalate/SKILL.md
@@ -1,0 +1,2 @@
+# /escalate
+Write to .agent-memory/escalations.md and events.jsonl, set mailbox STATUS: ESCALATED, stop working.

--- a/.github/skills/escalate/SKILL.md
+++ b/.github/skills/escalate/SKILL.md
@@ -1,2 +1,1 @@
-# /escalate
-Write to .agent-memory/escalations.md and events.jsonl, set mailbox STATUS: ESCALATED, stop working.
+# /escalate — write to escalations.md and events.jsonl, set mailbox ESCALATED, stop

--- a/.github/skills/handoff/SKILL.md
+++ b/.github/skills/handoff/SKILL.md
@@ -1,2 +1,1 @@
-# /handoff
-Append handoff block to .agent-memory/ACTIVE_TASK.md, write to next mailbox (STATUS: PENDING), log to events.jsonl.
+# /handoff — append handoff block to ACTIVE_TASK.md, write to next mailbox, log to events.jsonl

--- a/.github/skills/handoff/SKILL.md
+++ b/.github/skills/handoff/SKILL.md
@@ -1,0 +1,2 @@
+# /handoff
+Append handoff block to .agent-memory/ACTIVE_TASK.md, write to next mailbox (STATUS: PENDING), log to events.jsonl.

--- a/.github/skills/memory/SKILL.md
+++ b/.github/skills/memory/SKILL.md
@@ -1,0 +1,125 @@
+# /memory — Memory Bank Protocol Skill
+
+Use this skill to read, update, or initialize memory banks.
+Memory banks are the shared context that persists across all agent sessions.
+
+## Memory Bank Files
+
+| File | Purpose | Who Writes | Frequency |
+|------|---------|-----------|-----------|
+| `WORKSPACE.md` | Project context, tech stack, key paths | Human + coordinator | Setup + major changes |
+| `ACTIVE_TASK.md` | Current task + handoff log | All agents | Every session |
+| `DECISIONS.md` | Architecture decision log | planner, reviewer, coordinator | When decisions are made |
+| `CONVENTIONS.md` | Coding standards | Human + coordinator | As standards evolve |
+
+All files live in `.agent-memory/` at project root.
+
+## Reading Memory (Start of Session)
+
+Read in this order:
+1. `WORKSPACE.md` — establishes what project this is
+2. `ACTIVE_TASK.md` — establishes where work stands
+3. `DECISIONS.md` — establishes what's already been decided
+4. `CONVENTIONS.md` — establishes how to write code
+
+If any of these files don't exist, alert the user:
+> "Memory bank `[file]` not found. Recommend running /memory init
+>  or having the human populate it before proceeding."
+
+## Writing Memory (During/End of Session)
+
+### ACTIVE_TASK.md
+Append, don't overwrite. Always add to the Handoff Log section.
+Update the Status field and Artifacts section.
+
+### DECISIONS.md
+Append only. Never delete or modify existing decisions.
+To supersede a decision, add a new entry with `Status: Supersedes [DATE] [Title]`.
+
+### CONVENTIONS.md
+Add only. Flag proposed removals as `[DEPRECATED]` — don't delete.
+
+### WORKSPACE.md
+Only update if something fundamental changed (new service, removed dependency).
+Treat this as a reference doc that changes rarely.
+
+## Initializing a New Project
+
+If `.agent-memory/` doesn't exist, create it and seed these files:
+
+### WORKSPACE.md seed
+```markdown
+# Workspace: [Project Name]
+**Updated:** [date]
+
+## Project
+[1-paragraph description]
+
+## Tech Stack
+- Language:
+- Framework:
+- Data layer:
+- Key libraries:
+
+## Repo Structure
+[key directories and what they contain]
+
+## Entry Points
+- [main file / startup path]
+
+## Test Command
+`[how to run tests]`
+
+## Build Command
+`[how to build]`
+
+## Off-Limits Paths
+[paths agents should never modify without explicit human instruction]
+
+## Active Agents
+- coordinator (Claude)
+- planner (Claude)
+- implementer (Codex)
+- reviewer (Claude)
+- integrator (Copilot)
+- tester (Codex)
+- security (Claude)
+```
+
+### ACTIVE_TASK.md seed
+```markdown
+# Active Task: None
+**Status:** IDLE
+
+No active task. Activate coordinator with your request to begin.
+```
+
+### DECISIONS.md seed
+```markdown
+# Decision Log
+
+[Decisions will be appended here as work proceeds]
+```
+
+### CONVENTIONS.md seed
+```markdown
+# Conventions
+
+## Naming
+[project naming standards]
+
+## File Organization
+[where things go]
+
+## Patterns
+[patterns we use]
+
+## Anti-Patterns
+[patterns we explicitly avoid]
+
+## Testing
+[testing requirements and standards]
+
+## Comments
+[when and how to comment]
+```

--- a/.github/skills/prime/SKILL.md
+++ b/.github/skills/prime/SKILL.md
@@ -1,2 +1,1 @@
-# /prime
-Read all memory banks, tail events.jsonl, check all mailboxes for PENDING, check escalations.md, report status.
+# /prime — read all memory banks, tail events.jsonl, check mailboxes, report status

--- a/.github/skills/prime/SKILL.md
+++ b/.github/skills/prime/SKILL.md
@@ -1,0 +1,2 @@
+# /prime
+Read all memory banks, tail events.jsonl, check all mailboxes for PENDING, check escalations.md, report status.

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,8 @@ iac/databricks/account/tfplan
 .env*
 !.env.template
 .codex
+
+# Agent worktrees (separate checkouts, not repo content)
+.worktrees/
+setup_agents.sh
+../kindling-worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Agent System
 
 Multi-agent workflow across Claude Code, Codex (local + cloud), and VS Code Copilot.
-All agents share the same memory banks, mailboxes, and handoff protocol.
+All agents share memory banks, mailboxes, and handoff protocol.
 
 ## Agents
 
@@ -14,52 +14,38 @@ All agents share the same memory banks, mailboxes, and handoff protocol.
 | integrator | Wires modules — imports, DI, config, index files | Yes (integration only) |
 | tester | Test generation and execution | Yes (test files only) |
 | security | Security review, OSS license and secret hygiene | No |
+| ship | Creates PR, polls Copilot auto-review, routes changes, signals ready-to-merge | No |
 
 ## Memory Banks (.agent-memory/)
 
-| File | Purpose | Rule |
-|------|---------|------|
-| WORKSPACE.md | Project context, stack, commands | Fill in once |
-| ACTIVE_TASK.md | Task registry + handoff log | Agents append |
-| DECISIONS.md | Architecture decisions | Append-only, never delete |
-| CONVENTIONS.md | Coding standards | Agents enforce |
-| events.jsonl | Structured event log | Append-only |
-| escalations.md | Human review queue | Agents write, human resolves |
-| mailboxes/[role].md | Per-agent work queue | STATUS: IDLE/PENDING/IN_PROGRESS/ESCALATED |
+| File | Purpose |
+|------|---------|
+| WORKSPACE.md | Project context. Fill in once. |
+| ACTIVE_TASK.md | Task registry + handoff log. Agents append. |
+| DECISIONS.md | Architecture decisions. Append-only. |
+| CONVENTIONS.md | Coding standards. Agents enforce. |
+| events.jsonl | Structured event log. Append-only. |
+| escalations.md | Human review queue. |
+| mailboxes/[role].md | Per-agent work queue. STATUS: IDLE/PENDING/IN_PROGRESS/ESCALATED |
 
-## Mailbox Protocol
+## Chain
 
-Dispatcher writes:
-  STATUS: PENDING
-  TASK: TASK-[ID]
-  FROM: [role]
-  RECEIVED: [ISO]
-  ## Instruction / ## Context Files / ## On Complete
+coordinator → planner → implementer → tester → reviewer → integrator → ship
+  ship polls GitHub for Copilot auto-review, routes changes back if needed
+  ship writes to escalations.md when PR is approved and ready for human merge
+  CHANGES REQUESTED at any stage routes back to implementer
 
-Recipient polls, sets IN_PROGRESS, does work, sets IDLE, writes to next mailbox.
+## Sessions (3 standing + cloud on demand)
 
-## Invocation
-
-| Tool | Roles handled | How to start |
-|------|--------------|--------------|
-| Claude Code | coordinator, planner, reviewer, security | Paste `.github/sessions/claude-code-session.md` |
-| Codex local | implementer, tester | Paste `.github/sessions/codex-local-session.md` |
-| VS Code Copilot | integrator | Paste `.github/sessions/vscode-session.md` |
-| Codex cloud | implementer (heavy/parallel) | See `.github/sessions/codex-cloud-dispatch.md` |
-
-Three standing sessions total. Each reads the role doc when it picks up work.
-You only talk to the coordinator session.
-
-## Standing Sessions (VS Code / Codex local)
-
-Each agent runs as a standing session polling its mailbox every 10s.
-Coordinator is your only interface — all requests go through it.
-Reviewer pauses and writes to escalations.md when CHANGES REQUESTED.
-Human resolves escalations, then coordinator re-dispatches.
+| Session | Roles | Start |
+|---------|-------|-------|
+| Claude Code | coordinator, planner, reviewer, security, ship | paste .github/sessions/claude-code-session.md |
+| Codex local | implementer, tester | paste .github/sessions/codex-local-session.md |
+| VS Code | integrator | paste .github/sessions/vscode-session.md |
+| Codex cloud | implementer (heavy/parallel) | see .github/sessions/codex-cloud-dispatch.md |
 
 ## Worktree Convention
 
-- Integration branch: dev
 - Feature branches: agent/TASK-YYYYMMDD-NNN/slug
 - Worktree root: ../REPO-worktrees/
-- Merge: feature → dev (squash), dev → main (human only)
+- Merge: feature → dev (squash via PR), dev → main (human only)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# Agent System
+
+Multi-agent workflow across Claude Code, Codex (local + cloud), and VS Code Copilot.
+All agents share the same memory banks, mailboxes, and handoff protocol.
+
+## Agents
+
+| Agent | Role | Writes Code? |
+|-------|------|-------------|
+| coordinator | Decomposes tasks, dispatches via mailboxes, monitors escalations | No |
+| planner | Design docs, architecture, tradeoff analysis | No |
+| implementer | Builds code from design docs | Yes |
+| reviewer | Correctness, convention compliance, design fidelity | No |
+| integrator | Wires modules — imports, DI, config, index files | Yes (integration only) |
+| tester | Test generation and execution | Yes (test files only) |
+| security | Security review, OSS license and secret hygiene | No |
+
+## Memory Banks (.agent-memory/)
+
+| File | Purpose | Rule |
+|------|---------|------|
+| WORKSPACE.md | Project context, stack, commands | Fill in once |
+| ACTIVE_TASK.md | Task registry + handoff log | Agents append |
+| DECISIONS.md | Architecture decisions | Append-only, never delete |
+| CONVENTIONS.md | Coding standards | Agents enforce |
+| events.jsonl | Structured event log | Append-only |
+| escalations.md | Human review queue | Agents write, human resolves |
+| mailboxes/[role].md | Per-agent work queue | STATUS: IDLE/PENDING/IN_PROGRESS/ESCALATED |
+
+## Mailbox Protocol
+
+Dispatcher writes:
+  STATUS: PENDING
+  TASK: TASK-[ID]
+  FROM: [role]
+  RECEIVED: [ISO]
+  ## Instruction / ## Context Files / ## On Complete
+
+Recipient polls, sets IN_PROGRESS, does work, sets IDLE, writes to next mailbox.
+
+## Invocation
+
+| Tool | Roles handled | How to start |
+|------|--------------|--------------|
+| Claude Code | coordinator, planner, reviewer, security | Paste `.github/sessions/claude-code-session.md` |
+| Codex local | implementer, tester | Paste `.github/sessions/codex-local-session.md` |
+| VS Code Copilot | integrator | Paste `.github/sessions/vscode-session.md` |
+| Codex cloud | implementer (heavy/parallel) | See `.github/sessions/codex-cloud-dispatch.md` |
+
+Three standing sessions total. Each reads the role doc when it picks up work.
+You only talk to the coordinator session.
+
+## Standing Sessions (VS Code / Codex local)
+
+Each agent runs as a standing session polling its mailbox every 10s.
+Coordinator is your only interface — all requests go through it.
+Reviewer pauses and writes to escalations.md when CHANGES REQUESTED.
+Human resolves escalations, then coordinator re-dispatches.
+
+## Worktree Convention
+
+- Integration branch: dev
+- Feature branches: agent/TASK-YYYYMMDD-NNN/slug
+- Worktree root: ../REPO-worktrees/
+- Merge: feature → dev (squash), dev → main (human only)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# Claude Code Context
+
+## First action every session
+
+```bash
+cat .agent-memory/WORKSPACE.md .agent-memory/ACTIVE_TASK.md \
+    .agent-memory/DECISIONS.md .agent-memory/CONVENTIONS.md
+```
+
+## Agent system
+
+See AGENTS.md. Slash commands: /coordinator /planner /implementer
+/reviewer /integrator /tester /security /prime /escalate
+
+## Key rule
+
+Follow .agent-memory/CONVENTIONS.md exactly.
+Deviate only after writing a decision to .agent-memory/DECISIONS.md.
+
+## Worktree root
+
+../kindling-worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ cat .agent-memory/WORKSPACE.md .agent-memory/ACTIVE_TASK.md \
 ## Agent system
 
 See AGENTS.md. Slash commands: /coordinator /planner /implementer
-/reviewer /integrator /tester /security /prime /escalate
+/reviewer /integrator /tester /security /ship /prime /escalate
 
 ## Key rule
 

--- a/docs/data_pipes.md
+++ b/docs/data_pipes.md
@@ -208,6 +208,50 @@ pipes_to_run = ["clean_customer_data", "customer_orders_summary"]
 executer.run_datapipes(pipes_to_run)
 ```
 
+### DAG-Based Execution
+
+`run_datapipes` accepts a `use_dag=True` flag to delegate to the
+`ExecutionOrchestrator`, which builds a dependency graph and runs pipes
+in topological generation order. This is the recommended path for any
+pipeline with non-trivial dependencies.
+
+```python
+# Dependency-aware execution — runs pipes in correct order automatically
+executer.run_datapipes(pipes_to_run, use_dag=True)
+
+# With options: parallel within each generation, fail-fast on error
+from kindling.generation_executor import ErrorStrategy
+executer.run_datapipes(
+    pipes_to_run,
+    use_dag=True,
+    parallel=True,
+    max_workers=4,
+    error_strategy=ErrorStrategy.FAIL_FAST,
+    auto_cache=True,
+)
+```
+
+You can also use `ExecutionOrchestrator` directly for batch or streaming:
+
+```python
+from kindling.execution_orchestrator import ExecutionOrchestrator
+
+orchestrator = GlobalInjector.get(ExecutionOrchestrator)
+
+# Batch mode
+result = orchestrator.execute_batch(pipes_to_run, parallel=True)
+
+# Streaming mode
+result = orchestrator.execute_streaming(pipes_to_run)
+
+# Inspect result
+print(f"Succeeded: {result.succeeded}, Failed: {result.failed}")
+```
+
+`ExecutionOrchestrator` emits an `orchestrator.plan_generated` signal before
+execution begins, carrying the resolved strategy, pipe count, and generation
+count for observability hooks.
+
 ### Getting Registered Pipes
 
 ```python

--- a/docs/future_enhancements.md
+++ b/docs/future_enhancements.md
@@ -2,6 +2,11 @@
 
 This document captures planned enhancements and architectural considerations for future development.
 
+> **Note:** Items with a GitHub issue are tracked there; this doc provides the original design context.
+> - Workspace-Level Configuration → tracked in [#17](https://github.com/sep/spark-kindling-framework/issues/17) / [#31](https://github.com/sep/spark-kindling-framework/issues/31) / [#32](https://github.com/sep/spark-kindling-framework/issues/32)
+> - Extension Test Validation via App Insights → tracked in [#13](https://github.com/sep/spark-kindling-framework/issues/13)
+> - In-Memory Entity Provider as Reusable Views → tracked in [#7](https://github.com/sep/spark-kindling-framework/issues/7)
+
 ## Workspace-Level Configuration (Future)
 
 ### Current State

--- a/docs/proposals/scd_type2_implementation_plan.md
+++ b/docs/proposals/scd_type2_implementation_plan.md
@@ -1,0 +1,394 @@
+# TASK-20260429-001: SCD Type 2 — Implementation Plan
+
+**Task:** TASK-20260429-001
+**Status:** Ready for implementation
+**Design source:** `docs/proposals/scd_type2_support.md` (2026-04-29 revision)
+
+---
+
+## 1. File-by-File Implementation Order
+
+### Step 1 — `packages/kindling/data_entities.py`
+**Why first:** Everything downstream depends on `SCDConfig` and `scd_config_from_tags`. The module is already imported by `entity_provider_delta.py` so no new imports are needed.
+
+Add (in order):
+- `ROUTING_KEY_METHODS: tuple[str, ...] = ("hash", "concat")` — module-level constant
+- `SCDConfig` frozen dataclass (fields below)
+- `scd_config_from_tags(entity) -> SCDConfig` — module-level function
+- `_validate_scd_config(entity: EntityMetadata) -> None` — module-level private
+- `DataEntityManager._register_scd2_current_companion(base, cfg)` — new instance method
+- Modify `DataEntityManager.register_entity` to call validate then companion registration
+
+### Step 2 — `packages/kindling/entity_provider_delta.py` (registry + stubs)
+**Why second:** Registry and strategy ABCs must exist before `_merge_to_delta_table` can delegate.
+
+Add at module level before `DeltaEntityProvider`:
+- `DeltaMergeStrategy` ABC with `apply(delta_table, df, entity, merge_condition) -> None`
+- `DeltaMergeStrategies` class-level registry (raises on duplicate, `get()` returns fresh instance)
+- `SCD1MergeStrategy` decorated `@DeltaMergeStrategies.register(name="scd1")` — extract existing merge body
+- `SCD2MergeStrategy` stub decorated `@DeltaMergeStrategies.register(name="scd2")`
+
+Modify `DeltaEntityProvider._merge_to_delta_table`: replace body with strategy resolution and delegation.
+
+### Step 3 — `packages/kindling/entity_provider_delta.py` (SCD2 logic + schema)
+**Why third:** Requires Step 1 (SCDConfig) and Step 2 (strategy classes).
+
+Add:
+- `_execute_scd2_merge(delta_table, df, entity)` — module-level private (not a method; callable from strategy without circular dep)
+- Full `SCD2MergeStrategy.apply` body calling `_execute_scd2_merge`
+- `DeltaEntityProvider._augment_schema_for_scd2(schema, cfg) -> StructType`
+- Schema augmentation calls in `_create_physical_table` and `_create_managed_table`, gated on `cfg.enabled`
+- `DeltaEntityProvider.read_entity_as_of(entity, point_in_time) -> DataFrame`
+
+### Step 4 — `packages/kindling/entity_provider_current_view.py` (new file)
+**Why fourth:** Requires SCDConfig (Step 1) and DeltaEntityProvider (Step 3).
+
+Create `CurrentViewEntityProvider(BaseEntityProvider)`:
+- Read delegates to base entity's provider filtered to `is_current=true`
+- All write methods raise `NotImplementedError` with clear message
+- Inject `DataEntityManager` lazily (deferred import to avoid circular dep)
+
+### Step 5 — `packages/kindling/entity_provider_registry.py`
+**Why last:** Requires `CurrentViewEntityProvider` to exist (Step 4).
+
+Add `self.register_provider("current_view", CurrentViewEntityProvider)` in `_register_builtin_providers` using same try/except import guard pattern as `csv` and `eventhub`.
+
+---
+
+## 2. New Classes and Functions — Exact Signatures
+
+### `data_entities.py`
+
+```python
+ROUTING_KEY_METHODS: tuple[str, ...] = ("hash", "concat")
+
+@dataclass(frozen=True)
+class SCDConfig:
+    enabled: bool
+    tracked_columns: Optional[List[str]]       # None = track all non-key non-temporal cols
+    effective_from_column: str                 # default "__effective_from"
+    effective_to_column: str                   # default "__effective_to"
+    is_current_column: str                     # default "__is_current"
+    current_entity_id: str                     # default "{entityid}.current"
+    routing_key_method: str                    # "hash" | "concat"
+
+def scd_config_from_tags(entity) -> SCDConfig: ...
+    # Returns SCDConfig(enabled=False, ...) if scd.type tag absent
+    # Raises ValueError if scd.type present but != "2"
+    # Raises ValueError if scd.routing_key not in ROUTING_KEY_METHODS
+
+def _validate_scd_config(entity: EntityMetadata) -> None: ...
+    # Calls scd_config_from_tags; when enabled:
+    #   raises if merge_columns empty
+    #   raises if tracked_columns overlaps merge_columns
+    #   raises if temporal column names collide with business schema columns
+
+# Inside DataEntityManager:
+def _register_scd2_current_companion(self, base: EntityMetadata, cfg: SCDConfig) -> None: ...
+    # Skips if cfg.current_entity_id already in registry (user-declared wins)
+    # Builds companion EntityMetadata with tags:
+    #   "scd.companion_of": base.entityid
+    #   "scd.view_type": "current"
+    #   "provider.read_only": "true"
+    #   "provider_type": "current_view"
+    # Strips all scd.* tags from base except the above
+    # Emits "entity.scd2_companion_registered"
+```
+
+### `entity_provider_delta.py`
+
+```python
+class DeltaMergeStrategy(ABC):
+    @abstractmethod
+    def apply(
+        self,
+        delta_table,          # DeltaTable
+        df: DataFrame,
+        entity,               # EntityMetadata
+        merge_condition: str,
+    ) -> None: ...
+
+class DeltaMergeStrategies:
+    _registry: Dict[str, Type[DeltaMergeStrategy]] = {}
+
+    @classmethod
+    def register(cls, name: str): ...          # decorator; raises ValueError on duplicate
+    @classmethod
+    def get(cls, name: str) -> DeltaMergeStrategy: ...  # fresh instance; raises ValueError if unknown
+
+@DeltaMergeStrategies.register(name="scd1")
+class SCD1MergeStrategy(DeltaMergeStrategy):
+    def apply(self, delta_table, df, entity, merge_condition): ...
+    # Body: exact extract of current _merge_to_delta_table
+
+@DeltaMergeStrategies.register(name="scd2")
+class SCD2MergeStrategy(DeltaMergeStrategy):
+    def apply(self, delta_table, df, entity, merge_condition): ...
+    # Calls _execute_scd2_merge(delta_table, df, entity)
+    # merge_condition accepted for interface uniformity but unused
+
+def _execute_scd2_merge(delta_table, df: DataFrame, entity) -> None: ...
+    # Module-level; see Section 3
+
+# Inside DeltaEntityProvider:
+def _merge_to_delta_table(self, df: DataFrame, entity, table_ref: DeltaTableReference) -> None:
+    scd_config = scd_config_from_tags(entity)
+    strategy_name = "scd2" if scd_config.enabled else "scd1"
+    strategy = DeltaMergeStrategies.get(strategy_name)
+    merge_condition = self._build_merge_condition("old", "new", entity.merge_columns)
+    strategy.apply(table_ref.get_delta_table(), df, entity, merge_condition)
+
+def _augment_schema_for_scd2(self, schema: StructType, cfg: SCDConfig) -> StructType: ...
+    # Appends effective_from (TIMESTAMP NOT NULL), effective_to (TIMESTAMP NULL),
+    # is_current (BOOLEAN NOT NULL) — only if not already present
+
+def read_entity_as_of(self, entity, point_in_time) -> DataFrame: ...
+    # SCD2: filter effective_from<=t AND (effective_to IS NULL OR effective_to>t)
+    # Non-SCD2: Delta time travel via timestampAsOf option
+```
+
+### `entity_provider_current_view.py` (new file)
+
+```python
+@GlobalInjector.singleton_autobind()
+class CurrentViewEntityProvider(BaseEntityProvider):
+    @inject
+    def __init__(self, logger_provider: PythonLoggerProvider): ...
+    # NOTE: DataEntityManager and EntityProviderRegistry resolved lazily
+    # at read time via GlobalInjector.get() — deferred to avoid circular import
+
+    def read_entity(self, entity_metadata: EntityMetadata) -> DataFrame: ...
+    def check_entity_exists(self, entity) -> bool: ...
+    # All write methods raise NotImplementedError
+```
+
+---
+
+## 3. SCD2 Merge Logic — `_execute_scd2_merge`
+
+### Pre-conditions
+- `entity.merge_columns` is non-empty (enforced at registration)
+- `df` contains business columns only — no temporal columns
+- Target table already has temporal columns (added by `_augment_schema_for_scd2` at creation)
+
+### Step-by-step
+
+**3.1 Resolve config**
+```python
+cfg = scd_config_from_tags(entity)
+biz_keys = entity.merge_columns
+scd2_meta_cols = {cfg.effective_from_column, cfg.effective_to_column, cfg.is_current_column}
+tracked = cfg.tracked_columns or [
+    c for c in df.columns if c not in biz_keys and c not in scd2_meta_cols
+]
+```
+
+**3.2 Build change condition** (null-safe per-column OR chain)
+```python
+change_exprs = [
+    f"(source.`{c}` != target.`{c}` OR (source.`{c}` IS NULL) != (target.`{c}` IS NULL))"
+    for c in tracked
+]
+change_condition = " OR ".join(change_exprs)
+```
+
+**3.3 Routing key expression**
+
+`hash` (default): `sha2(to_json(struct(*biz_key_cols)), 256)` on source side;
+equivalent SQL expression using `named_struct` on target side.
+
+`concat`: `concat_ws("||", *[col(k).cast("string") for k in biz_keys])`.
+
+**3.4 Build staged DataFrame** (union of two groups)
+
+*Group A — NULL key (new versions of changed rows):*
+```python
+changed_rows = (
+    df.alias("source")
+    .join(
+        delta_table.toDF().filter(col(cfg.is_current_column) == True).alias("target"),
+        on=biz_keys, how="inner"
+    )
+    .where(change_condition)
+    .select("source.*")
+    .withColumn("__merge_key", lit(None).cast("string"))
+)
+```
+NULL key ensures these rows fall through to `whenNotMatchedInsert` (NULL never equals anything).
+
+*Group B — Real key (close existing / insert first-time rows):*
+```python
+keyed_rows = df.withColumn("__merge_key", routing_key_col_expr)
+```
+
+```python
+staged = changed_rows.unionByName(keyed_rows, allowMissingColumns=True)
+```
+
+**3.5 Insert values map**
+```python
+source_cols = [c for c in df.columns if c not in scd2_meta_cols]
+insert_values = {f"`{c}`": f"staged.`{c}`" for c in source_cols}
+insert_values[f"`{cfg.effective_from_column}`"] = "current_timestamp()"
+insert_values[f"`{cfg.effective_to_column}`"]   = "NULL"
+insert_values[f"`{cfg.is_current_column}`"]      = "true"
+```
+
+**3.6 Single-pass MERGE**
+```python
+merge_condition = (
+    f"{target_routing_key_sql} = staged.__merge_key "
+    f"AND target.`{cfg.is_current_column}` = true"
+)
+merge_builder = (
+    delta_table.alias("target")
+    .merge(source=staged.alias("staged"), condition=merge_condition)
+    .whenMatchedUpdate(set={
+        f"`{cfg.effective_to_column}`": "current_timestamp()",
+        f"`{cfg.is_current_column}`":   "false",
+    })
+    .whenNotMatchedInsert(values=insert_values)
+)
+if cfg.tags.get("scd.close_on_missing") == "true":   # see step 3.7
+    merge_builder = merge_builder.whenNotMatchedBySourceUpdate(
+        condition=f"target.`{cfg.is_current_column}` = true",
+        set={
+            f"`{cfg.effective_to_column}`": "current_timestamp()",
+            f"`{cfg.is_current_column}`":   "false",
+        }
+    )
+merge_builder.execute()
+```
+
+**3.7 `scd.close_on_missing`** — `whenNotMatchedBySourceUpdate` closes any current target row absent from source. Requires Delta Lake 2.3+ (project minimum is PySpark 3.4+ / Delta 2.4+, so always available).
+
+---
+
+## 4. Test Plan
+
+Run with `poe test-unit`. All tests use `pytest` + `pytest-mock`. Mock all Spark/Delta calls.
+
+### `tests/unit/test_scd_config.py`
+Tests for `SCDConfig`, `scd_config_from_tags`, `_validate_scd_config`.
+No Spark needed — construct `EntityMetadata` directly.
+
+Key tests:
+```
+test_scd_config_from_tags_no_tag_returns_disabled_config
+test_scd_config_from_tags_scd_type_2_returns_enabled_config
+test_scd_config_from_tags_invalid_scd_type_raises_value_error
+test_scd_config_from_tags_custom_column_names_respected
+test_scd_config_from_tags_tracked_columns_parsed_from_comma_list
+test_scd_config_from_tags_empty_tracked_returns_none
+test_scd_config_from_tags_routing_key_hash_is_default
+test_scd_config_from_tags_routing_key_concat_accepted
+test_scd_config_from_tags_invalid_routing_key_raises_value_error
+test_scd_config_from_tags_default_current_entity_id_is_entityid_dot_current
+test_validate_scd_config_scd2_missing_merge_columns_raises_value_error
+test_validate_scd_config_tracked_cols_overlap_merge_cols_raises_value_error
+test_validate_scd_config_temporal_col_collides_with_schema_raises_value_error
+test_validate_scd_config_non_scd_entity_passes
+```
+
+### `tests/unit/test_scd_merge_strategies.py`
+Tests for `DeltaMergeStrategies` registry and `SCD1MergeStrategy`.
+Mocks: `MagicMock()` for `delta_table`, `df`, `entity`.
+
+```
+test_delta_merge_strategies_register_stores_class
+test_delta_merge_strategies_register_duplicate_raises_value_error
+test_delta_merge_strategies_get_returns_fresh_instance_each_call
+test_delta_merge_strategies_get_unknown_name_raises_value_error
+test_scd1_strategy_apply_calls_when_matched_update_all
+test_scd1_strategy_apply_calls_when_not_matched_insert_all
+test_scd1_strategy_apply_calls_execute
+test_scd1_strategy_apply_uses_provided_merge_condition
+```
+
+### `tests/unit/test_scd2_merge.py`
+Tests for `_execute_scd2_merge` (importable as a module-level function).
+Mocks: full `DeltaTable` mock chain, `DataFrame` mock with `.columns`, `.alias()`, `.join()`, `.where()`, `.withColumn()`, `.unionByName()`.
+
+```
+test_execute_scd2_merge_calls_delta_table_merge
+test_execute_scd2_merge_when_matched_update_closes_current_row
+test_execute_scd2_merge_when_not_matched_insert_sets_is_current_true
+test_execute_scd2_merge_when_not_matched_insert_sets_effective_from_to_current_timestamp
+test_execute_scd2_merge_when_not_matched_insert_sets_effective_to_null
+test_execute_scd2_merge_tracked_columns_default_excludes_keys_and_temporal
+test_execute_scd2_merge_routing_key_hash_method_used_by_default
+test_execute_scd2_merge_routing_key_concat_method_used_when_configured
+test_execute_scd2_merge_close_on_missing_adds_when_not_matched_by_source_update
+test_execute_scd2_merge_close_on_missing_false_omits_extra_arm
+```
+
+### `tests/unit/test_scd2_schema_augmentation.py`
+Tests for `_augment_schema_for_scd2` and schema-path calls.
+
+```
+test_augment_schema_adds_all_three_temporal_columns
+test_augment_schema_skips_columns_already_in_schema
+test_augment_schema_effective_from_is_not_nullable
+test_augment_schema_effective_to_is_nullable
+test_augment_schema_is_current_is_not_nullable
+test_augment_schema_uses_custom_column_names_from_config
+test_create_physical_table_augments_schema_when_scd2_enabled
+test_create_physical_table_no_augment_when_scd2_disabled
+```
+
+### `tests/unit/test_current_view_provider.py`
+Tests for `CurrentViewEntityProvider`.
+
+```
+test_read_entity_filters_to_is_current_true
+test_read_entity_uses_is_current_column_from_scd_config
+test_read_entity_delegates_to_base_delta_provider
+test_check_entity_exists_delegates_to_base_provider
+test_merge_to_entity_raises_not_implemented_error
+test_write_to_entity_raises_not_implemented_error
+test_append_to_entity_raises_not_implemented_error
+test_read_entity_missing_companion_of_tag_raises_value_error
+```
+
+### `tests/unit/test_scd2_registration.py`
+Tests for `DataEntityManager` companion auto-registration.
+
+```
+test_register_entity_scd2_creates_companion_in_registry
+test_register_entity_scd2_companion_id_is_entityid_dot_current
+test_register_entity_scd2_companion_has_provider_type_current_view
+test_register_entity_scd2_companion_has_scd_companion_of_tag
+test_register_entity_scd2_companion_inherits_merge_columns
+test_register_entity_scd2_custom_current_entity_id_used
+test_register_entity_scd2_user_declared_companion_not_overwritten
+test_register_entity_scd2_emits_companion_registered_signal
+test_register_entity_non_scd2_does_not_create_companion
+test_register_entity_scd2_invalid_config_raises_before_registration
+```
+
+---
+
+## 5. Sequencing Constraints
+
+| Step | Requires |
+|------|----------|
+| Step 1 (`SCDConfig`, `scd_config_from_tags`) | Nothing |
+| Step 1 (`DataEntityManager` companion registration) | `SCDConfig`, `scd_config_from_tags` |
+| Step 2 (registry + SCD1 extraction) | Nothing (SCD1 is an extraction) |
+| Step 2 (`_merge_to_delta_table` refactor) | Step 1 + Step 2 registry |
+| Step 3 (`_execute_scd2_merge`) | Step 1 |
+| Step 3 (schema augmentation) | Step 1 |
+| Step 4 (`CurrentViewEntityProvider`) | Step 1, Step 3 |
+| Step 5 (registry wiring) | Step 4 |
+| Tests 6a (`test_scd_config.py`) | Step 1 |
+| Tests 6b (`test_scd_merge_strategies.py`) | Step 2 |
+| Tests 6c (`test_scd2_merge.py`) | Step 3 |
+| Tests 6d (`test_scd2_schema_augmentation.py`) | Step 3 |
+| Tests 6e (`test_current_view_provider.py`) | Step 4 |
+| Tests 6f (`test_scd2_registration.py`) | Step 1 |
+
+### Circular import hazard
+`CurrentViewEntityProvider` needs `DataEntityManager` (in `data_entities.py`). Resolve via `GlobalInjector.get()` inside the method body at call time — not at `__init__` or module scope. This is already the pattern used by other builtin providers.
+
+### Registry is class-level
+`DeltaMergeStrategies._registry` populates at module import. Built-in strategies self-register when their class bodies execute. `entity_provider_delta.py` is imported at startup via `EntityProviderRegistry._register_builtin_providers` so ordering is never an issue in production or in tests that import the module.

--- a/docs/proposals/scd_type2_support.md
+++ b/docs/proposals/scd_type2_support.md
@@ -3,17 +3,17 @@
 **Status:** Draft (revised)
 **Author:** System Analysis
 **Created:** 2026-02-26
-**Updated:** 2026-04-20
+**Updated:** 2026-04-29
 **Related:** obsolete/signal_dag_streaming_proposal.md, obsolete/dag_execution_implementation_plan.md, obsolete/config_based_entity_providers.md
 
-## Revision Summary (2026-04-20)
+## Revision Summary
 
-This proposal was revised based on design feedback after confirming no SCD2 support exists in the current codebase:
-
+### 2026-04-20
 1. **Tag-driven configuration, no new `EntityMetadata` fields.** The original proposal added `scd_type` and `scd2_config` fields to `EntityMetadata`. Revised design expresses all SCD configuration through the existing `tags` map under a `scd.*` namespace — no schema change to `EntityMetadata`, no new dataclasses, consistent with how other cross-cutting concerns (`layer`, `domain`, `provider.*`) are already carried in Kindling.
 2. **Automatic current-view companion entity.** The original proposal exposed `read_entity_current()` as a helper method users must remember to call. Revised design auto-registers a companion entity at `{entityid}.current` whenever an entity is tagged SCD2, so pipes can declare `input_entity_ids=["silver.dim_customer.current"]` and get the filtered-to-current view transparently via the normal registry lookup.
 
-Both changes keep SCD2 declarative and observable while minimizing the framework surface area and aligning with existing Kindling conventions.
+### 2026-04-29
+3. **`DeltaMergeStrategy` replaces branching inside the provider.** The original architecture had `_merge_to_delta_table()` branch on `scd.type` tags. Revised design introduces a `DeltaMergeStrategy` protocol — the provider resolves and applies a strategy object rather than branching internally. `SCD1MergeStrategy` is the default; `SCD2MergeStrategy` is applied when `scd.type == "2"`. This keeps the provider thin and makes each merge mode independently testable. The strategy is Delta-scoped by design — ~90% of SCD use cases in this framework are Delta-backed, and a cross-provider abstraction would be premature.
 
 ## Executive Summary
 
@@ -69,11 +69,12 @@ Without framework support, teams must:
 
 1. **Declarative** — SCD behavior is declared on the entity, not embedded in pipe logic.
 2. **Tags, not fields** — SCD config rides the existing `tags: Dict[str, str]` map under the `scd.*` namespace, consistent with how `layer`, `domain`, and `provider.*` already travel. No new `EntityMetadata` fields, no new dataclasses, no schema change to the registry.
-3. **Current view is automatic** — any entity tagged SCD2 gets a companion `{entityid}.current` entity auto-registered. Downstream pipes depend on the companion by ID; there is no separate API to remember.
-4. **Backward-compatible** — entities without `scd.type` tag behave exactly as today.
-5. **Convention over configuration** — sensible defaults for column names and tracking scope.
-6. **Observable** — dedicated signals for SCD2 merge outcomes.
-7. **Composable** — works with existing watermarking, streaming restart, and multi-provider architecture.
+3. **Strategy, not branching** — `DeltaEntityProvider` resolves and applies a `DeltaMergeStrategy` rather than branching internally on `scd.type`. `SCD1MergeStrategy` is the default; `SCD2MergeStrategy` activates when `scd.type == "2"`. Each strategy is independently testable.
+4. **Current view is automatic** — any entity tagged SCD2 gets a companion `{entityid}.current` entity auto-registered. Downstream pipes depend on the companion by ID; there is no separate API to remember.
+5. **Backward-compatible** — entities without `scd.type` tag behave exactly as today (SCD1 strategy is the default).
+6. **Convention over configuration** — sensible defaults for column names and tracking scope.
+7. **Observable** — dedicated signals for SCD2 merge outcomes.
+8. **Composable** — works with existing watermarking, streaming restart, and multi-provider architecture.
 
 ### Architecture Overview
 
@@ -81,17 +82,17 @@ Without framework support, teams must:
 Entity Declaration                      DeltaEntityProvider
 ┌──────────────────────────────┐        ┌──────────────────────────────┐
 │ tags = {                     │        │ _merge_to_delta_table()      │
-│   "scd.type": "2",           │───────▶│   ├─ no scd.type: overwrite  │
-│   "scd.tracked": "a,b,c",    │        │   └─ scd.type=="2": staged   │
-│   "scd.effective_from_col": "…",  │        │       _merge_scd2()          │
-│   "scd.effective_to_col": "…",        │        ├──────────────────────────────┤
-│   "scd.current_col": "…",    │        │ ensure_entity_table()        │
-│ }                            │        │   auto-augments schema with  │
-└──────────────────────────────┘        │   temporal columns when      │
-         │                              │   scd.type == "2"            │
-         │  DataEntities.entity()       └──────────────────────────────┘
-         ▼
-  DataEntityManager.register_entity()
+│   "scd.type": "2",           │───────▶│   strategy = _resolve_       │
+│   "scd.tracked": "a,b,c",    │        │     merge_strategy(entity)   │
+│   "scd.effective_from_col":  │        │   strategy.apply(            │
+│   "scd.effective_to_col":    │        │     delta_table, df, entity, │
+│   "scd.current_col": "…",    │        │     merge_condition)         │
+│ }                            │        ├──────────────────────────────┤
+└──────────────────────────────┘        │ ensure_entity_table()        │
+         │                              │   auto-augments schema with  │
+         │  DataEntities.entity()       │   temporal columns when      │
+         ▼                              │   scd.type == "2"            │
+  DataEntityManager.register_entity()   └──────────────────────────────┘
          │
          │  if scd.type == "2":
          │    also register companion entity at
@@ -102,11 +103,86 @@ Entity Declaration                      DeltaEntityProvider
     silver.dim_customer           (SCD2 table, all history)
     silver.dim_customer.current   (read-only view, current rows only)
 
-SimpleReadPersistStrategy: unchanged.
-  Provider's merge_to_entity branches on tags — strategy layer never needs to know.
+DeltaMergeStrategy protocol:
+  SCD1MergeStrategy   — default; whenMatchedUpdateAll / whenNotMatchedInsertAll
+  SCD2MergeStrategy   — staged-updates; close current row, insert new version
+
+SimpleReadPersistStrategy: unchanged. Strategy is resolved and applied entirely
+  within the provider — the execution layer never needs to know.
 ```
 
-The strategy layer does not change — SCD2 logic is encapsulated entirely in the provider and the registry-time auto-registration, both driven by tags on the entity.
+The execution layer does not change — SCD logic is encapsulated in the strategy and the registry-time auto-registration, both driven by tags on the entity.
+
+### Strategy Registration
+
+Merge strategies use the same **class-level decorator registry** pattern as `PlatformServices` and `DataPipes`. Built-in strategies self-register at module import time by decorating their class; third-party strategies follow the same pattern.
+
+```python
+class DeltaMergeStrategies:
+    """Registry for Delta merge strategies. Resolved by name from entity tags."""
+
+    _registry: Dict[str, Type[DeltaMergeStrategy]] = {}
+
+    @classmethod
+    def register(cls, name: str):
+        """Decorator to register a merge strategy under a given name."""
+        def decorator(strategy_cls: Type[DeltaMergeStrategy]):
+            if name in cls._registry:
+                raise ValueError(
+                    f"Merge strategy '{name}' is already registered. "
+                    "Use a different name or deregister the existing strategy first."
+                )
+            cls._registry[name] = strategy_cls
+            return strategy_cls
+        return decorator
+
+    @classmethod
+    def get(cls, name: str) -> DeltaMergeStrategy:
+        if name not in cls._registry:
+            raise ValueError(
+                f"Unknown merge strategy '{name}'. "
+                f"Registered strategies: {sorted(cls._registry)}"
+            )
+        return cls._registry[name]()
+
+
+# Built-ins self-register at module load — no setup call required.
+
+@DeltaMergeStrategies.register(name="scd1")
+class SCD1MergeStrategy(DeltaMergeStrategy):
+    def apply(self, delta_table, df, entity, merge_condition):
+        (
+            delta_table.alias("old")
+            .merge(source=df.alias("new"), condition=merge_condition)
+            .whenMatchedUpdateAll()
+            .whenNotMatchedInsertAll()
+            .execute()
+        )
+
+
+@DeltaMergeStrategies.register(name="scd2")
+class SCD2MergeStrategy(DeltaMergeStrategy):
+    def apply(self, delta_table, df, entity, merge_condition):
+        # staged-updates pattern — see SCD2 merge section below
+        ...
+```
+
+**Resolution in `_merge_to_delta_table`:**
+
+```python
+def _merge_to_delta_table(self, df, entity, table_ref):
+    scd_config = scd_config_from_tags(entity)
+    strategy_name = "scd2" if scd_config.enabled else "scd1"
+    strategy = DeltaMergeStrategies.get(strategy_name)
+    merge_condition = self._build_merge_condition("old", "new", entity.merge_columns)
+    strategy.apply(table_ref.get_delta_table(), df, entity, merge_condition)
+```
+
+**Key differences from `PlatformServices`:**
+- Duplicate registration raises `ValueError` rather than silently skipping. There is no Fabric-style cached-interpreter concern for merge strategies; a collision always indicates a bug.
+- `DeltaMergeStrategies.get()` returns a fresh instance per call (stateless strategies). If a strategy needs injected services, construction should go through `GlobalInjector` instead.
+
+**Third-party extension:** a custom strategy registers itself the same way — decorate and import before execution. No subclassing of `DeltaEntityProvider` required.
 
 ## Detailed Design
 

--- a/packages/kindling/data_entities.py
+++ b/packages/kindling/data_entities.py
@@ -7,11 +7,28 @@ from typing import Any, Callable, Dict, List, Optional
 
 from delta.tables import DeltaTable
 from injector import Binder, Injector, inject, singleton
+from pyspark.sql import DataFrame
+
 from kindling.injection import *
 from kindling.signaling import SignalEmitter, SignalProvider
 from kindling.spark_config import *
 from kindling.spark_log_provider import *
-from pyspark.sql import DataFrame
+
+ROUTING_KEY_METHODS: tuple[str, ...] = ("hash", "concat")
+
+
+# [implementer] add tag-derived SCD configuration surface — TASK-20260429-001
+@dataclass(frozen=True)
+class SCDConfig:
+    """Parsed SCD configuration derived from an entity's tags."""
+
+    enabled: bool
+    tracked_columns: Optional[List[str]]
+    effective_from_column: str
+    effective_to_column: str
+    is_current_column: str
+    current_entity_id: str
+    routing_key_method: str
 
 
 @dataclass
@@ -171,6 +188,88 @@ class EntityMetadata:
         return self.sql is not None
 
 
+def scd_config_from_tags(entity: EntityMetadata) -> SCDConfig:
+    """Extract and validate SCD configuration from an entity's tags."""
+    tags = entity.tags or {}
+    scd_type = tags.get("scd.type", "").strip()
+    default_config = SCDConfig(
+        enabled=False,
+        tracked_columns=None,
+        effective_from_column="__effective_from",
+        effective_to_column="__effective_to",
+        is_current_column="__is_current",
+        current_entity_id=f"{entity.entityid}.current",
+        routing_key_method="hash",
+    )
+
+    if not scd_type:
+        return default_config
+
+    if scd_type != "2":
+        raise ValueError(
+            f"Entity '{entity.entityid}': scd.type must be '2' "
+            f"(only SCD Type 2 is supported), got '{scd_type}'"
+        )
+
+    tracked_raw = tags.get("scd.tracked", "").strip()
+    tracked_columns = (
+        [column.strip() for column in tracked_raw.split(",") if column.strip()]
+        if tracked_raw
+        else None
+    )
+
+    routing_key_method = tags.get("scd.routing_key", "hash").strip().lower()
+    if routing_key_method not in ROUTING_KEY_METHODS:
+        raise ValueError(
+            f"Entity '{entity.entityid}': scd.routing_key must be one of "
+            f"{ROUTING_KEY_METHODS}, got '{routing_key_method}'"
+        )
+
+    return SCDConfig(
+        enabled=True,
+        tracked_columns=tracked_columns,
+        effective_from_column=tags.get("scd.effective_from_col", "__effective_from"),
+        effective_to_column=tags.get("scd.effective_to_col", "__effective_to"),
+        is_current_column=tags.get("scd.current_col", "__is_current"),
+        current_entity_id=tags.get("scd.current_entity_id", f"{entity.entityid}.current"),
+        routing_key_method=routing_key_method,
+    )
+
+
+def _validate_scd_config(entity: EntityMetadata) -> None:
+    """Validate SCD tag configuration at registration time."""
+    cfg = scd_config_from_tags(entity)
+    if not cfg.enabled:
+        return
+
+    if not entity.merge_columns:
+        raise ValueError(
+            f"Entity '{entity.entityid}': SCD Type 2 requires merge_columns "
+            "(business keys) to be defined"
+        )
+
+    if cfg.tracked_columns:
+        overlap = set(cfg.tracked_columns) & set(entity.merge_columns)
+        if overlap:
+            raise ValueError(
+                f"Entity '{entity.entityid}': scd.tracked must not include "
+                f"merge_columns (business keys): {sorted(overlap)}"
+            )
+
+    temporal_columns = {
+        cfg.effective_from_column,
+        cfg.effective_to_column,
+        cfg.is_current_column,
+    }
+    schema_names = {field.name for field in entity.schema.fields} if entity.schema else set()
+    collisions = temporal_columns & schema_names
+    if collisions:
+        raise ValueError(
+            f"Entity '{entity.entityid}': temporal column names {sorted(collisions)} "
+            "collide with business schema columns. Override via SCD column tags."
+        )
+
+
 class DataEntities:
 
     deregistry = None
@@ -265,6 +364,7 @@ class DataEntityRegistry(ABC):
 
     EMITS = [
         "entity.registered",
+        "entity.scd2_companion_registered",
     ]
 
     @abstractmethod
@@ -293,11 +393,52 @@ class DataEntityManager(DataEntityRegistry, SignalEmitter):
         self.config_service = config_service
 
     def register_entity(self, entityid, **decorator_params):
-        self.registry[entityid] = EntityMetadata(entityid, **decorator_params)
+        entity = EntityMetadata(entityid, **decorator_params)
+        _validate_scd_config(entity)
+
+        self.registry[entityid] = entity
         self.emit(
             "entity.registered",
             entity_id=entityid,
             entity_name=decorator_params.get("name", entityid),
+        )
+
+        scd_config = scd_config_from_tags(entity)
+        if scd_config.enabled:
+            self._register_scd2_current_companion(entity, scd_config)
+
+    def _register_scd2_current_companion(self, base: EntityMetadata, cfg: SCDConfig) -> None:
+        """Register the read-only current-row companion for an SCD2 entity."""
+        if cfg.current_entity_id in self.registry:
+            return
+
+        companion_tags = {
+            key: value for key, value in (base.tags or {}).items() if not key.startswith("scd.")
+        }
+        companion_tags.update(
+            {
+                "scd.companion_of": base.entityid,
+                "scd.view_type": "current",
+                "provider.read_only": "true",
+                "provider_type": "current_view",
+            }
+        )
+        companion = replace(
+            base,
+            entityid=cfg.current_entity_id,
+            name=f"{base.name} (current)",
+            tags=companion_tags,
+        )
+        self.registry[cfg.current_entity_id] = companion
+        self.emit(
+            "entity.registered",
+            entity_id=cfg.current_entity_id,
+            entity_name=companion.name,
+        )
+        self.emit(
+            "entity.scd2_companion_registered",
+            entity_id=base.entityid,
+            companion_entity_id=cfg.current_entity_id,
         )
 
     def get_entity_ids(self):

--- a/packages/kindling/entity_provider_current_view.py
+++ b/packages/kindling/entity_provider_current_view.py
@@ -1,0 +1,77 @@
+"""Read-only provider for SCD2 current-row companion entities."""
+
+from typing import Tuple
+
+from injector import inject
+from pyspark.sql import DataFrame
+from pyspark.sql.functions import col, lit
+
+from .data_entities import EntityMetadata, scd_config_from_tags
+from .entity_provider import BaseEntityProvider
+from .injection import GlobalInjector
+from .spark_log_provider import PythonLoggerProvider
+
+
+@GlobalInjector.singleton_autobind()
+class CurrentViewEntityProvider(BaseEntityProvider):
+    """Read-only provider that filters an SCD2 base entity to current rows."""
+
+    @inject
+    def __init__(self, logger_provider: PythonLoggerProvider):
+        self.logger = logger_provider.get_logger("CurrentViewEntityProvider")
+
+    def _resolve_base(
+        self, entity_metadata: EntityMetadata
+    ) -> Tuple[EntityMetadata, BaseEntityProvider]:
+        base_entity_id = (entity_metadata.tags or {}).get("scd.companion_of")
+        if not base_entity_id:
+            raise ValueError(
+                f"Entity '{entity_metadata.entityid}' is missing required "
+                "scd.companion_of tag for current_view provider"
+            )
+
+        from .data_entities import DataEntityManager
+        from .entity_provider_registry import EntityProviderRegistry
+
+        entity_manager = GlobalInjector.get(DataEntityManager)
+        provider_registry = GlobalInjector.get(EntityProviderRegistry)
+        base_entity = entity_manager.get_entity_definition(base_entity_id)
+        if base_entity is None:
+            raise ValueError(
+                f"Current view entity '{entity_metadata.entityid}' references "
+                f"unknown base entity '{base_entity_id}'"
+            )
+
+        return base_entity, provider_registry.get_provider_for_entity(base_entity)
+
+    # [implementer] add SCD2 current companion provider — TASK-20260429-001
+    def read_entity(self, entity_metadata: EntityMetadata) -> DataFrame:
+        """Read the base SCD2 entity filtered to current rows."""
+        base_entity, base_provider = self._resolve_base(entity_metadata)
+        cfg = scd_config_from_tags(base_entity)
+        return base_provider.read_entity(base_entity).filter(
+            col(cfg.is_current_column) == lit(True)
+        )
+
+    def check_entity_exists(self, entity_metadata: EntityMetadata) -> bool:
+        """Delegate existence checks to the base entity provider."""
+        base_entity, base_provider = self._resolve_base(entity_metadata)
+        return base_provider.check_entity_exists(base_entity)
+
+    def merge_to_entity(self, df: DataFrame, entity_metadata: EntityMetadata) -> None:
+        """Reject writes to read-only current-view companion entities."""
+        raise NotImplementedError(
+            "current_view entities are read-only; write to the base SCD2 entity"
+        )
+
+    def write_to_entity(self, df: DataFrame, entity_metadata: EntityMetadata) -> None:
+        """Reject writes to read-only current-view companion entities."""
+        raise NotImplementedError(
+            "current_view entities are read-only; write to the base SCD2 entity"
+        )
+
+    def append_to_entity(self, df: DataFrame, entity_metadata: EntityMetadata) -> None:
+        """Reject writes to read-only current-view companion entities."""
+        raise NotImplementedError(
+            "current_view entities are read-only; write to the base SCD2 entity"
+        )

--- a/packages/kindling/entity_provider_delta.py
+++ b/packages/kindling/entity_provider_delta.py
@@ -1,13 +1,16 @@
 import logging
 import time
+from abc import ABC, abstractmethod
 from enum import Enum
 from functools import reduce
-from typing import Callable, Literal, Optional
+from typing import Callable, Dict, Literal, Optional, Type
 
 import pyspark.sql.utils
 from delta.tables import DeltaTable
 from pyspark.errors import AnalysisException
 from pyspark.sql import DataFrame
+from pyspark.sql.functions import col, concat_ws, lit, sha2, struct, to_json
+from pyspark.sql.types import BooleanType, StructField, StructType, TimestampType
 
 from kindling.common_transforms import *
 from kindling.features import get_feature_bool, set_runtime_feature
@@ -26,6 +29,193 @@ from .entity_provider import (
     StreamWritableEntityProvider,
     WritableEntityProvider,
 )
+
+
+class DeltaMergeStrategy(ABC):
+    """Strategy protocol for Delta merge semantics."""
+
+    @abstractmethod
+    def apply(
+        self,
+        delta_table,
+        df: DataFrame,
+        entity,
+        merge_condition: str,
+    ) -> None:
+        """Apply a merge strategy to a Delta table."""
+
+
+class DeltaMergeStrategies:
+    """Class-level registry for Delta merge strategies."""
+
+    _registry: Dict[str, Type[DeltaMergeStrategy]] = {}
+
+    @classmethod
+    def register(cls, name: str):
+        """Register a Delta merge strategy by name."""
+
+        def decorator(strategy_cls: Type[DeltaMergeStrategy]) -> Type[DeltaMergeStrategy]:
+            if name in cls._registry:
+                raise ValueError(f"Merge strategy '{name}' is already registered.")
+            cls._registry[name] = strategy_cls
+            return strategy_cls
+
+        return decorator
+
+    @classmethod
+    def get(cls, name: str) -> DeltaMergeStrategy:
+        """Return a fresh strategy instance for a registered strategy name."""
+        if name not in cls._registry:
+            raise ValueError(
+                f"Unknown merge strategy '{name}'. "
+                f"Registered strategies: {sorted(cls._registry)}"
+            )
+        return cls._registry[name]()
+
+
+# [implementer] add Delta merge strategy implementations — TASK-20260429-001
+@DeltaMergeStrategies.register(name="scd1")
+class SCD1MergeStrategy(DeltaMergeStrategy):
+    """Default SCD1-style merge strategy."""
+
+    def apply(
+        self,
+        delta_table,
+        df: DataFrame,
+        entity,
+        merge_condition: str,
+    ) -> None:
+        """Run the legacy update-all / insert-all Delta merge."""
+        (
+            delta_table.alias("old")
+            .merge(source=df.alias("new"), condition=merge_condition)
+            .whenMatchedUpdateAll()
+            .whenNotMatchedInsertAll()
+            .execute()
+        )
+
+
+@DeltaMergeStrategies.register(name="scd2")
+class SCD2MergeStrategy(DeltaMergeStrategy):
+    """SCD Type 2 staged-updates merge strategy."""
+
+    def apply(
+        self,
+        delta_table,
+        df: DataFrame,
+        entity,
+        merge_condition: str,
+    ) -> None:
+        """Run an SCD2 merge for changed/new business keys."""
+        _execute_scd2_merge(delta_table, df, entity)
+
+
+def _quote_sql_identifier(name: str, alias: Optional[str] = None) -> str:
+    escaped = name.replace("`", "``")
+    if alias:
+        return f"{alias}.`{escaped}`"
+    return f"`{escaped}`"
+
+
+def _build_null_safe_change_condition(
+    source_alias: str, target_alias: str, tracked_columns: list[str]
+) -> str:
+    if not tracked_columns:
+        return "false"
+
+    return " OR ".join(
+        [
+            f"({_quote_sql_identifier(column, source_alias)} != "
+            f"{_quote_sql_identifier(column, target_alias)} OR "
+            f"({_quote_sql_identifier(column, source_alias)} IS NULL) != "
+            f"({_quote_sql_identifier(column, target_alias)} IS NULL))"
+            for column in tracked_columns
+        ]
+    )
+
+
+def _routing_key_column_expr(business_keys: list[str], method: str):
+    if method == "concat":
+        return concat_ws("||", *[col(key).cast("string") for key in business_keys])
+    return sha2(to_json(struct(*[col(key) for key in business_keys])), 256)
+
+
+def _routing_key_target_sql(business_keys: list[str], method: str) -> str:
+    if method == "concat":
+        key_exprs = [
+            f"CAST({_quote_sql_identifier(key, 'target')} AS STRING)" for key in business_keys
+        ]
+        return f"concat_ws('||', {', '.join(key_exprs)})"
+
+    named_struct_args = []
+    for key in business_keys:
+        safe_key = key.replace("'", "''")
+        named_struct_args.append(f"'{safe_key}'")
+        named_struct_args.append(_quote_sql_identifier(key, "target"))
+    return f"sha2(to_json(named_struct({', '.join(named_struct_args)})), 256)"
+
+
+def _execute_scd2_merge(delta_table, df: DataFrame, entity) -> None:
+    """Execute an SCD Type 2 staged-updates merge for a Delta table."""
+    cfg = scd_config_from_tags(entity)
+    business_keys = entity.merge_columns
+    temporal_columns = {
+        cfg.effective_from_column,
+        cfg.effective_to_column,
+        cfg.is_current_column,
+    }
+    tracked_columns = cfg.tracked_columns or [
+        column
+        for column in df.columns
+        if column not in business_keys and column not in temporal_columns
+    ]
+    change_condition = _build_null_safe_change_condition("source", "target", tracked_columns)
+    current_target = (
+        delta_table.toDF().filter(col(cfg.is_current_column) == lit(True)).alias("target")
+    )
+
+    changed_rows = (
+        df.alias("source")
+        .join(current_target, on=business_keys, how="inner")
+        .where(change_condition)
+        .select("source.*")
+    )
+    new_rows = df.join(current_target, on=business_keys, how="left_anti")
+    # [integrator] unchanged rows omitted from Group B — closing a row that hasn't changed creates a false history entry — TASK-20260429-001
+    rows_to_close_or_insert = changed_rows.unionByName(new_rows, allowMissingColumns=True)
+
+    insert_rows = changed_rows.withColumn("__merge_key", lit(None).cast("string"))
+    keyed_rows = rows_to_close_or_insert.withColumn(
+        "__merge_key", _routing_key_column_expr(business_keys, cfg.routing_key_method)
+    )
+    staged = insert_rows.unionByName(keyed_rows, allowMissingColumns=True)
+
+    source_columns = [column for column in df.columns if column not in temporal_columns]
+    insert_values = {
+        _quote_sql_identifier(column): _quote_sql_identifier(column, "staged")
+        for column in source_columns
+    }
+    insert_values[_quote_sql_identifier(cfg.effective_from_column)] = "current_timestamp()"
+    insert_values[_quote_sql_identifier(cfg.effective_to_column)] = "NULL"
+    insert_values[_quote_sql_identifier(cfg.is_current_column)] = "true"
+    target_routing_key_sql = _routing_key_target_sql(business_keys, cfg.routing_key_method)
+    merge_condition = (
+        f"{target_routing_key_sql} = staged.__merge_key "
+        f"AND {_quote_sql_identifier(cfg.is_current_column, 'target')} = true"
+    )
+
+    (
+        delta_table.alias("target")
+        .merge(source=staged.alias("staged"), condition=merge_condition)
+        .whenMatchedUpdate(
+            set={
+                _quote_sql_identifier(cfg.effective_to_column): "current_timestamp()",
+                _quote_sql_identifier(cfg.is_current_column): "false",
+            }
+        )
+        .whenNotMatchedInsert(values=insert_values)
+        .execute()
+    )
 
 
 class DeltaAccessMode:
@@ -480,9 +670,8 @@ class DeltaEntityProvider(
         # catalog entry from the builder path, which later causes append/saveAsTable
         # to fail with DELTA_MISSING_DELTA_TABLE.
         if entity.schema:
-            from pyspark.sql.types import StructType
-
-            schema_struct = StructType(entity.schema)
+            scd_config = scd_config_from_tags(entity)
+            schema_struct = self._augment_schema_for_scd2(entity.schema, scd_config)
 
             # Prefer Delta table builder for managed tables when clustering is requested.
             # Some engines require clustering to be enabled at create time and reject
@@ -718,8 +907,6 @@ class DeltaEntityProvider(
             # Avoid metastore/catalog DDL entirely for FOR_PATH mode.
             # Creating the Delta log by writing an empty dataframe is the most
             # portable approach across Fabric/Synapse/Databricks.
-            from pyspark.sql.types import StructType
-
             if not entity.schema:
                 # A Delta table can't be bootstrapped without a schema. If the caller
                 # wants to ensure storage destinations, they must provide schema;
@@ -728,6 +915,9 @@ class DeltaEntityProvider(
                     f"Cannot create physical Delta table at '{table_ref.table_path}' without schema "
                     f"for entity '{entity.entityid}'. Provide entity.schema or skip ensure."
                 )
+
+            scd_config = scd_config_from_tags(entity)
+            schema = self._augment_schema_for_scd2(entity.schema, scd_config)
 
             # Prefer Delta's table builder API when clustering is requested. Some engines
             # (Synapse in particular) reject `ALTER TABLE ... CLUSTER BY` unless the table
@@ -744,7 +934,7 @@ class DeltaEntityProvider(
                         .location(table_ref.table_path)
                         .property("delta.enableChangeDataFeed", "true")
                     )
-                    dt = dt.addColumns(entity.schema)
+                    dt = dt.addColumns(schema)
                     dt = dt.clusterBy(*cluster_cols)
                     # If the user provided partition_columns too, _should_partition_files() will return False.
                     if self._should_partition_files(entity):
@@ -760,7 +950,6 @@ class DeltaEntityProvider(
                         f"at '{table_ref.table_path}' (columns={cluster_cols}); falling back to dataframe bootstrap: {e}"
                     )
 
-            schema = entity.schema or StructType([])
             empty_df = self.spark.createDataFrame([], schema=schema)
             writer = (
                 empty_df.write.format("delta").mode("overwrite").option("overwriteSchema", "true")
@@ -946,16 +1135,30 @@ class DeltaEntityProvider(
 
     def _merge_to_delta_table(self, df: DataFrame, entity, table_ref: DeltaTableReference):
         """Merge DataFrame to existing Delta table"""
+        scd_config = scd_config_from_tags(entity)
+        strategy_name = "scd2" if scd_config.enabled else "scd1"
+        strategy = DeltaMergeStrategies.get(strategy_name)
         merge_condition = self._build_merge_condition("old", "new", entity.merge_columns)
+        strategy.apply(table_ref.get_delta_table(), df, entity, merge_condition)
 
-        (
-            table_ref.get_delta_table()
-            .alias("old")
-            .merge(source=df.alias("new"), condition=merge_condition)
-            .whenMatchedUpdateAll()
-            .whenNotMatchedInsertAll()
-            .execute()
-        )
+    def _augment_schema_for_scd2(self, schema: StructType, cfg: SCDConfig) -> StructType:
+        """Add SCD2 temporal columns to a schema when SCD2 is enabled."""
+        schema_struct = schema if isinstance(schema, StructType) else StructType(schema)
+        if not cfg.enabled:
+            return schema_struct
+
+        existing_names = {field.name for field in schema_struct.fields}
+        extra_fields = []
+        if cfg.effective_from_column not in existing_names:
+            extra_fields.append(StructField(cfg.effective_from_column, TimestampType(), False))
+        if cfg.effective_to_column not in existing_names:
+            extra_fields.append(StructField(cfg.effective_to_column, TimestampType(), True))
+        if cfg.is_current_column not in existing_names:
+            extra_fields.append(StructField(cfg.is_current_column, BooleanType(), False))
+
+        if not extra_fields:
+            return schema_struct
+        return StructType(schema_struct.fields + extra_fields)
 
     def _append_to_delta_table(self, df: DataFrame, entity, table_ref: DeltaTableReference):
         """Append DataFrame to existing Delta table"""
@@ -1152,6 +1355,25 @@ class DeltaEntityProvider(
         table_ref = self._get_table_reference(entity)
         df = self._read_delta_table(table_ref, since_version)
         return self._transform_delta_feed_to_changes(df, entity.merge_columns)
+
+    def read_entity_as_of(self, entity, point_in_time) -> DataFrame:
+        """Read entity state at a specific point in time."""
+        scd_config = scd_config_from_tags(entity)
+        table_ref = self._get_table_reference(entity)
+        if not scd_config.enabled:
+            return (
+                self.spark.read.format("delta")
+                .option("timestampAsOf", str(point_in_time))
+                .load(table_ref.get_read_path())
+            )
+
+        return self.read_entity(entity).filter(
+            (col(scd_config.effective_from_column) <= point_in_time)
+            & (
+                col(scd_config.effective_to_column).isNull()
+                | (col(scd_config.effective_to_column) > point_in_time)
+            )
+        )
 
     def read_entity(self, entity) -> DataFrame:
         """Read full entity table with signal emissions."""

--- a/packages/kindling/entity_provider_registry.py
+++ b/packages/kindling/entity_provider_registry.py
@@ -159,4 +159,12 @@ class EntityProviderRegistry:
         except ImportError:
             self.logger.debug("Memory provider not available")
 
+        # [implementer] register SCD2 current-view provider — TASK-20260429-001
+        try:
+            from .entity_provider_current_view import CurrentViewEntityProvider
+
+            self.register_provider("current_view", CurrentViewEntityProvider)
+        except ImportError:
+            self.logger.debug("Current view provider not available")
+
         self.logger.info(f"Registered {len(self._provider_classes)} built-in provider(s)")

--- a/packages/kindling/file_ingestion.py
+++ b/packages/kindling/file_ingestion.py
@@ -236,8 +236,10 @@ class ParallelizingFileIngestionProcessor(FileIngestionProcessor, SignalEmitter)
         de = self.der.get_entity_definition(dest_entity_id)
 
         if not de:
-            self.logger.error(f"Entity definition not found: {dest_entity_id}")
-            return
+            raise ValueError(
+                f"File ingestor references unknown destination entity '{dest_entity_id}'. "
+                "Register the entity with @DataEntities.entity() before running ingestion."
+            )
 
         # Union all DataFrames for this table
         dfs = [df for df, _ in df_list]

--- a/tests/unit/test_current_view_provider.py
+++ b/tests/unit/test_current_view_provider.py
@@ -1,0 +1,131 @@
+from unittest.mock import MagicMock
+
+import pytest
+from pyspark.sql.types import StringType, StructField, StructType
+
+from kindling.data_entities import EntityMetadata
+from kindling.entity_provider_current_view import CurrentViewEntityProvider
+
+
+class Expr:
+    def __init__(self, value):
+        self.value = value
+
+    def __eq__(self, other):
+        return Expr(f"{self.value} = {other}")
+
+    def __str__(self):
+        return self.value
+
+
+@pytest.fixture(autouse=True)
+def patch_spark_sql_functions(monkeypatch):
+    monkeypatch.setattr(
+        "kindling.entity_provider_current_view.col", lambda name: Expr(f"col({name})")
+    )
+    monkeypatch.setattr(
+        "kindling.entity_provider_current_view.lit", lambda value: Expr(f"lit({value})")
+    )
+
+
+def _entity(entityid, tags=None):
+    return EntityMetadata(
+        entityid=entityid,
+        name=entityid,
+        merge_columns=["id"],
+        tags=tags or {},
+        schema=StructType([StructField("id", StringType(), False)]),
+    )
+
+
+def _provider():
+    logger_provider = MagicMock()
+    logger_provider.get_logger.return_value = MagicMock()
+    return CurrentViewEntityProvider(logger_provider)
+
+
+def _wire_provider(monkeypatch, companion, base=None, base_provider=None):
+    base = base or _entity("orders", {"scd.type": "2"})
+    base_provider = base_provider or MagicMock()
+    base_df = MagicMock()
+    filtered_df = MagicMock()
+    base_provider.read_entity.return_value = base_df
+    base_df.filter.return_value = filtered_df
+
+    entity_manager = MagicMock()
+    entity_manager.get_entity_definition.return_value = base
+    provider_registry = MagicMock()
+    provider_registry.get_provider_for_entity.return_value = base_provider
+
+    def fake_get(cls):
+        if cls.__name__ == "DataEntityManager":
+            return entity_manager
+        if cls.__name__ == "EntityProviderRegistry":
+            return provider_registry
+        raise AssertionError(f"Unexpected injector lookup for {cls}")
+
+    monkeypatch.setattr("kindling.entity_provider_current_view.GlobalInjector.get", fake_get)
+    return base, base_provider, base_df, filtered_df, entity_manager, provider_registry
+
+
+def test_read_entity_filters_to_is_current_true(monkeypatch):
+    companion = _entity("orders.current", {"scd.companion_of": "orders"})
+    _, _, base_df, filtered_df, _, _ = _wire_provider(monkeypatch, companion)
+
+    result = _provider().read_entity(companion)
+
+    assert result is filtered_df
+    base_df.filter.assert_called_once()
+    assert "__is_current" in str(base_df.filter.call_args.args[0])
+
+
+def test_read_entity_uses_is_current_column_from_scd_config(monkeypatch):
+    companion = _entity("orders.current", {"scd.companion_of": "orders"})
+    base = _entity("orders", {"scd.type": "2", "scd.current_col": "current_flag"})
+    _, _, base_df, _, _, _ = _wire_provider(monkeypatch, companion, base=base)
+
+    _provider().read_entity(companion)
+
+    assert "current_flag" in str(base_df.filter.call_args.args[0])
+
+
+def test_read_entity_delegates_to_base_delta_provider(monkeypatch):
+    companion = _entity("orders.current", {"scd.companion_of": "orders"})
+    base, base_provider, _, _, entity_manager, provider_registry = _wire_provider(
+        monkeypatch, companion
+    )
+
+    _provider().read_entity(companion)
+
+    entity_manager.get_entity_definition.assert_called_once_with("orders")
+    provider_registry.get_provider_for_entity.assert_called_once_with(base)
+    base_provider.read_entity.assert_called_once_with(base)
+
+
+def test_check_entity_exists_delegates_to_base_provider(monkeypatch):
+    companion = _entity("orders.current", {"scd.companion_of": "orders"})
+    base, base_provider, _, _, _, _ = _wire_provider(monkeypatch, companion)
+    base_provider.check_entity_exists.return_value = True
+
+    assert _provider().check_entity_exists(companion) is True
+    base_provider.check_entity_exists.assert_called_once_with(base)
+
+
+def test_merge_to_entity_raises_not_implemented_error():
+    with pytest.raises(NotImplementedError, match="read-only"):
+        _provider().merge_to_entity(MagicMock(), _entity("orders.current"))
+
+
+def test_write_to_entity_raises_not_implemented_error():
+    with pytest.raises(NotImplementedError, match="read-only"):
+        _provider().write_to_entity(MagicMock(), _entity("orders.current"))
+
+
+def test_append_to_entity_raises_not_implemented_error():
+    with pytest.raises(NotImplementedError, match="read-only"):
+        _provider().append_to_entity(MagicMock(), _entity("orders.current"))
+
+
+def test_read_entity_missing_companion_of_tag_raises_value_error():
+    with pytest.raises(ValueError, match="scd.companion_of"):
+        _provider().read_entity(_entity("orders.current"))

--- a/tests/unit/test_scd2_merge.py
+++ b/tests/unit/test_scd2_merge.py
@@ -1,0 +1,187 @@
+from unittest.mock import MagicMock
+
+import pytest
+from pyspark.sql.types import StringType, StructField, StructType
+
+from kindling.data_entities import EntityMetadata
+from kindling.entity_provider_delta import _execute_scd2_merge
+
+
+class Expr:
+    def __init__(self, value):
+        self.value = value
+
+    def cast(self, data_type):
+        return Expr(f"CAST({self.value} AS {data_type})")
+
+    def __str__(self):
+        return self.value
+
+
+@pytest.fixture(autouse=True)
+def patch_spark_sql_functions(monkeypatch):
+    monkeypatch.setattr("kindling.entity_provider_delta.col", lambda name: Expr(f"col({name})"))
+    monkeypatch.setattr("kindling.entity_provider_delta.lit", lambda value: Expr(f"lit({value})"))
+    monkeypatch.setattr(
+        "kindling.entity_provider_delta.concat_ws",
+        lambda separator, *cols: Expr(
+            f"concat_ws({separator}, {', '.join(str(col) for col in cols)})"
+        ),
+    )
+    monkeypatch.setattr(
+        "kindling.entity_provider_delta.struct",
+        lambda *cols: Expr(f"struct({', '.join(str(col) for col in cols)})"),
+    )
+    monkeypatch.setattr(
+        "kindling.entity_provider_delta.to_json", lambda expr: Expr(f"to_json({expr})")
+    )
+    monkeypatch.setattr(
+        "kindling.entity_provider_delta.sha2",
+        lambda expr, bits: Expr(f"sha2({expr}, {bits})"),
+    )
+
+
+def _entity(tags=None):
+    return EntityMetadata(
+        entityid="customer_dim",
+        name="customer_dim",
+        merge_columns=["customer_id"],
+        tags={"scd.type": "2", **(tags or {})},
+        schema=StructType(
+            [
+                StructField("customer_id", StringType(), False),
+                StructField("name", StringType(), True),
+                StructField("status", StringType(), True),
+            ]
+        ),
+    )
+
+
+def _mock_source_df():
+    df = MagicMock(name="source_df")
+    df.columns = ["customer_id", "name", "status"]
+
+    joined_changed = MagicMock(name="joined_changed")
+    filtered_changed = MagicMock(name="filtered_changed")
+    changed_rows = MagicMock(name="changed_rows")
+    new_rows = MagicMock(name="new_rows")
+    rows_to_close_or_insert = MagicMock(name="rows_to_close_or_insert")
+    insert_rows = MagicMock(name="insert_rows")
+    keyed_rows = MagicMock(name="keyed_rows")
+    staged = MagicMock(name="staged")
+
+    df.alias.return_value = df
+    df.join.side_effect = [joined_changed, new_rows]
+    joined_changed.where.return_value = filtered_changed
+    filtered_changed.select.return_value = changed_rows
+    changed_rows.unionByName.return_value = rows_to_close_or_insert
+    changed_rows.withColumn.return_value = insert_rows
+    rows_to_close_or_insert.withColumn.return_value = keyed_rows
+    insert_rows.unionByName.return_value = staged
+    staged.alias.return_value = staged
+
+    return df, {
+        "changed_rows": changed_rows,
+        "new_rows": new_rows,
+        "rows_to_close_or_insert": rows_to_close_or_insert,
+        "insert_rows": insert_rows,
+        "keyed_rows": keyed_rows,
+        "staged": staged,
+        "joined_changed": joined_changed,
+    }
+
+
+def _mock_delta_table():
+    delta_table = MagicMock(name="delta_table")
+    target_df = MagicMock(name="target_df")
+    filtered_target = MagicMock(name="filtered_target")
+    merge_builder = MagicMock(name="merge_builder")
+
+    delta_table.toDF.return_value = target_df
+    target_df.filter.return_value = filtered_target
+    filtered_target.alias.return_value = filtered_target
+    delta_table.alias.return_value = delta_table
+    delta_table.merge.return_value = merge_builder
+    merge_builder.whenMatchedUpdate.return_value = merge_builder
+    merge_builder.whenNotMatchedInsert.return_value = merge_builder
+    merge_builder.whenNotMatchedBySourceUpdate.return_value = merge_builder
+
+    return delta_table, merge_builder
+
+
+def _execute(tags=None):
+    delta_table, merge_builder = _mock_delta_table()
+    df, frames = _mock_source_df()
+    _execute_scd2_merge(delta_table, df, _entity(tags))
+    return delta_table, merge_builder, df, frames
+
+
+def test_execute_scd2_merge_calls_delta_table_merge():
+    delta_table, _, _, frames = _execute()
+
+    delta_table.merge.assert_called_once()
+    assert delta_table.merge.call_args.kwargs["source"] is frames["staged"]
+
+
+def test_execute_scd2_merge_when_matched_update_closes_current_row():
+    _, merge_builder, _, _ = _execute()
+
+    merge_builder.whenMatchedUpdate.assert_called_once_with(
+        set={"`__effective_to`": "current_timestamp()", "`__is_current`": "false"}
+    )
+
+
+def test_execute_scd2_merge_when_not_matched_insert_sets_is_current_true():
+    _, merge_builder, _, _ = _execute()
+
+    values = merge_builder.whenNotMatchedInsert.call_args.kwargs["values"]
+    assert values["`__is_current`"] == "true"
+
+
+def test_execute_scd2_merge_when_not_matched_insert_sets_effective_from_to_current_timestamp():
+    _, merge_builder, _, _ = _execute()
+
+    values = merge_builder.whenNotMatchedInsert.call_args.kwargs["values"]
+    assert values["`__effective_from`"] == "current_timestamp()"
+
+
+def test_execute_scd2_merge_when_not_matched_insert_sets_effective_to_null():
+    _, merge_builder, _, _ = _execute()
+
+    values = merge_builder.whenNotMatchedInsert.call_args.kwargs["values"]
+    assert values["`__effective_to`"] == "NULL"
+
+
+def test_execute_scd2_merge_tracked_columns_default_excludes_keys_and_temporal():
+    _, _, _, frames = _execute()
+
+    where_condition = frames["joined_changed"].where.call_args.args[0]
+    assert "source.`name`" in where_condition
+    assert "source.`status`" in where_condition
+    assert "source.`customer_id`" not in where_condition
+    assert "source.`__effective_from`" not in where_condition
+
+
+def test_execute_scd2_merge_routing_key_hash_method_used_by_default():
+    delta_table, _, _, frames = _execute()
+
+    merge_condition = delta_table.merge.call_args.kwargs["condition"]
+    assert merge_condition.startswith("sha2(to_json(named_struct(")
+    assert "target.`customer_id`" in merge_condition
+    routing_expr = frames["rows_to_close_or_insert"].withColumn.call_args.args[1]
+    assert "sha2" in str(routing_expr)
+
+
+def test_execute_scd2_merge_routing_key_concat_method_used_when_configured():
+    delta_table, _, _, frames = _execute({"scd.routing_key": "concat"})
+
+    merge_condition = delta_table.merge.call_args.kwargs["condition"]
+    assert merge_condition.startswith("concat_ws('||', CAST(target.`customer_id` AS STRING))")
+    routing_expr = frames["rows_to_close_or_insert"].withColumn.call_args.args[1]
+    assert "concat_ws" in str(routing_expr)
+
+
+def test_execute_scd2_merge_does_not_implement_close_on_missing_in_phase_1():
+    _, merge_builder, _, _ = _execute({"scd.close_on_missing": "true"})
+
+    merge_builder.whenNotMatchedBySourceUpdate.assert_not_called()

--- a/tests/unit/test_scd2_registration.py
+++ b/tests/unit/test_scd2_registration.py
@@ -1,0 +1,134 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from kindling.data_entities import DataEntityManager
+
+
+def register_base_scd2_entity(manager, *, entityid="silver.customer", tags=None):
+    merged_tags = {"scd.type": "2", **(tags or {})}
+    manager.register_entity(
+        entityid,
+        name="Customer",
+        merge_columns=["customer_id"],
+        tags=merged_tags,
+        schema=None,
+    )
+
+
+def test_register_entity_scd2_creates_companion_in_registry():
+    manager = DataEntityManager()
+
+    register_base_scd2_entity(manager)
+
+    assert "silver.customer.current" in manager.registry
+
+
+def test_register_entity_scd2_companion_id_is_entityid_dot_current():
+    manager = DataEntityManager()
+
+    register_base_scd2_entity(manager)
+    companion = manager.registry["silver.customer.current"]
+
+    assert companion.entityid == "silver.customer.current"
+
+
+def test_register_entity_scd2_companion_has_provider_type_current_view():
+    manager = DataEntityManager()
+
+    register_base_scd2_entity(manager)
+    companion = manager.registry["silver.customer.current"]
+
+    assert companion.tags["provider_type"] == "current_view"
+
+
+def test_register_entity_scd2_companion_has_scd_companion_of_tag():
+    manager = DataEntityManager()
+
+    register_base_scd2_entity(manager)
+    companion = manager.registry["silver.customer.current"]
+
+    assert companion.tags["scd.companion_of"] == "silver.customer"
+    assert companion.tags["scd.view_type"] == "current"
+    assert companion.tags["provider.read_only"] == "true"
+
+
+def test_register_entity_scd2_companion_inherits_merge_columns():
+    manager = DataEntityManager()
+
+    register_base_scd2_entity(manager)
+    companion = manager.registry["silver.customer.current"]
+
+    assert companion.merge_columns == ["customer_id"]
+
+
+def test_register_entity_scd2_custom_current_entity_id_used():
+    manager = DataEntityManager()
+
+    register_base_scd2_entity(
+        manager,
+        tags={"scd.current_entity_id": "serving.current_customer"},
+    )
+
+    assert "serving.current_customer" in manager.registry
+    assert "silver.customer.current" not in manager.registry
+
+
+def test_register_entity_scd2_user_declared_companion_not_overwritten():
+    manager = DataEntityManager()
+    manager.register_entity(
+        "silver.customer.current",
+        name="User Declared Current Customer",
+        merge_columns=["customer_id"],
+        tags={"provider_type": "delta", "owner": "analytics"},
+        schema=None,
+    )
+
+    register_base_scd2_entity(manager)
+    companion = manager.registry["silver.customer.current"]
+
+    assert companion.name == "User Declared Current Customer"
+    assert companion.tags == {"provider_type": "delta", "owner": "analytics"}
+
+
+def test_register_entity_scd2_emits_companion_registered_signal():
+    manager = DataEntityManager()
+    manager.emit = MagicMock()
+
+    register_base_scd2_entity(manager)
+
+    manager.emit.assert_any_call(
+        "entity.scd2_companion_registered",
+        entity_id="silver.customer",
+        companion_entity_id="silver.customer.current",
+    )
+
+
+def test_register_entity_non_scd2_does_not_create_companion():
+    manager = DataEntityManager()
+
+    manager.register_entity(
+        "silver.customer",
+        name="Customer",
+        merge_columns=["customer_id"],
+        tags={},
+        schema=None,
+    )
+
+    assert "silver.customer" in manager.registry
+    assert "silver.customer.current" not in manager.registry
+
+
+def test_register_entity_scd2_invalid_config_raises_before_registration():
+    manager = DataEntityManager()
+
+    with pytest.raises(ValueError, match="requires merge_columns"):
+        manager.register_entity(
+            "silver.customer",
+            name="Customer",
+            merge_columns=[],
+            tags={"scd.type": "2"},
+            schema=None,
+        )
+
+    assert manager.registry == {}

--- a/tests/unit/test_scd2_schema_augmentation.py
+++ b/tests/unit/test_scd2_schema_augmentation.py
@@ -1,0 +1,160 @@
+from unittest.mock import MagicMock
+
+from pyspark.sql.types import (
+    BooleanType,
+    StringType,
+    StructField,
+    StructType,
+    TimestampType,
+)
+
+from kindling.data_entities import EntityMetadata, SCDConfig
+from kindling.entity_provider_delta import (
+    DeltaAccessMode,
+    DeltaEntityProvider,
+    DeltaTableReference,
+)
+
+
+def _provider():
+    provider = DeltaEntityProvider.__new__(DeltaEntityProvider)
+    provider.config = MagicMock()
+    provider.config.get.return_value = None
+    provider.logger = MagicMock()
+    provider.spark = MagicMock()
+    provider._get_cluster_columns = MagicMock(return_value=[])
+    provider._should_partition_files = MagicMock(return_value=False)
+    return provider
+
+
+def _scd_config(**overrides):
+    values = {
+        "enabled": True,
+        "tracked_columns": None,
+        "effective_from_column": "__effective_from",
+        "effective_to_column": "__effective_to",
+        "is_current_column": "__is_current",
+        "current_entity_id": "orders.current",
+        "routing_key_method": "hash",
+    }
+    values.update(overrides)
+    return SCDConfig(**values)
+
+
+def _schema():
+    return StructType([StructField("id", StringType(), False)])
+
+
+def _field(schema, name):
+    return next(field for field in schema.fields if field.name == name)
+
+
+def _entity(tags=None):
+    return EntityMetadata(
+        entityid="orders",
+        name="orders",
+        merge_columns=["id"],
+        tags=tags or {},
+        schema=_schema(),
+    )
+
+
+def test_augment_schema_adds_all_three_temporal_columns():
+    augmented = _provider()._augment_schema_for_scd2(_schema(), _scd_config())
+
+    assert {field.name for field in augmented.fields} == {
+        "id",
+        "__effective_from",
+        "__effective_to",
+        "__is_current",
+    }
+
+
+def test_augment_schema_skips_columns_already_in_schema():
+    schema = StructType(
+        [
+            StructField("id", StringType(), False),
+            StructField("__effective_from", TimestampType(), False),
+        ]
+    )
+
+    augmented = _provider()._augment_schema_for_scd2(schema, _scd_config())
+
+    assert [field.name for field in augmented.fields].count("__effective_from") == 1
+    assert {field.name for field in augmented.fields} == {
+        "id",
+        "__effective_from",
+        "__effective_to",
+        "__is_current",
+    }
+
+
+def test_augment_schema_effective_from_is_not_nullable():
+    augmented = _provider()._augment_schema_for_scd2(_schema(), _scd_config())
+
+    field = _field(augmented, "__effective_from")
+    assert isinstance(field.dataType, TimestampType)
+    assert field.nullable is False
+
+
+def test_augment_schema_effective_to_is_nullable():
+    augmented = _provider()._augment_schema_for_scd2(_schema(), _scd_config())
+
+    field = _field(augmented, "__effective_to")
+    assert isinstance(field.dataType, TimestampType)
+    assert field.nullable is True
+
+
+def test_augment_schema_is_current_is_not_nullable():
+    augmented = _provider()._augment_schema_for_scd2(_schema(), _scd_config())
+
+    field = _field(augmented, "__is_current")
+    assert isinstance(field.dataType, BooleanType)
+    assert field.nullable is False
+
+
+def test_augment_schema_uses_custom_column_names_from_config():
+    cfg = _scd_config(
+        effective_from_column="valid_from",
+        effective_to_column="valid_to",
+        is_current_column="current_flag",
+    )
+
+    augmented = _provider()._augment_schema_for_scd2(_schema(), cfg)
+
+    assert {field.name for field in augmented.fields} == {
+        "id",
+        "valid_from",
+        "valid_to",
+        "current_flag",
+    }
+
+
+def test_create_physical_table_augments_schema_when_scd2_enabled():
+    provider = _provider()
+    entity = _entity({"scd.type": "2"})
+    table_ref = DeltaTableReference.__new__(DeltaTableReference)
+    table_ref.table_path = "/tmp/orders"
+    table_ref.table_name = None
+    table_ref.access_mode = DeltaAccessMode.STORAGE
+
+    provider._create_physical_table(entity, table_ref)
+
+    schema = provider.spark.createDataFrame.call_args.kwargs["schema"]
+    assert "__effective_from" in schema.names
+    assert "__effective_to" in schema.names
+    assert "__is_current" in schema.names
+
+
+def test_create_physical_table_no_augment_when_scd2_disabled():
+    provider = _provider()
+    entity = _entity()
+    table_ref = DeltaTableReference.__new__(DeltaTableReference)
+    table_ref.table_path = "/tmp/orders"
+    table_ref.table_name = None
+    table_ref.access_mode = DeltaAccessMode.STORAGE
+
+    provider._create_physical_table(entity, table_ref)
+
+    schema = provider.spark.createDataFrame.call_args.kwargs["schema"]
+    assert schema.names == ["id"]

--- a/tests/unit/test_scd_config.py
+++ b/tests/unit/test_scd_config.py
@@ -1,0 +1,142 @@
+from types import SimpleNamespace
+
+import pytest
+
+from kindling.data_entities import (
+    EntityMetadata,
+    _validate_scd_config,
+    scd_config_from_tags,
+)
+
+
+def make_entity(
+    *,
+    entityid="silver.customer",
+    merge_columns=None,
+    tags=None,
+    schema=None,
+):
+    return EntityMetadata(
+        entityid=entityid,
+        name="Customer",
+        merge_columns=[] if merge_columns is None else merge_columns,
+        tags={} if tags is None else tags,
+        schema=schema,
+    )
+
+
+def make_schema(*field_names):
+    return SimpleNamespace(fields=[SimpleNamespace(name=field_name) for field_name in field_names])
+
+
+def test_scd_config_from_tags_no_tag_returns_disabled_config():
+    cfg = scd_config_from_tags(make_entity())
+
+    assert cfg.enabled is False
+    assert cfg.tracked_columns is None
+    assert cfg.effective_from_column == "__effective_from"
+    assert cfg.effective_to_column == "__effective_to"
+    assert cfg.is_current_column == "__is_current"
+    assert cfg.current_entity_id == "silver.customer.current"
+    assert cfg.routing_key_method == "hash"
+
+
+def test_scd_config_from_tags_scd_type_2_returns_enabled_config():
+    cfg = scd_config_from_tags(make_entity(tags={"scd.type": "2"}))
+
+    assert cfg.enabled is True
+
+
+def test_scd_config_from_tags_invalid_scd_type_raises_value_error():
+    entity = make_entity(tags={"scd.type": "1"})
+
+    with pytest.raises(ValueError, match="scd.type must be '2'"):
+        scd_config_from_tags(entity)
+
+
+def test_scd_config_from_tags_custom_column_names_respected():
+    cfg = scd_config_from_tags(
+        make_entity(
+            tags={
+                "scd.type": "2",
+                "scd.effective_from_col": "valid_from",
+                "scd.effective_to_col": "valid_to",
+                "scd.current_col": "is_active",
+            }
+        )
+    )
+
+    assert cfg.effective_from_column == "valid_from"
+    assert cfg.effective_to_column == "valid_to"
+    assert cfg.is_current_column == "is_active"
+
+
+def test_scd_config_from_tags_tracked_columns_parsed_from_comma_list():
+    cfg = scd_config_from_tags(
+        make_entity(tags={"scd.type": "2", "scd.tracked": "name, email, status"})
+    )
+
+    assert cfg.tracked_columns == ["name", "email", "status"]
+
+
+def test_scd_config_from_tags_empty_tracked_returns_none():
+    cfg = scd_config_from_tags(make_entity(tags={"scd.type": "2", "scd.tracked": "  "}))
+
+    assert cfg.tracked_columns is None
+
+
+def test_scd_config_from_tags_routing_key_hash_is_default():
+    cfg = scd_config_from_tags(make_entity(tags={"scd.type": "2"}))
+
+    assert cfg.routing_key_method == "hash"
+
+
+def test_scd_config_from_tags_routing_key_concat_accepted():
+    cfg = scd_config_from_tags(make_entity(tags={"scd.type": "2", "scd.routing_key": "concat"}))
+
+    assert cfg.routing_key_method == "concat"
+
+
+def test_scd_config_from_tags_invalid_routing_key_raises_value_error():
+    entity = make_entity(tags={"scd.type": "2", "scd.routing_key": "uuid"})
+
+    with pytest.raises(ValueError, match="scd.routing_key"):
+        scd_config_from_tags(entity)
+
+
+def test_scd_config_from_tags_default_current_entity_id_is_entityid_dot_current():
+    cfg = scd_config_from_tags(make_entity(entityid="gold.account", tags={"scd.type": "2"}))
+
+    assert cfg.current_entity_id == "gold.account.current"
+
+
+def test_validate_scd_config_scd2_missing_merge_columns_raises_value_error():
+    entity = make_entity(tags={"scd.type": "2"}, merge_columns=[])
+
+    with pytest.raises(ValueError, match="requires merge_columns"):
+        _validate_scd_config(entity)
+
+
+def test_validate_scd_config_tracked_cols_overlap_merge_cols_raises_value_error():
+    entity = make_entity(
+        merge_columns=["customer_id"],
+        tags={"scd.type": "2", "scd.tracked": "customer_id,email"},
+    )
+
+    with pytest.raises(ValueError, match="must not include merge_columns"):
+        _validate_scd_config(entity)
+
+
+def test_validate_scd_config_temporal_col_collides_with_schema_raises_value_error():
+    entity = make_entity(
+        merge_columns=["customer_id"],
+        tags={"scd.type": "2"},
+        schema=make_schema("customer_id", "__effective_from"),
+    )
+
+    with pytest.raises(ValueError, match="collide with business schema columns"):
+        _validate_scd_config(entity)
+
+
+def test_validate_scd_config_non_scd_entity_passes():
+    _validate_scd_config(make_entity(merge_columns=[], schema={"no": "fields attr"}))

--- a/tests/unit/test_scd_merge_strategies.py
+++ b/tests/unit/test_scd_merge_strategies.py
@@ -1,0 +1,88 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from kindling.entity_provider_delta import (
+    DeltaMergeStrategies,
+    DeltaMergeStrategy,
+    SCD1MergeStrategy,
+)
+
+
+class ExampleMergeStrategy(DeltaMergeStrategy):
+    def apply(self, delta_table, df, entity, merge_condition):
+        return None
+
+
+def test_delta_merge_strategies_register_stores_class():
+    name = "unit_test_strategy"
+    original = dict(DeltaMergeStrategies._registry)
+    DeltaMergeStrategies._registry.pop(name, None)
+
+    try:
+        registered = DeltaMergeStrategies.register(name)(ExampleMergeStrategy)
+
+        assert registered is ExampleMergeStrategy
+        assert DeltaMergeStrategies._registry[name] is ExampleMergeStrategy
+    finally:
+        DeltaMergeStrategies._registry = original
+
+
+def test_delta_merge_strategies_register_duplicate_raises_value_error():
+    with pytest.raises(ValueError, match="already registered"):
+        DeltaMergeStrategies.register("scd1")(ExampleMergeStrategy)
+
+
+def test_delta_merge_strategies_get_returns_fresh_instance_each_call():
+    first = DeltaMergeStrategies.get("scd1")
+    second = DeltaMergeStrategies.get("scd1")
+
+    assert isinstance(first, SCD1MergeStrategy)
+    assert isinstance(second, SCD1MergeStrategy)
+    assert first is not second
+
+
+def test_delta_merge_strategies_get_unknown_name_raises_value_error():
+    with pytest.raises(ValueError, match="Unknown merge strategy"):
+        DeltaMergeStrategies.get("missing")
+
+
+def _apply_scd1_strategy():
+    delta_table = MagicMock()
+    aliased_delta = delta_table.alias.return_value
+    merge_builder = aliased_delta.merge.return_value
+    df = MagicMock()
+    entity = MagicMock()
+
+    SCD1MergeStrategy().apply(delta_table, df, entity, "old.`id` = new.`id`")
+
+    return delta_table, df, merge_builder
+
+
+def test_scd1_strategy_apply_calls_when_matched_update_all():
+    _, _, merge_builder = _apply_scd1_strategy()
+
+    merge_builder.whenMatchedUpdateAll.assert_called_once_with()
+
+
+def test_scd1_strategy_apply_calls_when_not_matched_insert_all():
+    _, _, merge_builder = _apply_scd1_strategy()
+
+    merge_builder.whenMatchedUpdateAll.return_value.whenNotMatchedInsertAll.assert_called_once_with()
+
+
+def test_scd1_strategy_apply_calls_execute():
+    _, _, merge_builder = _apply_scd1_strategy()
+
+    merge_builder.whenMatchedUpdateAll.return_value.whenNotMatchedInsertAll.return_value.execute.assert_called_once_with()
+
+
+def test_scd1_strategy_apply_uses_provided_merge_condition():
+    delta_table, df, _ = _apply_scd1_strategy()
+
+    delta_table.alias.assert_called_once_with("old")
+    df.alias.assert_called_once_with("new")
+    delta_table.alias.return_value.merge.assert_called_once_with(
+        source=df.alias.return_value,
+        condition="old.`id` = new.`id`",
+    )


### PR DESCRIPTION
## What
Add SCD Type 2 entity support to the Delta provider via a named `DeltaMergeStrategy` registry. Entities tagged `scd.type: "2"` automatically receive closed-row / new-version merge semantics and a read-only `.current` companion entity — without any changes to the execution layer or `EntityMetadata` schema.

## Why
Slowly Changing Dimension Type 2 is a standard pattern for preserving full history of entity changes. Previously the Delta provider only supported SCD1 (overwrite). Teams needed either custom merge logic or workarounds that leaked into pipeline code. This change encapsulates the behavior in a first-class strategy so pipeline authors only need a tag.

## Changes

**Core implementation**
- `packages/kindling/data_entities.py` — `SCDConfig` dataclass, `scd_config_from_tags()` helper, `_validate_scd_config()`, companion entity auto-registration in `DataEntityManager`
- `packages/kindling/entity_provider_delta.py` — `DeltaMergeStrategy` ABC, `DeltaMergeStrategies` class-level registry with `@register(name=...)` decorator (raises on duplicate), `SCD1MergeStrategy` (default), `SCD2MergeStrategy` (staged-updates), `_execute_scd2_merge()`, `_augment_schema_for_scd2()`, `read_entity_as_of()`
- `packages/kindling/entity_provider_current_view.py` _(new)_ — `CurrentViewEntityProvider`: read-only companion, filters `is_current=true`
- `packages/kindling/entity_provider_registry.py` — registers `"current_view"` provider
- `packages/kindling/file_ingestion.py` — converts silent failure to explicit `ValueError` when destination entity is unknown (issue #11)

**Tests** _(57 new, 1080 total passing)_
- `tests/unit/test_scd_config.py`
- `tests/unit/test_scd2_registration.py`
- `tests/unit/test_scd_merge_strategies.py`
- `tests/unit/test_scd2_merge.py`
- `tests/unit/test_scd2_schema_augmentation.py`
- `tests/unit/test_current_view_provider.py`

**Docs**
- `docs/proposals/scd_type2_support.md` — updated with strategy registration design
- `docs/proposals/scd_type2_implementation_plan.md` _(new)_ — implementation plan artifact

**Agent infrastructure** _(separate commit)_
- `.agent-memory/`, `.github/agents/`, `.github/skills/`, `.agents/`, `AGENTS.md`, `CLAUDE.md` — multi-agent workflow scaffolding

## Acceptance Criteria
- [x] `DeltaMergeStrategy` ABC with `apply(delta_table, df, entity, merge_condition)` signature
- [x] `DeltaMergeStrategies` registry with `@register(name=...)` decorator (raises on duplicate)
- [x] `SCD1MergeStrategy` registered as `"scd1"` — default; existing behaviour preserved
- [x] `SCD2MergeStrategy` registered as `"scd2"` — staged-updates: close current row, insert new version
- [x] `_merge_to_delta_table` resolves strategy by name; no internal branching
- [x] `scd_config_from_tags(entity)` extracts and validates `scd.*` tags into `SCDConfig`
- [x] Schema auto-augmented with `__effective_from`, `__effective_to`, `__is_current` for SCD2 entities
- [x] Companion entity `{entityid}.current` auto-registered and filters to `is_current=true`
- [x] Existing entities without `scd.type` tag are unaffected
- [x] Unit tests cover all above behaviours

## Review
**Verdict:** APPROVED WITH NOTES (internal reviewer, 2026-04-29)

Notes addressed before merge to this branch:
1. Added explanatory comment in `_execute_scd2_merge` for unchanged-row Group B exclusion
2. Explicit boolean filter: `col(cfg.is_current_column) == lit(True)`
3. Companion name aligned to spec: `f"{base.name} (current)"`

**Test results:** 57 new tests passed, 1080 total passing (`poe test-unit` + `poe test-quick`)

## Task
TASK-ID: TASK-20260429-001

Closes #63
