### PR TITLE
Respect no-watermark execution override

### DIFF
--- a/packages/kindling/data_pipes.py
+++ b/packages/kindling/data_pipes.py
@@ -8,12 +8,11 @@ from typing import Any, Callable, Dict, List, Optional
 
 from delta.tables import DeltaTable
 from injector import Binder, Injector, inject, singleton
-from pyspark.sql import DataFrame
-
 from kindling.injection import *
 from kindling.signaling import SignalEmitter, SignalProvider
 from kindling.spark_log_provider import *
 from kindling.spark_trace import *
+from pyspark.sql import DataFrame
 
 from .data_entities import *
 from .data_entities import _raise_if_not_initialized
@@ -224,7 +223,9 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
             **dag_kwargs: Additional DAG execution options
         """
         if use_dag:
-            return self.run_datapipes_dag(pipes, strategy=dag_strategy, **dag_kwargs)
+            return self.run_datapipes_dag(
+                pipes, strategy=dag_strategy, no_watermark=no_watermark, **dag_kwargs
+            )
 
         run_id = str(uuid.uuid4())
         start_time = time.time()
@@ -342,6 +343,7 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
         pipe_timeout: Optional[float] = None,
         streaming_options: Optional[Dict[str, Any]] = None,
         auto_cache: bool = False,
+        no_watermark: bool = False,
     ):
         """Execute pipes via DAG planning/generation execution facade."""
         from kindling.execution_orchestrator import ExecutionOrchestrator
@@ -358,6 +360,7 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
             pipe_timeout=pipe_timeout,
             streaming_options=streaming_options,
             auto_cache=auto_cache,
+            no_watermark=no_watermark,
         )
 
     def _execute_datapipe(

--- a/packages/kindling/data_pipes.py
+++ b/packages/kindling/data_pipes.py
@@ -211,6 +211,7 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
         pipes: List[str],
         use_dag: bool = False,
         dag_strategy: Optional[Any] = None,
+        no_watermark: bool = False,
         **dag_kwargs,
     ):
         """Execute a list of pipes with signal emissions.
@@ -219,6 +220,7 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
             pipes: List of pipe IDs to execute
             use_dag: If True, delegate execution to DAG orchestrator mode
             dag_strategy: Optional DAG execution strategy override
+            no_watermark: If True, disable watermark reads/writes for this run
             **dag_kwargs: Additional DAG execution options
         """
         if use_dag:
@@ -240,6 +242,8 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
             with self.tp.span(component="data_pipes_executer", operation="execute_datapipes"):
                 for index, pipeid in enumerate(pipes):
                     pipe = self.dpr.get_pipe_definition(pipeid)
+                    if no_watermark and pipe.use_watermark:
+                        pipe = dataclasses.replace(pipe, use_watermark=False)
                     pipe_start = time.time()
 
                     # Emit before_pipe signal

--- a/packages/kindling/execution_orchestrator.py
+++ b/packages/kindling/execution_orchestrator.py
@@ -7,7 +7,6 @@ generation-based execution while preserving existing executor options.
 from typing import Any, List, Optional
 
 from injector import inject
-
 from kindling.execution_strategy import ExecutionPlanGenerator, ExecutionStrategy
 from kindling.generation_executor import (
     ErrorStrategy,
@@ -54,6 +53,7 @@ class ExecutionOrchestrator(SignalEmitter):
         pipe_timeout: Optional[float] = None,
         streaming_options: Optional[dict[str, Any]] = None,
         auto_cache: bool = False,
+        no_watermark: bool = False,
     ) -> ExecutionResult:
         """Generate an execution plan and run it through GenerationExecutor."""
         plan = self.plan_generator.generate_plan(pipe_ids, strategy=strategy)
@@ -81,6 +81,7 @@ class ExecutionOrchestrator(SignalEmitter):
             pipe_timeout=pipe_timeout,
             streaming_options=streaming_options,
             auto_cache=auto_cache,
+            no_watermark=no_watermark,
         )
 
     def execute_batch(

--- a/packages/kindling/generation_executor.py
+++ b/packages/kindling/generation_executor.py
@@ -21,7 +21,7 @@ Part of: Capability #15 - Unified DAG Orchestrator
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import Enum
 from threading import Lock
 from typing import Any, Callable, Dict, List, Optional
@@ -226,6 +226,7 @@ class GenerationExecutor(SignalEmitter):
         pipe_timeout: Optional[float] = None,
         streaming_options: Optional[Dict[str, Any]] = None,
         auto_cache: bool = False,
+        no_watermark: bool = False,
     ) -> ExecutionResult:
         """Execute an ExecutionPlan generation by generation.
 
@@ -246,6 +247,7 @@ class GenerationExecutor(SignalEmitter):
                 applied to all pipes.
             auto_cache: If True, call `persist()/cache()` on recommended shared
                 entities when first read in batch mode.
+            no_watermark: If True, disable watermark reads/writes for this run.
 
         Returns:
             ExecutionResult with per-pipe and per-generation results
@@ -292,6 +294,7 @@ class GenerationExecutor(SignalEmitter):
                         error_strategy=error_strategy,
                         pipe_timeout=pipe_timeout,
                         streaming_options=streaming_options,
+                        no_watermark=no_watermark,
                     )
                     result.generation_results.append(gen_result)
 
@@ -519,6 +522,7 @@ class GenerationExecutor(SignalEmitter):
         error_strategy: ErrorStrategy,
         pipe_timeout: Optional[float],
         streaming_options: Optional[Dict[str, Any]],
+        no_watermark: bool = False,
     ) -> GenerationResult:
         """Execute all pipes in a generation."""
         gen_start = time.time()
@@ -541,7 +545,7 @@ class GenerationExecutor(SignalEmitter):
         if parallel and not is_streaming and len(generation.pipe_ids) > 1:
             # Parallel batch execution
             gen_result = self._execute_generation_parallel(
-                generation, run_id, max_workers, error_strategy, pipe_timeout
+                generation, run_id, max_workers, error_strategy, pipe_timeout, no_watermark
             )
         else:
             # Sequential execution (batch or streaming)
@@ -552,6 +556,7 @@ class GenerationExecutor(SignalEmitter):
                     is_streaming=is_streaming,
                     pipe_timeout=pipe_timeout,
                     streaming_options=streaming_options,
+                    no_watermark=no_watermark,
                 )
                 gen_result.pipe_results.append(pipe_result)
 
@@ -589,6 +594,7 @@ class GenerationExecutor(SignalEmitter):
         max_workers: int,
         error_strategy: ErrorStrategy,
         pipe_timeout: Optional[float],
+        no_watermark: bool = False,
     ) -> GenerationResult:
         """Execute pipes within a generation in parallel using ThreadPoolExecutor."""
         gen_result = GenerationResult(generation_number=generation.number)
@@ -608,6 +614,7 @@ class GenerationExecutor(SignalEmitter):
                     is_streaming=False,
                     pipe_timeout=pipe_timeout,
                     streaming_options=None,
+                    no_watermark=no_watermark,
                 ): pipe_id
                 for pipe_id in generation.pipe_ids
             }
@@ -641,6 +648,7 @@ class GenerationExecutor(SignalEmitter):
         is_streaming: bool,
         pipe_timeout: Optional[float],
         streaming_options: Optional[Dict[str, Any]],
+        no_watermark: bool = False,
     ) -> PipeResult:
         """Execute a single pipe (batch or streaming)."""
         pipe_start = time.time()
@@ -658,6 +666,8 @@ class GenerationExecutor(SignalEmitter):
             pipe = self.pipes_registry.get_pipe_definition(pipe_id)
             if pipe is None:
                 raise ValueError(f"Pipe '{pipe_id}' not found in registry")
+            if no_watermark and pipe.use_watermark:
+                pipe = replace(pipe, use_watermark=False)
 
             if is_streaming:
                 result = self._execute_pipe_streaming(pipe, streaming_options)
@@ -725,7 +735,7 @@ class GenerationExecutor(SignalEmitter):
             input_entities[key] = self._read_batch_input_entity(
                 entity_id=entity_id,
                 entity_reader=entity_reader,
-                is_first=is_first,
+                use_watermark=pipe.use_watermark and is_first,
                 run_id=run_id,
             )
 
@@ -747,14 +757,14 @@ class GenerationExecutor(SignalEmitter):
         self,
         entity_id: str,
         entity_reader: Callable[[Any, bool], Any],
-        is_first: bool,
+        use_watermark: bool,
         run_id: str,
     ) -> Any:
         """Read an input entity with shared-entity cache tracking."""
         entity = self.entity_registry.get_entity_definition(entity_id)
 
         if not self._cache_enabled or entity_id not in self._cache_recommendations:
-            return entity_reader(entity, is_first)
+            return entity_reader(entity, use_watermark)
 
         with self._cache_lock:
             if entity_id in self._cached_entities:
@@ -770,7 +780,7 @@ class GenerationExecutor(SignalEmitter):
                 )
                 return self._cached_entities[entity_id]
 
-            frame = entity_reader(entity, is_first)
+            frame = entity_reader(entity, use_watermark)
             self._cached_entities[entity_id] = frame
             self._cache_misses += 1
             self._cache_misses_by_entity[entity_id] = (

--- a/tests/unit/test_data_pipes.py
+++ b/tests/unit/test_data_pipes.py
@@ -8,7 +8,6 @@ from typing import Callable, Dict, List
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
-
 from kindling.data_entities import KindlingNotInitializedError
 from kindling.data_pipes import (
     DataPipes,
@@ -872,6 +871,7 @@ class TestDataPipesExecuter:
         executer.run_datapipes_dag.assert_called_once_with(
             ["pipe_a"],
             strategy="batch",
+            no_watermark=False,
             parallel=True,
             max_workers=2,
         )
@@ -897,6 +897,7 @@ class TestDataPipesExecuter:
                 pipe_timeout=12.5,
                 streaming_options={"pipe1": {"checkpoint": "/tmp/checkpoints"}},
                 auto_cache=True,
+                no_watermark=True,
             )
 
         assert result == "ok"
@@ -909,6 +910,7 @@ class TestDataPipesExecuter:
         assert kwargs["pipe_timeout"] == 12.5
         assert kwargs["streaming_options"] == {"pipe1": {"checkpoint": "/tmp/checkpoints"}}
         assert kwargs["auto_cache"] is True
+        assert kwargs["no_watermark"] is True
         assert kwargs["error_strategy"] is not None
 
 

--- a/tests/unit/test_data_pipes.py
+++ b/tests/unit/test_data_pipes.py
@@ -654,6 +654,44 @@ class TestDataPipesExecuter:
         # Verify all pipes were retrieved
         assert self.mock_pipes_registry.get_pipe_definition.call_count == 3
 
+    def test_run_datapipes_no_watermark_uses_per_run_pipe_override(self):
+        """no_watermark=True disables watermarking without mutating registry metadata."""
+        executer = DataPipesExecuter(
+            self.mock_logger_provider,
+            self.mock_entity_registry,
+            self.mock_pipes_registry,
+            self.mock_erps,
+            self.mock_trace_provider,
+        )
+
+        mock_df = Mock()
+        registered_pipe = PipeMetadata(
+            pipeid="test_pipe",
+            name="Test Pipe",
+            execute=Mock(return_value=mock_df),
+            tags={},
+            input_entity_ids=["source.entity"],
+            output_entity_id="target.entity",
+            output_type="delta",
+            use_watermark=True,
+        )
+        self.mock_pipes_registry.get_pipe_definition.return_value = registered_pipe
+        self.mock_entity_registry.get_entity_definition.return_value = Mock()
+        mock_reader = Mock(return_value=mock_df)
+        mock_activator = Mock()
+        self.mock_erps.create_pipe_entity_reader.return_value = mock_reader
+        self.mock_erps.create_pipe_persist_activator.return_value = mock_activator
+
+        executer.run_datapipes(["test_pipe"], no_watermark=True)
+
+        effective_pipe = self.mock_erps.create_pipe_entity_reader.call_args.args[0]
+        assert effective_pipe.use_watermark is False
+        assert effective_pipe is not registered_pipe
+        assert registered_pipe.use_watermark is True
+        mock_reader.assert_called_once()
+        assert mock_reader.call_args.args[1] is False
+        self.mock_erps.create_pipe_persist_activator.assert_called_once_with(effective_pipe)
+
     def test_execute_datapipe_with_single_input(self):
         """Test _execute_datapipe with single input entity"""
         executer = DataPipesExecuter(

--- a/tests/unit/test_execution_orchestrator.py
+++ b/tests/unit/test_execution_orchestrator.py
@@ -58,6 +58,7 @@ def test_execute_generates_plan_emits_signal_and_delegates():
         pipe_timeout=10.0,
         streaming_options={"pipe_a": {"checkpoint": "/tmp/checkpoints"}},
         auto_cache=True,
+        no_watermark=False,
     )
 
     signal.send.assert_called_once()

--- a/tests/unit/test_generation_executor.py
+++ b/tests/unit/test_generation_executor.py
@@ -11,7 +11,6 @@ from concurrent.futures import Future
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
-
 from kindling.data_pipes import PipeMetadata
 from kindling.entity_provider import (
     StreamableEntityProvider,
@@ -141,7 +140,7 @@ def executor(
     )
 
 
-def make_pipe(pipe_id, inputs=None, output=None, tags=None):
+def make_pipe(pipe_id, inputs=None, output=None, tags=None, use_watermark=False):
     """Helper to create a PipeMetadata object."""
     return PipeMetadata(
         pipeid=pipe_id,
@@ -151,6 +150,7 @@ def make_pipe(pipe_id, inputs=None, output=None, tags=None):
         input_entity_ids=inputs or [],
         output_entity_id=output or f"entity.{pipe_id}",
         output_type="delta",
+        use_watermark=use_watermark,
     )
 
 
@@ -394,6 +394,40 @@ class TestBatchExecution:
         assert len(result.generation_results) == 1
         persist_strategy.create_pipe_entity_reader.assert_called_once_with(pipe)
         persist_strategy.create_pipe_persist_activator.assert_called_once_with(pipe)
+
+    def test_no_watermark_uses_per_run_pipe_override(
+        self, executor, pipes_registry, persist_strategy, entity_registry
+    ):
+        """DAG batch execution honors no_watermark without mutating registry metadata."""
+        pipe = make_pipe(
+            "pipe1",
+            inputs=["entity.src"],
+            output="entity.dst",
+            use_watermark=True,
+        )
+        pipes_registry.get_pipe_definition.return_value = pipe
+        entity_registry.get_entity_definition.return_value = Mock(entityid="entity.src")
+
+        mock_df = Mock()
+        reader = Mock(return_value=mock_df)
+        persist_strategy.create_pipe_entity_reader.return_value = reader
+        persist_strategy.create_pipe_persist_activator.return_value = Mock()
+
+        plan = make_plan(
+            ["pipe1"],
+            [Generation(number=0, pipe_ids=["pipe1"], dependencies=[])],
+            strategy="batch",
+        )
+
+        result = executor.execute(plan, no_watermark=True)
+
+        assert result.success_count == 1
+        effective_pipe = persist_strategy.create_pipe_entity_reader.call_args.args[0]
+        assert effective_pipe.use_watermark is False
+        assert effective_pipe is not pipe
+        assert pipe.use_watermark is True
+        reader.assert_called_once()
+        assert reader.call_args.args[1] is False
 
     def test_multi_generation_batch(
         self, executor, pipes_registry, persist_strategy, entity_registry

--- a/tests/unit/test_simple_stage_processor.py
+++ b/tests/unit/test_simple_stage_processor.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock
+
+from kindling.data_pipes import PipeMetadata
+from kindling.simple_stage_processor import StageProcessor
+
+
+def _pipe(pipeid: str, use_watermark: bool) -> PipeMetadata:
+    return PipeMetadata(
+        pipeid=pipeid,
+        name=pipeid,
+        execute=MagicMock(),
+        tags={},
+        input_entity_ids=["source.entity"],
+        output_entity_id="target.entity",
+        output_type="delta",
+        use_watermark=use_watermark,
+    )
+
+
+def _make_processor(pipes):
+    dpr = MagicMock()
+    dpr.get_pipe_ids.return_value = pipes.keys()
+    dpr.get_pipe_definition.side_effect = lambda pipeid: pipes[pipeid]
+    ep = MagicMock()
+    dep = MagicMock()
+    wef = MagicMock()
+    wef.get_watermark_entity_for_layer.return_value = MagicMock()
+    trace_provider = MagicMock()
+    trace_provider.span.return_value.__enter__.return_value = None
+    trace_provider.span.return_value.__exit__.return_value = False
+
+    return StageProcessor(dpr, ep, dep, wef, trace_provider), ep, dep, wef
+
+
+def test_stage_processor_does_not_ensure_watermark_table_without_watermark_enabled_pipe():
+    processor, ep, dep, wef = _make_processor(
+        {
+            "bronze.load_orders": _pipe("bronze.load_orders", use_watermark=False),
+            "bronze.load_customers": _pipe("bronze.load_customers", use_watermark=False),
+        }
+    )
+
+    processor.execute("bronze", "Bronze", {}, "bronze")
+
+    wef.get_watermark_entity_for_layer.assert_not_called()
+    ep.ensure_entity_table.assert_not_called()
+    dep.run_datapipes.assert_called_once_with(["bronze.load_orders", "bronze.load_customers"])
+
+
+def test_stage_processor_ensures_watermark_table_for_watermark_enabled_pipe():
+    processor, ep, dep, wef = _make_processor(
+        {
+            "bronze.load_orders": _pipe("bronze.load_orders", use_watermark=True),
+        }
+    )
+    watermark_entity = wef.get_watermark_entity_for_layer.return_value
+
+    processor.execute("bronze", "Bronze", {}, "bronze")
+
+    wef.get_watermark_entity_for_layer.assert_called_once_with("bronze")
+    ep.ensure_entity_table.assert_called_once_with(watermark_entity)
+    dep.run_datapipes.assert_called_once_with(["bronze.load_orders"])


### PR DESCRIPTION
## Summary
- apply `no_watermark=True` as a per-run `PipeMetadata` override instead of mutating registered pipe definitions
- cover the no-watermark runtime path so readers and persist activators see watermarking disabled
- add stage processor coverage that watermark table ensure only happens when a stage has watermark-enabled pipes

## Verification
- `pytest tests/unit/test_data_pipes.py tests/unit/test_simple_stage_processor.py tests/unit/test_cli_local_dev_dx.py -q`