### PR TITLE
feat: print env check hint after kindling job init, fail fast in job create (kindling-43h)

### DIFF
--- a/packages/kindling_cli/kindling_cli/cli.py
+++ b/packages/kindling_cli/kindling_cli/cli.py
@@ -1000,6 +1000,11 @@ _AZURE_SP_VARS: List[str] = ["AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_CLIENT
 _AZURE_SP_PLATFORMS: frozenset = frozenset({"fabric", "synapse"})
 
 
+def _missing_platform_vars(platform: str) -> List[str]:
+    """Return required env vars for platform that are not currently set."""
+    return [var for var in _PLATFORM_BASE_VARS.get(platform, []) if not os.getenv(var)]
+
+
 def _check_java() -> Tuple[bool, str]:
     import subprocess
 
@@ -2290,6 +2295,10 @@ def job_init(
     if resolved_platform:
         source = "explicit" if platform_explicit else "auto-detected from environment"
         click.echo(f"Platform: {resolved_platform} ({source})")
+        click.echo(
+            f"Tip: Run `kindling env check --platform {resolved_platform}`"
+            " to verify credentials before creating the job."
+        )
     else:
         click.echo(
             "Platform not detected — set FABRIC_WORKSPACE_ID, SYNAPSE_WORKSPACE_NAME, "
@@ -2315,6 +2324,13 @@ def job_create(config_path: Path, platform: Optional[str]) -> None:
         raise click.ClickException(
             "Unable to determine platform. Set --platform or one of "
             "FABRIC_WORKSPACE_ID, SYNAPSE_WORKSPACE_NAME, DATABRICKS_HOST."
+        )
+
+    missing = _missing_platform_vars(resolved_platform)
+    if missing:
+        raise click.ClickException(
+            f"Missing required environment variables for {resolved_platform}: {', '.join(missing)}.\n"
+            f"Run `kindling env check --platform {resolved_platform}` to verify your credentials."
         )
 
     job_config = _load_mapping_file(config_path, "job config")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -567,6 +567,8 @@ def test_app_deploy_json_output_includes_storage_path(monkeypatch):
 
 
 def test_job_create_loads_yaml_and_prints_structured_result(monkeypatch):
+    monkeypatch.setenv("SYNAPSE_WORKSPACE_NAME", "test-workspace")
+
     class FakeAPI:
         def create_job(self, job_name, job_config):
             assert job_name == "nightly-demo"
@@ -1166,6 +1168,73 @@ def test_job_init_produces_valid_yaml():
         assert isinstance(parsed, dict)
         assert parsed["job_name"] == "my-job"
         assert parsed["app_name"] == "my-app"
+
+
+def test_job_init_prints_env_check_hint_for_explicit_platform():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli, ["job", "init", "--name", "j", "--app", "a", "--platform", "fabric"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "kindling env check --platform fabric" in result.output
+
+
+def test_job_init_prints_env_check_hint_for_auto_detected_platform(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_HOST", "https://adb-123.azuredatabricks.net")
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["job", "init", "--name", "j", "--app", "a"])
+
+        assert result.exit_code == 0, result.output
+        assert "kindling env check --platform databricks" in result.output
+
+
+def test_job_init_omits_env_check_hint_when_no_platform():
+    runner = CliRunner()
+    env = {"FABRIC_WORKSPACE_ID": "", "SYNAPSE_WORKSPACE_NAME": "", "DATABRICKS_HOST": ""}
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            ["job", "init", "--name", "j", "--app", "a"],
+            env=env,
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "env check" not in result.output
+
+
+def test_job_create_fails_fast_when_platform_vars_missing(monkeypatch):
+    monkeypatch.delenv("DATABRICKS_HOST", raising=False)
+    monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("job.yaml").write_text("job_name: my-job\n", encoding="utf-8")
+        result = runner.invoke(cli, ["job", "create", "job.yaml", "--platform", "databricks"])
+
+        assert result.exit_code != 0
+        assert "Missing required environment variables" in result.output
+        assert "DATABRICKS_HOST" in result.output
+        assert "kindling env check --platform databricks" in result.output
+
+
+def test_job_create_does_not_fail_fast_when_platform_vars_present(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_HOST", "https://adb-123.azuredatabricks.net")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "token-abc")
+
+    class FakeAPI:
+        def create_job(self, job_name, job_config):
+            return {"job_id": "j-1", "job_name": job_name}
+
+    monkeypatch.setattr("kindling_cli.cli._create_platform_api", lambda p: (FakeAPI(), p))
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("job.yaml").write_text("job_name: my-job\n", encoding="utf-8")
+        result = runner.invoke(cli, ["job", "create", "job.yaml", "--platform", "databricks"])
+
+        assert result.exit_code == 0, result.output
+        assert "Missing" not in result.output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- After `kindling job init` succeeds with a resolved platform (explicit or auto-detected), prints: `Tip: Run \`kindling env check --platform <platform>\` to verify credentials before creating the job.`
- Adds `_missing_platform_vars` helper that checks `_PLATFORM_BASE_VARS` for unset env vars
- `kindling job create` now fails fast with a clear message listing missing env vars before making any API calls

## Test plan
- [ ] CI passes
- [ ] AI review comments addressed

Resolves: kindling-43h

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>