### PR TITLE
Add ADX entity provider extension

### DIFF
--- a/packages/kindling_adx/README.md
+++ b/packages/kindling_adx/README.md
@@ -1,0 +1,110 @@
+# kindling-adx
+
+Azure Data Explorer entity provider extension for Kindling.
+
+This extension registers `provider_type: adx` as an append-oriented materialization
+target backed by the Azure Data Explorer Spark connector.
+
+## Spark Runtime Package
+
+Install the Kusto Spark connector on the Spark pool or cluster:
+
+```text
+com.microsoft.azure.kusto:kusto-spark_3.0_2.12:7.0.6
+```
+
+The Python wheel does not install this Maven dependency. Managed Spark runtimes
+need the connector available before a Kindling app writes to ADX.
+
+## Entity Tags
+
+Synapse linked service:
+
+```python
+tags={
+    "provider_type": "adx",
+    "provider.auth": "synapse_linked_service",
+    "provider.linked_service": "fawkes_adx",
+    "provider.database": "MyDatabase",
+    "provider.table": "MyTable",
+}
+```
+
+Managed identity:
+
+```python
+tags={
+    "provider_type": "adx",
+    "provider.auth": "managed_identity",
+    "provider.cluster": "https://mycluster.region.kusto.windows.net",
+    "provider.database": "MyDatabase",
+    "provider.table": "MyTable",
+}
+```
+
+User-assigned managed identity:
+
+```python
+tags={
+    "provider_type": "adx",
+    "provider.auth": "managed_identity",
+    "provider.cluster": "https://mycluster.region.kusto.windows.net",
+    "provider.database": "MyDatabase",
+    "provider.table": "MyTable",
+    "provider.managed_identity_client_id": "<client-id>",
+}
+```
+
+Service principal:
+
+```python
+tags={
+    "provider_type": "adx",
+    "provider.auth": "service_principal",
+    "provider.cluster": "https://mycluster.region.kusto.windows.net",
+    "provider.database": "MyDatabase",
+    "provider.table": "MyTable",
+    "provider.client_id": "<app-id>",
+    "provider.client_secret": "<secret>",
+    "provider.tenant_id": "<tenant-id>",
+}
+```
+
+Access token:
+
+```python
+tags={
+    "provider_type": "adx",
+    "provider.auth": "access_token",
+    "provider.cluster": "https://mycluster.region.kusto.windows.net",
+    "provider.database": "MyDatabase",
+    "provider.table": "MyTable",
+    "provider.access_token": "<aad-token>",
+}
+```
+
+## Optional Connector Options
+
+Any tag under `provider.option.*` is passed through to the Spark connector with
+the `provider.option.` prefix removed:
+
+```python
+tags={
+    "provider_type": "adx",
+    "provider.auth": "managed_identity",
+    "provider.cluster": "https://mycluster.region.kusto.windows.net",
+    "provider.database": "MyDatabase",
+    "provider.table": "MyTable",
+    "provider.option.adjustSchema": "GenerateDynamicCsvMapping",
+}
+```
+
+Defaults:
+
+- `provider.write_mode`: `Queued`
+- `provider.table_create_options`: `FailIfNotExist`
+- `provider.assume_exists`: `true`
+
+`provider.assume_exists` defaults to `true` because this first extension version
+is a write target. It avoids requiring read/query permissions just to decide
+whether the Kindling persist path should call append or write.

--- a/packages/kindling_adx/kindling_adx/__init__.py
+++ b/packages/kindling_adx/kindling_adx/__init__.py
@@ -1,0 +1,18 @@
+"""Azure Data Explorer entity provider extension for Kindling."""
+
+from .entity_provider_adx import (
+    ADX_SPARK_CONNECTOR_MAVEN_COORDINATE,
+    AdxEntityProvider,
+    register_provider,
+)
+
+__all__ = [
+    "ADX_SPARK_CONNECTOR_MAVEN_COORDINATE",
+    "AdxEntityProvider",
+    "register_provider",
+]
+
+__version__ = "0.1.0"
+
+
+register_provider()

--- a/packages/kindling_adx/kindling_adx/entity_provider_adx.py
+++ b/packages/kindling_adx/kindling_adx/entity_provider_adx.py
@@ -85,7 +85,7 @@ class AdxEntityProvider(BaseEntityProvider, WritableEntityProvider):
         self, entity_metadata: EntityMetadata, config: Dict[str, Any]
     ) -> Dict[str, str]:
         database = config.get("database")
-        table = config.get("table") or config.get("table_name") or entity_metadata.name
+        table = config.get("table") or config.get("table_name")
         if not database:
             raise ValueError(f"ADX entity '{entity_metadata.entityid}' requires provider.database")
         if not table:
@@ -118,7 +118,11 @@ class AdxEntityProvider(BaseEntityProvider, WritableEntityProvider):
             options.update(self._auth_options(entity_metadata, config, auth_mode))
 
         options.update(self._extra_connector_options(config))
-        return {key: str(value) for key, value in options.items() if value is not None}
+        return {
+            key: self._stringify_option(value)
+            for key, value in options.items()
+            if value is not None
+        }
 
     def _auth_mode(self, config: Dict[str, Any]) -> str:
         return str(config.get("auth", config.get("auth_mode", "managed_identity"))).lower()
@@ -168,6 +172,11 @@ class AdxEntityProvider(BaseEntityProvider, WritableEntityProvider):
             for key, value in config.items()
             if key.startswith(prefix) and value is not None
         }
+
+    def _stringify_option(self, value: Any) -> str:
+        if isinstance(value, bool):
+            return str(value).lower()
+        return str(value)
 
 
 def register_provider(provider_type: str = "adx") -> None:

--- a/packages/kindling_adx/kindling_adx/entity_provider_adx.py
+++ b/packages/kindling_adx/kindling_adx/entity_provider_adx.py
@@ -1,0 +1,176 @@
+"""Azure Data Explorer entity provider for Kindling.
+
+The provider is intentionally append-oriented. ADX is an ingestion target, not a
+Delta table, so merge/upsert semantics should be modeled explicitly by the app
+or by a later provider feature instead of being implied.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from injector import inject
+from kindling.data_entities import EntityMetadata
+from kindling.entity_provider import BaseEntityProvider, WritableEntityProvider
+from kindling.entity_provider_registry import EntityProviderRegistry
+from kindling.injection import GlobalInjector
+from kindling.spark_log_provider import PythonLoggerProvider
+from pyspark.sql import DataFrame
+
+ADX_SPARK_CONNECTOR_MAVEN_COORDINATE = "com.microsoft.azure.kusto:kusto-spark_3.0_2.12:7.0.6"
+GENERIC_FORMAT = "com.microsoft.kusto.spark.datasource"
+SYNAPSE_FORMAT = "com.microsoft.kusto.spark.synapse.datasource"
+
+
+class AdxEntityProvider(BaseEntityProvider, WritableEntityProvider):
+    """Write DataFrames to Azure Data Explorer through the Kusto Spark connector."""
+
+    @inject
+    def __init__(self, logger_provider: PythonLoggerProvider):
+        self.logger = logger_provider.get_logger("AdxEntityProvider")
+
+    def read_entity(self, entity_metadata: EntityMetadata) -> DataFrame:
+        """Read support is intentionally absent from the first extension version."""
+        raise NotImplementedError(
+            "AdxEntityProvider is currently a materialization target only. "
+            "Use it for write_to_entity/append_to_entity, or add read support with kustoQuery."
+        )
+
+    def check_entity_exists(self, entity_metadata: EntityMetadata) -> bool:
+        """Return configured existence assumption for write-path compatibility.
+
+        Kindling's current persist path asks whether the destination exists before
+        choosing append vs write. For ADX both operations route through the same
+        Spark sink, so defaulting to True keeps runtime ingestion append-oriented
+        and avoids requiring read/query permissions for a write-only target.
+        """
+        config = self._get_provider_config(entity_metadata)
+        return bool(config.get("assume_exists", True))
+
+    def write_to_entity(self, df: DataFrame, entity_metadata: EntityMetadata) -> None:
+        """Write DataFrame to ADX using the configured save mode."""
+        config = self._get_provider_config(entity_metadata)
+        mode = str(config.get("save_mode", config.get("mode", "Append")))
+        self._save(df, entity_metadata, mode)
+
+    def append_to_entity(self, df: DataFrame, entity_metadata: EntityMetadata) -> None:
+        """Append DataFrame rows to ADX."""
+        self._save(df, entity_metadata, "Append")
+
+    def _save(self, df: DataFrame, entity_metadata: EntityMetadata, mode: str) -> None:
+        config = self._get_provider_config(entity_metadata)
+        options = self._build_options(entity_metadata, config)
+        source_format = self._source_format(config)
+
+        self.logger.info(
+            "Writing entity '%s' to ADX table '%s' using %s",
+            entity_metadata.entityid,
+            options.get("kustoTable"),
+            source_format,
+        )
+
+        writer = df.write.format(source_format)
+        for key, value in options.items():
+            writer = writer.option(key, value)
+        writer.mode(mode).save()
+
+    def _source_format(self, config: Dict[str, Any]) -> str:
+        if "format" in config:
+            return str(config["format"])
+        if self._auth_mode(config) == "synapse_linked_service":
+            return SYNAPSE_FORMAT
+        return GENERIC_FORMAT
+
+    def _build_options(
+        self, entity_metadata: EntityMetadata, config: Dict[str, Any]
+    ) -> Dict[str, str]:
+        database = config.get("database")
+        table = config.get("table") or config.get("table_name") or entity_metadata.name
+        if not database:
+            raise ValueError(f"ADX entity '{entity_metadata.entityid}' requires provider.database")
+        if not table:
+            raise ValueError(f"ADX entity '{entity_metadata.entityid}' requires provider.table")
+
+        options: Dict[str, Any] = {
+            "kustoDatabase": database,
+            "kustoTable": table,
+            "writeMode": config.get("write_mode", "Queued"),
+            "tableCreateOptions": config.get("table_create_options", "FailIfNotExist"),
+        }
+
+        auth_mode = self._auth_mode(config)
+        if auth_mode == "synapse_linked_service":
+            linked_service = config.get("linked_service")
+            if not linked_service:
+                raise ValueError(
+                    f"ADX entity '{entity_metadata.entityid}' uses synapse_linked_service auth "
+                    "but provider.linked_service is not set"
+                )
+            options["spark.synapse.linkedService"] = linked_service
+        else:
+            cluster = config.get("cluster")
+            if not cluster:
+                raise ValueError(
+                    f"ADX entity '{entity_metadata.entityid}' requires provider.cluster "
+                    f"for auth mode '{auth_mode}'"
+                )
+            options["kustoCluster"] = cluster
+            options.update(self._auth_options(entity_metadata, config, auth_mode))
+
+        options.update(self._extra_connector_options(config))
+        return {key: str(value) for key, value in options.items() if value is not None}
+
+    def _auth_mode(self, config: Dict[str, Any]) -> str:
+        return str(config.get("auth", config.get("auth_mode", "managed_identity"))).lower()
+
+    def _auth_options(
+        self, entity_metadata: EntityMetadata, config: Dict[str, Any], auth_mode: str
+    ) -> Dict[str, Any]:
+        if auth_mode in ("managed_identity", "system_identity", "system_assigned_identity"):
+            options: Dict[str, Any] = {"managedIdentityAuth": "true"}
+            client_id = config.get("managed_identity_client_id") or config.get("client_id")
+            if client_id:
+                options["managedIdentityClientId"] = client_id
+            return options
+
+        if auth_mode == "access_token":
+            token = config.get("access_token")
+            if not token:
+                raise ValueError(
+                    f"ADX entity '{entity_metadata.entityid}' uses access_token auth "
+                    "but provider.access_token is not set"
+                )
+            return {"accessToken": token}
+
+        if auth_mode in ("service_principal", "spn"):
+            required = {
+                "kustoAadAppId": config.get("app_id") or config.get("client_id"),
+                "kustoAadAppSecret": config.get("app_secret") or config.get("client_secret"),
+                "kustoAadAuthorityID": config.get("tenant_id") or config.get("authority_id"),
+            }
+            missing = [key for key, value in required.items() if not value]
+            if missing:
+                raise ValueError(
+                    f"ADX entity '{entity_metadata.entityid}' service principal auth "
+                    f"is missing options: {', '.join(missing)}"
+                )
+            return required
+
+        raise ValueError(
+            f"Unsupported ADX auth mode '{auth_mode}'. Supported modes: "
+            "managed_identity, synapse_linked_service, access_token, service_principal."
+        )
+
+    def _extra_connector_options(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        prefix = "option."
+        return {
+            key[len(prefix) :]: value
+            for key, value in config.items()
+            if key.startswith(prefix) and value is not None
+        }
+
+
+def register_provider(provider_type: str = "adx") -> None:
+    """Register the ADX provider with Kindling's entity provider registry."""
+    registry = GlobalInjector.get(EntityProviderRegistry)
+    registry.register_provider(provider_type, AdxEntityProvider)

--- a/packages/kindling_adx/pyproject.toml
+++ b/packages/kindling_adx/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "kindling-adx"
+version = "0.1.0"
+description = "Azure Data Explorer entity provider extension for Kindling"
+authors = ["SEP Engineering <engineering@sep.com>"]
+license = "MIT"
+readme = "README.md"
+packages = [
+    {include = "kindling_adx"},
+]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+# Kindling and Spark are provided by the target runtime. The ADX Spark connector
+# is a JVM/Spark package and must be installed as a Maven coordinate on the pool.
+
+[tool.poetry.group.dev.dependencies]
+pytest = ">=7.0.0"
+black = ">=23.0.0"

--- a/tests/unit/test_adx_entity_provider_extension.py
+++ b/tests/unit/test_adx_entity_provider_extension.py
@@ -6,7 +6,11 @@ import pytest
 from kindling.data_entities import EntityMetadata
 
 EXTENSION_PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "packages" / "kindling_adx"
-sys.path.insert(0, str(EXTENSION_PACKAGE_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def _extension_package_on_path(monkeypatch):
+    monkeypatch.syspath_prepend(str(EXTENSION_PACKAGE_ROOT))
 
 
 def _entity(tags):
@@ -150,6 +154,7 @@ def test_extra_connector_options_are_passed_through():
             "provider.table": "Orders",
             "provider.option.adjustSchema": "GenerateDynamicCsvMapping",
             "provider.option.clientBatchingLimit": "1024",
+            "provider.option.useManagedIdentity": "true",
         }
     )
 
@@ -157,7 +162,24 @@ def test_extra_connector_options_are_passed_through():
 
     assert writer.options["adjustSchema"] == "GenerateDynamicCsvMapping"
     assert writer.options["clientBatchingLimit"] == "1024"
+    assert writer.options["useManagedIdentity"] == "true"
 
 
 def test_check_entity_exists_defaults_to_true_for_write_only_target():
     assert _provider().check_entity_exists(_entity({})) is True
+
+
+def test_table_is_required():
+    provider = _provider()
+    df = MagicMock()
+    df.write = _Writer()
+    entity = _entity(
+        {
+            "provider.auth": "managed_identity",
+            "provider.cluster": "fawkes.eastus",
+            "provider.database": "Kindling",
+        }
+    )
+
+    with pytest.raises(ValueError, match="provider.table"):
+        provider.append_to_entity(df, entity)

--- a/tests/unit/test_adx_entity_provider_extension.py
+++ b/tests/unit/test_adx_entity_provider_extension.py
@@ -1,0 +1,163 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from kindling.data_entities import EntityMetadata
+
+EXTENSION_PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "packages" / "kindling_adx"
+sys.path.insert(0, str(EXTENSION_PACKAGE_ROOT))
+
+
+def _entity(tags):
+    return EntityMetadata(
+        entityid="gold.orders",
+        name="orders",
+        partition_columns=[],
+        merge_columns=[],
+        tags={"provider_type": "adx", **tags},
+        schema=None,
+    )
+
+
+class _Writer:
+    def __init__(self):
+        self.format_name = None
+        self.options = {}
+        self.mode_name = None
+        self.saved = False
+
+    def format(self, name):
+        self.format_name = name
+        return self
+
+    def option(self, key, value):
+        self.options[key] = value
+        return self
+
+    def mode(self, name):
+        self.mode_name = name
+        return self
+
+    def save(self):
+        self.saved = True
+
+
+def _provider():
+    from kindling_adx import AdxEntityProvider
+
+    logger_provider = MagicMock()
+    logger_provider.get_logger.return_value = MagicMock()
+    return AdxEntityProvider(logger_provider)
+
+
+def test_import_registers_adx_provider():
+    for module_name in list(sys.modules):
+        if module_name == "kindling_adx" or module_name.startswith("kindling_adx."):
+            del sys.modules[module_name]
+
+    registry = MagicMock()
+
+    with patch("kindling.injection.GlobalInjector.get", return_value=registry):
+        import kindling_adx
+
+    provider_class = registry.register_provider.call_args.args[1]
+    assert registry.register_provider.call_args.args[0] == "adx"
+    assert provider_class.__name__ == "AdxEntityProvider"
+
+
+def test_managed_identity_append_uses_generic_kusto_sink_options():
+    provider = _provider()
+    writer = _Writer()
+    df = MagicMock()
+    df.write = writer
+    entity = _entity(
+        {
+            "provider.auth": "managed_identity",
+            "provider.cluster": "https://fawkes.eastus.kusto.windows.net",
+            "provider.database": "Kindling",
+            "provider.table": "Orders",
+        }
+    )
+
+    provider.append_to_entity(df, entity)
+
+    assert writer.format_name == "com.microsoft.kusto.spark.datasource"
+    assert writer.options["kustoCluster"] == "https://fawkes.eastus.kusto.windows.net"
+    assert writer.options["kustoDatabase"] == "Kindling"
+    assert writer.options["kustoTable"] == "Orders"
+    assert writer.options["managedIdentityAuth"] == "true"
+    assert writer.options["writeMode"] == "Queued"
+    assert writer.options["tableCreateOptions"] == "FailIfNotExist"
+    assert writer.mode_name == "Append"
+    assert writer.saved is True
+
+
+def test_synapse_linked_service_uses_synapse_connector_format():
+    provider = _provider()
+    writer = _Writer()
+    df = MagicMock()
+    df.write = writer
+    entity = _entity(
+        {
+            "provider.auth": "synapse_linked_service",
+            "provider.linked_service": "fawkes_adx",
+            "provider.database": "Kindling",
+            "provider.table": "Orders",
+        }
+    )
+
+    provider.append_to_entity(df, entity)
+
+    assert writer.format_name == "com.microsoft.kusto.spark.synapse.datasource"
+    assert writer.options == {
+        "kustoDatabase": "Kindling",
+        "kustoTable": "Orders",
+        "writeMode": "Queued",
+        "tableCreateOptions": "FailIfNotExist",
+        "spark.synapse.linkedService": "fawkes_adx",
+    }
+
+
+def test_service_principal_requires_all_auth_fields():
+    provider = _provider()
+    df = MagicMock()
+    df.write = _Writer()
+    entity = _entity(
+        {
+            "provider.auth": "service_principal",
+            "provider.cluster": "https://fawkes.eastus.kusto.windows.net",
+            "provider.database": "Kindling",
+            "provider.table": "Orders",
+            "provider.client_id": "client-id",
+        }
+    )
+
+    with pytest.raises(ValueError, match="kustoAadAppSecret"):
+        provider.append_to_entity(df, entity)
+
+
+def test_extra_connector_options_are_passed_through():
+    provider = _provider()
+    writer = _Writer()
+    df = MagicMock()
+    df.write = writer
+    entity = _entity(
+        {
+            "provider.auth": "managed_identity",
+            "provider.cluster": "fawkes.eastus",
+            "provider.database": "Kindling",
+            "provider.table": "Orders",
+            "provider.option.adjustSchema": "GenerateDynamicCsvMapping",
+            "provider.option.clientBatchingLimit": "1024",
+        }
+    )
+
+    provider.append_to_entity(df, entity)
+
+    assert writer.options["adjustSchema"] == "GenerateDynamicCsvMapping"
+    assert writer.options["clientBatchingLimit"] == "1024"
+
+
+def test_check_entity_exists_defaults_to_true_for_write_only_target():
+    assert _provider().check_entity_exists(_entity({})) is True


### PR DESCRIPTION
## Summary
- add a standalone `kindling-adx` extension package
- register `provider_type: adx` for append-oriented ADX materialization targets
- support managed identity, Synapse linked service, access token, and service principal connector options
- document Spark connector setup and entity tag examples

## Verification
- `pytest tests/unit/test_adx_entity_provider_extension.py -q`
- `poetry build -C packages/kindling_adx`