### PR TITLE
fix: wrap kindling run errors with actionable guidance (kindling-6m3)

### DIFF
--- a/packages/kindling_cli/kindling_cli/cli.py
+++ b/packages/kindling_cli/kindling_cli/cli.py
@@ -411,7 +411,20 @@ def _load_app_module(app_path: Path, env: Optional[str], config_dir: Optional[Pa
             raise click.ClickException(f"Could not load app.py at {app_path}")
         module = importlib.util.module_from_spec(spec)
         sys.modules[module_key] = module
-        spec.loader.exec_module(module)
+        try:
+            spec.loader.exec_module(module)
+        except SyntaxError as exc:
+            raise click.ClickException(
+                f"Failed to import app.py: {exc}\n"
+                f"  File: {app_path}\n"
+                '  Hint: Check for syntax errors — run: python -c "import app" to see the full traceback.'
+            ) from exc
+        except ImportError as exc:
+            raise click.ClickException(
+                f"Failed to import app.py: {exc}\n"
+                f"  File: {app_path}\n"
+                '  Hint: Check for syntax errors — run: python -c "import app" to see the full traceback.'
+            ) from exc
 
         initialize = getattr(module, "initialize", None)
         if initialize is None:
@@ -590,6 +603,11 @@ def run_pipe(
             f"Note: --env {env} controls config loading only. "
             "To run remotely use: kindling job run <job_id>"
         )
+    if config_dir is None and not Path("config/settings.yaml").exists():
+        raise click.ClickException(
+            "Config file not found at config/settings.yaml.\n"
+            "  Hint: Run `kindling config init` to generate a starter config, or use --config <path>."
+        )
     resolved_app = _discover_app_py(app_path)
     _load_app_module(resolved_app, resolved_env, config_dir)
 
@@ -597,7 +615,11 @@ def run_pipe(
     pipe = registry.get_pipe_definition(pipe_id)
     if pipe is None:
         available = ", ".join(registry.get_pipe_ids()) or "(none registered)"
-        raise click.ClickException(f"Pipe '{pipe_id}' not found. Available pipes: {available}")
+        raise click.ClickException(
+            f"Pipe '{pipe_id}' not found.\n"
+            f"  Registered pipes: {available}\n"
+            "  Hint: Check for typos, or run `kindling validate` to see all registered pipes."
+        )
 
     click.echo(f"Running pipe: {pipe_id}")
     executer = GlobalInjector.get(DataPipesExecution)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,8 +1,11 @@
 import base64
 import json
+import sys
+import types
 import zipfile
 from pathlib import Path
 
+import click
 import yaml
 from click.testing import CliRunner
 from kindling_cli.cli import (
@@ -10,6 +13,7 @@ from kindling_cli.cli import (
     _find_wheels,
     _generate_bootstrap_notebook,
     _generate_sample_notebook,
+    _load_app_module,
     _render_environment_bootstrap_source,
     _render_starter_notebook_source,
     cli,
@@ -1300,3 +1304,81 @@ class TestEnvCheckPlatform:
             )
         assert "[PASS] platform: databricks" in result.output
         assert "env:DATABRICKS_HOST" in result.output
+
+
+# ---------------------------------------------------------------------------
+# run — actionable error messages (kindling-6m3)
+# ---------------------------------------------------------------------------
+
+
+def test_run_missing_config_gives_actionable_message():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["run", "my_pipe"])
+        assert result.exit_code != 0
+        assert "Config file not found at config/settings.yaml" in result.output
+        assert "kindling config init" in result.output
+        assert "--config" in result.output
+
+
+def test_load_app_module_syntax_error_gives_actionable_message(tmp_path):
+    app_py = tmp_path / "app.py"
+    app_py.write_text("def foo(:\n    pass\n", encoding="utf-8")
+    try:
+        _load_app_module(app_py, "local")
+        assert False, "expected ClickException"
+    except click.ClickException as exc:
+        msg = exc.format_message()
+        assert "Failed to import app.py" in msg
+        assert str(app_py) in msg
+        assert "Hint:" in msg
+
+
+def test_load_app_module_import_error_gives_actionable_message(tmp_path):
+    app_py = tmp_path / "app.py"
+    app_py.write_text("from nonexistent_package_xyz import something\n", encoding="utf-8")
+    try:
+        _load_app_module(app_py, "local")
+        assert False, "expected ClickException"
+    except click.ClickException as exc:
+        msg = exc.format_message()
+        assert "Failed to import app.py" in msg
+        assert str(app_py) in msg
+        assert "Hint:" in msg
+
+
+def test_run_missing_pipe_gives_actionable_message(monkeypatch, tmp_path):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "settings.yaml").write_text("name: test-app\n", encoding="utf-8")
+
+    app_py = tmp_path / "app.py"
+    app_py.write_text("def initialize(env='local'): pass\n", encoding="utf-8")
+
+    fake_registry = types.SimpleNamespace(
+        get_pipe_definition=lambda pipe_id: None,
+        get_pipe_ids=lambda: ["bronze_to_silver", "silver_to_gold"],
+    )
+    fake_injector = types.SimpleNamespace(get=lambda cls: fake_registry)
+
+    fake_kindling_pipes = types.ModuleType("kindling.data_pipes")
+    fake_kindling_pipes.DataPipesRegistry = object
+    fake_kindling_pipes.DataPipesExecution = object
+    fake_kindling_injection = types.ModuleType("kindling.injection")
+    fake_kindling_injection.GlobalInjector = fake_injector
+
+    monkeypatch.setitem(sys.modules, "kindling.data_pipes", fake_kindling_pipes)
+    monkeypatch.setitem(sys.modules, "kindling.injection", fake_kindling_injection)
+    monkeypatch.setattr("kindling_cli.cli._load_app_module", lambda *a, **kw: None)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("config").mkdir()
+        Path("config/settings.yaml").write_text("name: test-app\n", encoding="utf-8")
+        result = runner.invoke(cli, ["run", "slver_to_gold", "--app", str(app_py)])
+
+    assert result.exit_code != 0
+    assert "Pipe 'slver_to_gold' not found" in result.output
+    assert "bronze_to_silver" in result.output
+    assert "silver_to_gold" in result.output
+    assert "kindling validate" in result.output


### PR DESCRIPTION
## Summary
- Catch `SyntaxError`/`ImportError` in `_load_app_module` and surface structured message with file path and hint to check syntax
- Add pre-flight check in `run_pipe` for missing `config/settings.yaml` with hint to run `kindling config init` or pass `--config`
- Restructure pipe-not-found error to list registered pipes and hint to run `kindling validate`

## Test plan
- [ ] `test_run_missing_config_gives_actionable_message` — missing settings.yaml shows hint
- [ ] `test_load_app_module_syntax_error_gives_actionable_message` — syntax errors show file + hint
- [ ] `test_load_app_module_import_error_gives_actionable_message` — import errors show file + hint
- [ ] `test_run_missing_pipe_gives_actionable_message` — pipe-not-found lists registered pipes + hint
- [ ] CI passes

Resolves: kindling-6m3

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>