### PR TITLE
feat(TASK-20260430-004): SCD2 Phase 4 — close_on_missing + optimize_unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to spark-kindling are documented here.
 ## [Unreleased]
 
 ### Added
+- `scd.close_on_missing: "true"` tag on SCD2 entities — rows absent from the source batch are logically closed (`__effective_to = now`, `__is_current = false`) via `whenNotMatchedBySourceUpdate`; safe for full-snapshot sources (TASK-20260430-004, #83)
+- `scd.optimize_unchanged: "true"` tag on SCD2 entities — SHA2-256 hash comparison over tracked columns replaces per-column change detection; reduces merge cost for large dimensions with many unchanged rows (TASK-20260430-004, #84)
 - CLI Quick Start section in `README.md` — covers `kindling new` → `poetry install` → `kindling run` end-to-end local workflow (TASK-20260430-003)
 - Local Development section in `docs/setup_guide.md` — placed before cloud-platform sections so developers can run locally without cloud credentials (TASK-20260430-003)
 - Sentinel-based missing-key debug logging to `DynaconfConfig.get()` in `spark_config.py` — surfaces misconfigured keys without raising at call-time (TASK-20260430-003)

--- a/packages/kindling/data_entities.py
+++ b/packages/kindling/data_entities.py
@@ -57,6 +57,8 @@ class SCDConfig:
     is_current_column: str
     current_entity_id: str
     routing_key_method: str
+    close_on_missing: bool = False
+    optimize_unchanged: bool = False
 
 
 @dataclass
@@ -261,6 +263,8 @@ def scd_config_from_tags(entity: EntityMetadata) -> SCDConfig:
         is_current_column=tags.get("scd.current_col", "__is_current"),
         current_entity_id=tags.get("scd.current_entity_id", f"{entity.entityid}.current"),
         routing_key_method=routing_key_method,
+        close_on_missing=tags.get("scd.close_on_missing", "false").strip().lower() == "true",
+        optimize_unchanged=tags.get("scd.optimize_unchanged", "false").strip().lower() == "true",
     )
 
 

--- a/packages/kindling/entity_provider_delta.py
+++ b/packages/kindling/entity_provider_delta.py
@@ -165,17 +165,12 @@ def _routing_key_target_sql(business_keys: list[str], method: str) -> str:
 
 
 def _hash_tracked_columns(tracked_columns: list[str]):
-    """SHA2-256 hash over sorted tracked columns for change detection."""
-    return sha2(
-        concat_ws(
-            "|",
-            *[
-                coalesce(col(c).cast("string"), lit(_SCD2_NULL_SENTINEL))
-                for c in sorted(tracked_columns)
-            ],
-        ),
-        256,
-    )
+    """SHA2-256 hash over sorted tracked columns for change detection.
+
+    Uses to_json(struct(...)) to avoid delimiter-collision issues that arise
+    with concat_ws when column values contain the separator character.
+    """
+    return sha2(to_json(struct(*[col(c) for c in sorted(tracked_columns)])), 256)
 
 
 def _execute_scd2_merge(delta_table, df: DataFrame, entity) -> None:
@@ -296,7 +291,7 @@ def _execute_scd2_merge(delta_table, df: DataFrame, entity) -> None:
             )
             .whenNotMatchedInsert(values=insert_values)
             .whenNotMatchedBySourceUpdate(
-                condition=f"target.`{cfg.is_current_column}` = true",
+                condition=f"{_quote_sql_identifier(cfg.is_current_column, 'target')} = true",
                 set=close_set,
             )
             .execute()

--- a/packages/kindling/entity_provider_delta.py
+++ b/packages/kindling/entity_provider_delta.py
@@ -21,6 +21,7 @@ from kindling.signaling import SignalEmitter, SignalProvider
 
 _SCD2_NULL_SENTINEL = "__null__"
 _SCD2_MERGE_KEY_COLUMN = "__merge_key"
+_SCD2_CHANGED_COLUMN = "__scd2_changed"
 from kindling.spark_config import *
 from kindling.spark_log_provider import *
 
@@ -163,6 +164,20 @@ def _routing_key_target_sql(business_keys: list[str], method: str) -> str:
     return f"sha2(to_json(named_struct({', '.join(named_struct_args)})), 256)"
 
 
+def _hash_tracked_columns(tracked_columns: list[str]):
+    """SHA2-256 hash over sorted tracked columns for change detection."""
+    return sha2(
+        concat_ws(
+            "|",
+            *[
+                coalesce(col(c).cast("string"), lit(_SCD2_NULL_SENTINEL))
+                for c in sorted(tracked_columns)
+            ],
+        ),
+        256,
+    )
+
+
 def _execute_scd2_merge(delta_table, df: DataFrame, entity) -> None:
     """Execute an SCD Type 2 staged-updates merge for a Delta table."""
     if _SCD2_MERGE_KEY_COLUMN in df.columns:
@@ -182,27 +197,76 @@ def _execute_scd2_merge(delta_table, df: DataFrame, entity) -> None:
         for column in df.columns
         if column not in business_keys and column not in temporal_columns
     ]
-    change_condition = _build_null_safe_change_condition("source", "target", tracked_columns)
     current_target = (
         delta_table.toDF().filter(col(cfg.is_current_column) == lit(True)).alias("target")
     )
 
-    changed_rows = (
-        df.alias("source")
-        .join(current_target, on=business_keys, how="inner")
-        .where(change_condition)
-        .select("source.*")
-    )
+    # ── Step 1: compute changed_rows ─────────────────────────────────────
+    if cfg.optimize_unchanged and tracked_columns:
+        # Hash-based change detection — single pass instead of N column comparisons.
+        # source_hashed / target_hashed are kept in scope for the close_on_missing
+        # sentinel computation below when both features are active.
+        hash_expr = _hash_tracked_columns(tracked_columns)
+        source_hashed = df.withColumn("__scd2_src_hash", hash_expr)
+        target_hashed = current_target.withColumn("__scd2_tgt_hash", hash_expr)
+        changed_rows = (
+            source_hashed.alias("source")
+            .join(target_hashed, on=business_keys, how="inner")
+            .where(col("__scd2_src_hash") != col("__scd2_tgt_hash"))
+            .select("source.*")
+        )
+    else:
+        source_hashed = None
+        target_hashed = None
+        change_condition = _build_null_safe_change_condition("source", "target", tracked_columns)
+        changed_rows = (
+            df.alias("source")
+            .join(current_target, on=business_keys, how="inner")
+            .where(change_condition)
+            .select("source.*")
+        )
+
     new_rows = df.join(current_target, on=business_keys, how="left_anti")
     # [integrator] unchanged rows omitted from Group B — closing a row that hasn't changed creates a false history entry — TASK-20260429-001
     rows_to_close_or_insert = changed_rows.unionByName(new_rows, allowMissingColumns=True)
 
+    # ── Step 2: build staged ──────────────────────────────────────────────
     insert_rows = changed_rows.withColumn(_SCD2_MERGE_KEY_COLUMN, lit(None).cast("string"))
     keyed_rows = rows_to_close_or_insert.withColumn(
         _SCD2_MERGE_KEY_COLUMN, _routing_key_column_expr(business_keys, cfg.routing_key_method)
     )
-    staged = insert_rows.unionByName(keyed_rows, allowMissingColumns=True)
 
+    if cfg.close_on_missing:
+        # Add sentinel rows for unchanged-but-present keys so whenNotMatchedBySource
+        # does NOT fire on them — only truly absent keys should be closed.
+        if source_hashed is not None:
+            # Reuse hashed frames from the optimize_unchanged branch above.
+            unchanged_rows = (
+                source_hashed.alias("source")
+                .join(target_hashed, on=business_keys, how="inner")
+                .where(col("__scd2_src_hash") == col("__scd2_tgt_hash"))
+                .select("source.*")
+            )
+        else:
+            unchanged_rows = (
+                df.alias("source")
+                .join(current_target, on=business_keys, how="inner")
+                .where(f"NOT ({change_condition})")
+                .select("source.*")
+            )
+        sentinels = unchanged_rows.withColumn(
+            _SCD2_MERGE_KEY_COLUMN, _routing_key_column_expr(business_keys, cfg.routing_key_method)
+        ).withColumn(_SCD2_CHANGED_COLUMN, lit(False))
+        keyed_rows = keyed_rows.withColumn(_SCD2_CHANGED_COLUMN, lit(True))
+        insert_rows = insert_rows.withColumn(_SCD2_CHANGED_COLUMN, lit(False))
+        staged = insert_rows.unionByName(
+            keyed_rows.unionByName(sentinels, allowMissingColumns=True),
+            allowMissingColumns=True,
+        )
+    else:
+        staged = insert_rows.unionByName(keyed_rows, allowMissingColumns=True)
+
+    # ── Step 3: insert values and merge condition (unchanged) ─────────────
     source_columns = [column for column in df.columns if column not in temporal_columns]
     insert_values = {
         _quote_sql_identifier(column): _quote_sql_identifier(column, "staged")
@@ -216,19 +280,37 @@ def _execute_scd2_merge(delta_table, df: DataFrame, entity) -> None:
         f"{target_routing_key_sql} = staged.__merge_key "
         f"AND {_quote_sql_identifier(cfg.is_current_column, 'target')} = true"
     )
+    close_set = {
+        _quote_sql_identifier(cfg.effective_to_column): "current_timestamp()",
+        _quote_sql_identifier(cfg.is_current_column): "false",
+    }
 
-    (
-        delta_table.alias("target")
-        .merge(source=staged.alias("staged"), condition=merge_condition)
-        .whenMatchedUpdate(
-            set={
-                _quote_sql_identifier(cfg.effective_to_column): "current_timestamp()",
-                _quote_sql_identifier(cfg.is_current_column): "false",
-            }
+    # ── Step 4: execute merge ─────────────────────────────────────────────
+    if cfg.close_on_missing:
+        (
+            delta_table.alias("target")
+            .merge(source=staged.alias("staged"), condition=merge_condition)
+            .whenMatchedUpdate(
+                condition=f"staged.`{_SCD2_CHANGED_COLUMN}` = true",
+                set=close_set,
+            )
+            .whenNotMatchedInsert(values=insert_values)
+            .whenNotMatchedBySourceUpdate(
+                condition=f"target.`{cfg.is_current_column}` = true",
+                set=close_set,
+            )
+            .execute()
         )
-        .whenNotMatchedInsert(values=insert_values)
-        .execute()
-    )
+    else:
+        (
+            delta_table.alias("target")
+            .merge(source=staged.alias("staged"), condition=merge_condition)
+            .whenMatchedUpdate(
+                set=close_set,
+            )
+            .whenNotMatchedInsert(values=insert_values)
+            .execute()
+        )
 
 
 class DeltaAccessMode:

--- a/tests/unit/test_scd2_merge.py
+++ b/tests/unit/test_scd2_merge.py
@@ -195,7 +195,172 @@ def test_execute_scd2_merge_routing_key_concat_column_expr_uses_null_sentinel():
     assert "__null__" in str(routing_expr)
 
 
-def test_execute_scd2_merge_does_not_implement_close_on_missing_in_phase_1():
-    _, merge_builder, _, _ = _execute({"scd.close_on_missing": "true"})
+# ── close_on_missing tests ────────────────────────────────────────────────────
+
+
+def _mock_source_df_close_on_missing():
+    """Mock source DataFrame for close_on_missing=True (3 joins: changed, new, unchanged)."""
+    df = MagicMock(name="source_df")
+    df.columns = ["customer_id", "name", "status"]
+
+    join_changed = MagicMock(name="join_changed")
+    new_rows = MagicMock(name="new_rows")
+    join_unchanged = MagicMock(name="join_unchanged")
+    changed_rows = MagicMock(name="changed_rows")
+    unchanged_rows = MagicMock(name="unchanged_rows")
+
+    df.alias.return_value = df
+    df.join.side_effect = [join_changed, new_rows, join_unchanged]
+    join_changed.where.return_value.select.return_value = changed_rows
+    join_unchanged.where.return_value.select.return_value = unchanged_rows
+
+    rows_to_close_or_insert = MagicMock(name="rows_to_close_or_insert")
+    changed_rows.unionByName.return_value = rows_to_close_or_insert
+
+    insert_rows_wk = MagicMock(name="insert_rows_wk")
+    insert_rows = MagicMock(name="insert_rows")
+    keyed_rows_wk = MagicMock(name="keyed_rows_wk")
+    keyed_rows = MagicMock(name="keyed_rows")
+    sentinels_wk = MagicMock(name="sentinels_wk")
+    sentinels = MagicMock(name="sentinels")
+
+    changed_rows.withColumn.return_value = insert_rows_wk
+    insert_rows_wk.withColumn.return_value = insert_rows
+    rows_to_close_or_insert.withColumn.return_value = keyed_rows_wk
+    keyed_rows_wk.withColumn.return_value = keyed_rows
+    unchanged_rows.withColumn.return_value = sentinels_wk
+    sentinels_wk.withColumn.return_value = sentinels
+
+    keyed_plus_sentinels = MagicMock(name="keyed_plus_sentinels")
+    staged = MagicMock(name="staged")
+    keyed_rows.unionByName.return_value = keyed_plus_sentinels
+    insert_rows.unionByName.return_value = staged
+    staged.alias.return_value = staged
+
+    return df
+
+
+def _execute_com(extra_tags=None):
+    """Run _execute_scd2_merge with close_on_missing=True."""
+    delta_table, merge_builder = _mock_delta_table()
+    df = _mock_source_df_close_on_missing()
+    tags = {"scd.close_on_missing": "true", **(extra_tags or {})}
+    _execute_scd2_merge(delta_table, df, _entity(tags))
+    return delta_table, merge_builder, df
+
+
+def test_close_on_missing_calls_whenNotMatchedBySourceUpdate():
+    _, merge_builder, _ = _execute_com()
+
+    merge_builder.whenNotMatchedBySourceUpdate.assert_called_once()
+
+
+def test_close_on_missing_whenNotMatchedBySourceUpdate_condition_targets_current_rows():
+    _, merge_builder, _ = _execute_com()
+
+    kwargs = merge_builder.whenNotMatchedBySourceUpdate.call_args.kwargs
+    assert "__is_current" in kwargs["condition"]
+
+
+def test_close_on_missing_whenNotMatchedBySourceUpdate_set_closes_row():
+    _, merge_builder, _ = _execute_com()
+
+    kwargs = merge_builder.whenNotMatchedBySourceUpdate.call_args.kwargs
+    assert kwargs["set"]["`__effective_to`"] == "current_timestamp()"
+    assert kwargs["set"]["`__is_current`"] == "false"
+
+
+def test_close_on_missing_whenMatchedUpdate_has_changed_column_condition():
+    _, merge_builder, _ = _execute_com()
+
+    kwargs = merge_builder.whenMatchedUpdate.call_args.kwargs
+    assert "__scd2_changed" in kwargs["condition"]
+
+
+def test_close_on_missing_false_does_not_call_whenNotMatchedBySourceUpdate():
+    _, merge_builder, _, _ = _execute()
 
     merge_builder.whenNotMatchedBySourceUpdate.assert_not_called()
+
+
+def test_close_on_missing_false_whenMatchedUpdate_has_no_condition():
+    _, merge_builder, _, _ = _execute()
+
+    merge_builder.whenMatchedUpdate.assert_called_once_with(
+        set={"`__effective_to`": "current_timestamp()", "`__is_current`": "false"}
+    )
+
+
+# ── optimize_unchanged tests ──────────────────────────────────────────────────
+
+
+def _mock_source_df_optimize_unchanged():
+    """Mock source DataFrame for optimize_unchanged=True (hash-based changed_rows)."""
+    df = MagicMock(name="source_df")
+    df.columns = ["customer_id", "name", "status"]
+
+    source_hashed = MagicMock(name="source_hashed")
+    new_rows = MagicMock(name="new_rows")
+    changed_rows = MagicMock(name="changed_rows")
+    rows_to_close_or_insert = MagicMock(name="rows_to_close_or_insert")
+    insert_rows = MagicMock(name="insert_rows")
+    keyed_rows = MagicMock(name="keyed_rows")
+    staged = MagicMock(name="staged")
+
+    df.withColumn.return_value = source_hashed
+    df.join.return_value = new_rows
+
+    source_hashed.alias.return_value = source_hashed
+    source_hashed.join.return_value.where.return_value.select.return_value = changed_rows
+
+    changed_rows.unionByName.return_value = rows_to_close_or_insert
+    changed_rows.withColumn.return_value = insert_rows
+    rows_to_close_or_insert.withColumn.return_value = keyed_rows
+    insert_rows.unionByName.return_value = staged
+    staged.alias.return_value = staged
+
+    return df
+
+
+def _execute_ou(extra_tags=None):
+    """Run _execute_scd2_merge with optimize_unchanged=True."""
+    delta_table, merge_builder = _mock_delta_table()
+    df = _mock_source_df_optimize_unchanged()
+    tags = {"scd.optimize_unchanged": "true", **(extra_tags or {})}
+    _execute_scd2_merge(delta_table, df, _entity(tags))
+    return delta_table, merge_builder, df
+
+
+def test_optimize_unchanged_adds_src_hash_column_to_df():
+    _, _, df = _execute_ou()
+
+    col_names = [call.args[0] for call in df.withColumn.call_args_list]
+    assert "__scd2_src_hash" in col_names
+
+
+def test_optimize_unchanged_false_does_not_add_src_hash_column():
+    _, _, df, _ = _execute()
+
+    col_names = [call.args[0] for call in df.withColumn.call_args_list]
+    assert "__scd2_src_hash" not in col_names
+
+
+def test_optimize_unchanged_hash_expr_uses_sha2():
+    _, _, df = _execute_ou()
+
+    hash_call = next(c for c in df.withColumn.call_args_list if c.args[0] == "__scd2_src_hash")
+    assert "sha2" in str(hash_call.args[1])
+
+
+def test_optimize_unchanged_does_not_call_whenNotMatchedBySourceUpdate():
+    _, merge_builder, _ = _execute_ou()
+
+    merge_builder.whenNotMatchedBySourceUpdate.assert_not_called()
+
+
+def test_optimize_unchanged_whenMatchedUpdate_has_no_condition():
+    _, merge_builder, _ = _execute_ou()
+
+    merge_builder.whenMatchedUpdate.assert_called_once_with(
+        set={"`__effective_to`": "current_timestamp()", "`__is_current`": "false"}
+    )

--- a/tests/unit/test_scd2_merge.py
+++ b/tests/unit/test_scd2_merge.py
@@ -364,3 +364,86 @@ def test_optimize_unchanged_whenMatchedUpdate_has_no_condition():
     merge_builder.whenMatchedUpdate.assert_called_once_with(
         set={"`__effective_to`": "current_timestamp()", "`__is_current`": "false"}
     )
+
+
+# ── both flags together ───────────────────────────────────────────────────────
+
+
+def _mock_source_df_both_flags():
+    """Mock for optimize_unchanged=True + close_on_missing=True.
+
+    source_hashed.join is called twice:
+      call 1 → hash != tgt_hash → changed_rows (where clause differs)
+      call 2 → hash == tgt_hash → unchanged_rows
+    """
+    df = MagicMock(name="source_df")
+    df.columns = ["customer_id", "name", "status"]
+
+    source_hashed = MagicMock(name="source_hashed")
+    new_rows = MagicMock(name="new_rows")
+    changed_rows = MagicMock(name="changed_rows")
+    unchanged_rows = MagicMock(name="unchanged_rows")
+
+    df.withColumn.return_value = source_hashed
+    df.join.return_value = new_rows
+
+    join_changed = MagicMock(name="join_changed")
+    join_unchanged = MagicMock(name="join_unchanged")
+    source_hashed.alias.return_value = source_hashed
+    source_hashed.join.side_effect = [join_changed, join_unchanged]
+    join_changed.where.return_value.select.return_value = changed_rows
+    join_unchanged.where.return_value.select.return_value = unchanged_rows
+
+    rows_to_close_or_insert = MagicMock(name="rows_to_close_or_insert")
+    changed_rows.unionByName.return_value = rows_to_close_or_insert
+
+    insert_rows_wk = MagicMock(name="insert_rows_wk")
+    insert_rows = MagicMock(name="insert_rows")
+    keyed_rows_wk = MagicMock(name="keyed_rows_wk")
+    keyed_rows = MagicMock(name="keyed_rows")
+    sentinels_wk = MagicMock(name="sentinels_wk")
+    sentinels = MagicMock(name="sentinels")
+
+    changed_rows.withColumn.return_value = insert_rows_wk
+    insert_rows_wk.withColumn.return_value = insert_rows
+    rows_to_close_or_insert.withColumn.return_value = keyed_rows_wk
+    keyed_rows_wk.withColumn.return_value = keyed_rows
+    unchanged_rows.withColumn.return_value = sentinels_wk
+    sentinels_wk.withColumn.return_value = sentinels
+
+    keyed_plus_sentinels = MagicMock(name="keyed_plus_sentinels")
+    staged = MagicMock(name="staged")
+    keyed_rows.unionByName.return_value = keyed_plus_sentinels
+    insert_rows.unionByName.return_value = staged
+    staged.alias.return_value = staged
+
+    return df
+
+
+def _execute_both():
+    delta_table, merge_builder = _mock_delta_table()
+    df = _mock_source_df_both_flags()
+    tags = {"scd.close_on_missing": "true", "scd.optimize_unchanged": "true"}
+    _execute_scd2_merge(delta_table, df, _entity(tags))
+    return delta_table, merge_builder, df
+
+
+def test_both_flags_calls_whenNotMatchedBySourceUpdate():
+    _, merge_builder, _ = _execute_both()
+
+    merge_builder.whenNotMatchedBySourceUpdate.assert_called_once()
+
+
+def test_both_flags_uses_hash_for_changed_rows():
+    _, _, df = _execute_both()
+
+    col_names = [call.args[0] for call in df.withColumn.call_args_list]
+    assert "__scd2_src_hash" in col_names
+
+
+def test_both_flags_sentinel_uses_second_hash_join_not_change_condition():
+    """Unchanged rows come from hash comparison, not _build_null_safe_change_condition."""
+    _, _, df = _execute_both()
+
+    source_hashed = df.withColumn.return_value
+    assert source_hashed.join.call_count == 2

--- a/tests/unit/test_scd_config.py
+++ b/tests/unit/test_scd_config.py
@@ -173,3 +173,43 @@ def test_validate_scd_config_current_entity_id_empty_raises_value_error():
 
     with pytest.raises(ValueError, match="scd.current_entity_id must"):
         _validate_scd_config(entity)
+
+
+def test_scd_config_from_tags_close_on_missing_false_by_default():
+    cfg = scd_config_from_tags(make_entity(tags={"scd.type": "2"}))
+
+    assert cfg.close_on_missing is False
+
+
+def test_scd_config_from_tags_close_on_missing_true_when_tag_set():
+    cfg = scd_config_from_tags(make_entity(tags={"scd.type": "2", "scd.close_on_missing": "true"}))
+
+    assert cfg.close_on_missing is True
+
+
+def test_scd_config_from_tags_close_on_missing_case_insensitive():
+    cfg = scd_config_from_tags(make_entity(tags={"scd.type": "2", "scd.close_on_missing": "True"}))
+
+    assert cfg.close_on_missing is True
+
+
+def test_scd_config_from_tags_optimize_unchanged_false_by_default():
+    cfg = scd_config_from_tags(make_entity(tags={"scd.type": "2"}))
+
+    assert cfg.optimize_unchanged is False
+
+
+def test_scd_config_from_tags_optimize_unchanged_true_when_tag_set():
+    cfg = scd_config_from_tags(
+        make_entity(tags={"scd.type": "2", "scd.optimize_unchanged": "true"})
+    )
+
+    assert cfg.optimize_unchanged is True
+
+
+def test_scd_config_from_tags_optimize_unchanged_case_insensitive():
+    cfg = scd_config_from_tags(
+        make_entity(tags={"scd.type": "2", "scd.optimize_unchanged": "TRUE"})
+    )
+
+    assert cfg.optimize_unchanged is True


### PR DESCRIPTION
## What

Implements two deferred Phase 4 SCD2 features (closes #83, closes #84).

**`scd.close_on_missing: "true"`** — rows absent from the source batch are logically closed: `__effective_to = now`, `__is_current = false`. Designed for full-snapshot sources where a missing key means "deleted upstream." Default `false` leaves absent rows open (correct for incremental feeds).

**`scd.optimize_unchanged: "true"`** — replaces per-column `_build_null_safe_change_condition` with a single SHA2-256 hash over sorted tracked columns for change detection. Reduces merge cost for large dimensions with many unchanged rows. Default `false` preserves existing behavior.

## Why

Both were explicitly deferred from Phase 4 in PR #77. Phase 4 items are now the only remaining SCD2 work.

## Changes

- `packages/kindling/data_entities.py` — `SCDConfig` gains `close_on_missing: bool = False` and `optimize_unchanged: bool = False`; `scd_config_from_tags()` parses both tags
- `packages/kindling/entity_provider_delta.py` — new `_SCD2_CHANGED_COLUMN` constant; new `_hash_tracked_columns()` helper; `_execute_scd2_merge` rewritten to branch on both flags with shared hash frames for the interaction case
- `tests/unit/test_scd2_merge.py` — removed Phase 1 deferral test; added 11 new tests (close_on_missing, optimize_unchanged, both together)
- `tests/unit/test_scd_config.py` — 6 new tag parsing tests
- `CHANGELOG.md` — entries for both features

## Key design note: interaction safety

When both flags are active, `optimize_unchanged` pre-computes `source_hashed`/`target_hashed` in scope. The `close_on_missing` sentinel computation reuses those frames to find unchanged rows via hash equality — so unchanged rows aren't mistaken for absent rows. Both features are internal to `_execute_scd2_merge`; no pre-filtering in `SCD2MergeStrategy.apply()`.

## Acceptance Criteria

- [x] `scd.close_on_missing: "true"` calls `whenNotMatchedBySourceUpdate` with `target.__is_current = true` guard
- [x] `scd.close_on_missing: "false"` (default) does not call `whenNotMatchedBySourceUpdate`
- [x] `scd.optimize_unchanged: "true"` adds `__scd2_src_hash` via hash expression to df
- [x] `scd.optimize_unchanged: "false"` (default) does not add hash column
- [x] Both flags active: hash frames reused, `whenNotMatchedBySourceUpdate` still fires correctly
- [x] Existing Phase 1 SCD2 tests all pass (1131 total)

## Review

APPROVED WITH NOTES — 2 nits (both non-blocking): `_SCD2_CHANGED_COLUMN` position between imports (consistent with existing constants); `__scd2_src_hash` column propagates through staged (Delta ignores extra source columns in explicit set/values operations).

## Task

TASK-20260430-004 — closes #83, #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)