### PR TITLE
Use selected settings overlays for app config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to spark-kindling are documented here.
 - Added `--load-lake` flag to `kindling app run` (standalone-only) to explicitly force
   downloading lake-reqs packages from the lake regardless of local install state.
 
-## [Unreleased]
+## [0.10.32] - 2026-06-23
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ All notable changes to spark-kindling are documented here.
 
 ### Changed
 
+- App runtime configuration now treats `app.yaml` as manifest-only and loads runtime
+  settings from `settings.yaml`, `settings.<platform>.yaml`, then
+  `settings.<env>.yaml`, with environment overlays taking precedence. Legacy
+  `platform_<platform>.yaml`, `env_<env>.yaml`, and app-local `app.<target>.yaml`
+  files remain fallback inputs for compatibility, but new config should use the
+  dot-style `settings.*.yaml` names.
 - `runtime publish` renamed to `runtime deploy`. Same behavior; the new name is consistent with
   `app deploy`, `package deploy`, and `workspace deploy`. **Breaking change**: update scripts
   and CI pipelines to use `kindling runtime deploy`.

--- a/docs/contributing/platform_workspace_config.md
+++ b/docs/contributing/platform_workspace_config.md
@@ -56,11 +56,11 @@ kindling:
 Settings specific to a platform (Fabric, Synapse, or Databricks). These override base settings.
 
 **Platforms:**
-- `platform_fabric.yaml` - Microsoft Fabric settings
+- `settings.fabric.yaml` - Microsoft Fabric settings
 - `platform_synapse.yaml` - Azure Synapse Analytics settings
 - `platform_databricks.yaml` - Databricks settings
 
-**Example:** `platform_fabric.yaml`
+**Example:** `settings.fabric.yaml`
 
 ```yaml
 kindling:
@@ -78,7 +78,7 @@ kindling:
     - kindling-otel-azure>=0.3.0
 ```
 
-**Upload to:** `{artifacts_storage_path}/config/platform_fabric.yaml`
+**Upload to:** `{artifacts_storage_path}/config/settings.fabric.yaml`
 
 ## Delta Table Conventions (Fabric / Synapse / Databricks)
 
@@ -137,7 +137,7 @@ kindling:
 
 Settings specific to an environment (dev, test, staging, prod). **Highest priority** among YAML files.
 
-**Example:** `env_prod.yaml`
+**Example:** `settings.prod.yaml`
 
 ```yaml
 kindling:
@@ -154,7 +154,7 @@ kindling:
     auto_compact: true
 ```
 
-**Upload to:** `{artifacts_storage_path}/config/env_prod.yaml`
+**Upload to:** `{artifacts_storage_path}/config/settings.prod.yaml`
 
 ## Usage Patterns
 
@@ -166,7 +166,7 @@ Minimal setup with just base settings and environment overrides:
 config/
 ├── settings.yaml     # Base settings
 ├── env_dev.yaml      # Development overrides
-└── env_prod.yaml     # Production overrides
+└── settings.prod.yaml     # Production overrides
 ```
 
 ### Pattern 2: Base + Platform + Environment
@@ -176,11 +176,11 @@ Add platform-specific settings for multi-platform deployments:
 ```
 config/
 ├── settings.yaml           # Base settings
-├── platform_fabric.yaml    # Fabric-specific settings
+├── settings.fabric.yaml    # Fabric-specific settings
 ├── platform_synapse.yaml   # Synapse-specific settings
 ├── platform_databricks.yaml # Databricks-specific settings
 ├── env_dev.yaml            # Development overrides
-└── env_prod.yaml           # Production overrides
+└── settings.prod.yaml      # Production overrides
 ```
 
 ### Pattern 3: Full Hierarchy (Most Control)
@@ -190,13 +190,13 @@ Complete hierarchy with workspace-specific settings:
 ```
 config/
 ├── settings.yaml                           # Base settings
-├── platform_fabric.yaml                    # Fabric settings
+├── settings.fabric.yaml                    # Fabric settings
 ├── platform_synapse.yaml                   # Synapse settings
 ├── workspace_abc123.yaml                   # Team A workspace
 ├── workspace_def456.yaml                   # Team B workspace
 ├── env_dev.yaml                            # Development env
 ├── env_staging.yaml                        # Staging env
-└── env_prod.yaml                           # Production env
+└── settings.prod.yaml                      # Production env
 ```
 
 ### Pattern 4: Workspace Per Environment
@@ -206,13 +206,13 @@ Workspaces aligned with environments (common pattern):
 ```
 config/
 ├── settings.yaml                           # Base settings
-├── platform_fabric.yaml                    # Fabric settings
+├── settings.fabric.yaml                    # Fabric settings
 ├── workspace_dev-workspace-id.yaml         # Dev workspace
 ├── workspace_staging-workspace-id.yaml     # Staging workspace
 ├── workspace_prod-workspace-id.yaml        # Prod workspace
 ├── env_dev.yaml                            # Dev env overrides
 ├── env_staging.yaml                        # Staging env overrides
-└── env_prod.yaml                           # Prod env overrides
+└── settings.prod.yaml                      # Prod env overrides
 ```
 
 ## Configuration Detection
@@ -294,7 +294,7 @@ kindling:
     logging:
       level: INFO
 
-# platform_fabric.yaml - Fabric-specific
+# settings.fabric.yaml - Fabric-specific
 kindling:
   platform:
     name: fabric
@@ -315,7 +315,7 @@ kindling:
   DATA:
     bronze: "abfss://bronze-team-b@..."
 
-# env_prod.yaml - Production overrides
+# settings.prod.yaml - Production overrides
 kindling:
   telemetry:
     logging:
@@ -334,7 +334,7 @@ kindling:
   delta:
     access_mode: catalog
 
-# platform_fabric.yaml - Fabric tuning
+# settings.fabric.yaml - Fabric tuning
 kindling:
   TELEMETRY:
     logging:
@@ -377,7 +377,7 @@ kindling:
   LIMITS:
     max_executors: 50
 
-# env_prod.yaml - Production environment overrides
+# settings.prod.yaml - Production environment overrides
 kindling:
   SPARK_CONFIGS:
     spark.executor.memory: "32g"
@@ -407,9 +407,9 @@ Platform: fabric
 Workspace ID: 12345678-1234-1234-1234-123456789abc
 Environment: prod
 ✓ Downloaded: settings.yaml
-✓ Downloaded: platform_fabric.yaml
+✓ Downloaded: settings.fabric.yaml
 ✓ Downloaded: workspace_12345678-1234-1234-1234-123456789abc.yaml
-✓ Downloaded: env_prod.yaml
+✓ Downloaded: settings.prod.yaml
 ```
 
 ### Workspace ID Not Detected
@@ -458,8 +458,8 @@ config/
 ```
 config/
 ├── settings.yaml           # Base settings
-├── platform_fabric.yaml    # Fabric-specific
-└── env_prod.yaml          # Environment-specific
+├── settings.fabric.yaml   # Fabric-specific
+└── settings.prod.yaml     # Environment-specific
 ```
 
 **Migration Steps:**

--- a/docs/contributing/platform_workspace_config.md
+++ b/docs/contributing/platform_workspace_config.md
@@ -11,9 +11,9 @@ See `docs/config_reference.md` for an exhaustive list of Kindling config keys an
 Configuration files are loaded in the following order (lowest to highest priority):
 
 1. **`settings.yaml`** - Base framework settings (lowest priority)
-2. **`platform_{platform}.yaml`** - Platform-specific settings (fabric, synapse, databricks)
+2. **`settings.{platform}.yaml`** - Platform-specific settings (fabric, synapse, databricks)
 3. **`workspace_{workspace_id}.yaml`** - Workspace-specific settings
-4. **`env_{environment}.yaml`** - Environment-specific settings (dev, prod, etc.)
+4. **`settings.{environment}.yaml`** - Environment-specific settings (dev, prod, etc.)
 5. **SparkConf** - `spark.kindling.*` pool/session settings
 6. **Bootstrap Config** - In-memory overrides from BOOTSTRAP_CONFIG dict (highest priority)
 
@@ -51,14 +51,14 @@ kindling:
 
 **Upload to:** `{artifacts_storage_path}/config/settings.yaml`
 
-### 2. Platform-Specific Settings (`platform_{platform}.yaml`)
+### 2. Platform-Specific Settings (`settings.{platform}.yaml`)
 
 Settings specific to a platform (Fabric, Synapse, or Databricks). These override base settings.
 
 **Platforms:**
 - `settings.fabric.yaml` - Microsoft Fabric settings
-- `platform_synapse.yaml` - Azure Synapse Analytics settings
-- `platform_databricks.yaml` - Databricks settings
+- `settings.synapse.yaml` - Azure Synapse Analytics settings
+- `settings.databricks.yaml` - Databricks settings
 
 **Example:** `settings.fabric.yaml`
 
@@ -133,7 +133,7 @@ kindling:
 
 **Upload to:** `{artifacts_storage_path}/config/workspace_{workspace_id}.yaml`
 
-### 4. Environment-Specific Settings (`env_{environment}.yaml`)
+### 4. Environment-Specific Settings (`settings.{environment}.yaml`)
 
 Settings specific to an environment (dev, test, staging, prod). **Highest priority** among YAML files.
 
@@ -164,9 +164,9 @@ Minimal setup with just base settings and environment overrides:
 
 ```
 config/
-├── settings.yaml     # Base settings
-├── env_dev.yaml      # Development overrides
-└── settings.prod.yaml     # Production overrides
+├── settings.yaml       # Base settings
+├── settings.dev.yaml   # Development overrides
+└── settings.prod.yaml  # Production overrides
 ```
 
 ### Pattern 2: Base + Platform + Environment
@@ -175,12 +175,12 @@ Add platform-specific settings for multi-platform deployments:
 
 ```
 config/
-├── settings.yaml           # Base settings
-├── settings.fabric.yaml    # Fabric-specific settings
-├── platform_synapse.yaml   # Synapse-specific settings
-├── platform_databricks.yaml # Databricks-specific settings
-├── env_dev.yaml            # Development overrides
-└── settings.prod.yaml      # Production overrides
+├── settings.yaml             # Base settings
+├── settings.fabric.yaml      # Fabric-specific settings
+├── settings.synapse.yaml     # Synapse-specific settings
+├── settings.databricks.yaml  # Databricks-specific settings
+├── settings.dev.yaml         # Development overrides
+└── settings.prod.yaml        # Production overrides
 ```
 
 ### Pattern 3: Full Hierarchy (Most Control)
@@ -191,11 +191,11 @@ Complete hierarchy with workspace-specific settings:
 config/
 ├── settings.yaml                           # Base settings
 ├── settings.fabric.yaml                    # Fabric settings
-├── platform_synapse.yaml                   # Synapse settings
+├── settings.synapse.yaml                   # Synapse settings
 ├── workspace_abc123.yaml                   # Team A workspace
 ├── workspace_def456.yaml                   # Team B workspace
-├── env_dev.yaml                            # Development env
-├── env_staging.yaml                        # Staging env
+├── settings.dev.yaml                       # Development env
+├── settings.staging.yaml                   # Staging env
 └── settings.prod.yaml                      # Production env
 ```
 
@@ -210,8 +210,8 @@ config/
 ├── workspace_dev-workspace-id.yaml         # Dev workspace
 ├── workspace_staging-workspace-id.yaml     # Staging workspace
 ├── workspace_prod-workspace-id.yaml        # Prod workspace
-├── env_dev.yaml                            # Dev env overrides
-├── env_staging.yaml                        # Staging env overrides
+├── settings.dev.yaml                       # Dev env overrides
+├── settings.staging.yaml                   # Staging env overrides
 └── settings.prod.yaml                      # Prod env overrides
 ```
 
@@ -340,7 +340,7 @@ kindling:
     logging:
       level: DEBUG  # Need verbose logs for diagnostic emitters
 
-# platform_databricks.yaml - Databricks tuning
+# settings.databricks.yaml - Databricks tuning
 kindling:
   TELEMETRY:
     logging:
@@ -464,8 +464,8 @@ config/
 
 **Migration Steps:**
 1. Keep existing `settings.yaml` as base
-2. Extract platform-specific settings to `platform_{platform}.yaml`
-3. Extract environment-specific settings to `env_{environment}.yaml`
+2. Extract platform-specific settings to `settings.{platform}.yaml`
+3. Extract environment-specific settings to `settings.{environment}.yaml`
 4. Test with each layer to verify behavior
 
 ### From Bootstrap Config Only

--- a/docs/guide/domain_project_quickstart.md
+++ b/docs/guide/domain_project_quickstart.md
@@ -141,7 +141,7 @@ After this command the following are in place in your storage container:
 
 ```
 artifacts/kindling/config/settings.yaml
-artifacts/kindling/config/platform_fabric.yaml   (if present)
+artifacts/kindling/config/settings.fabric.yaml   (if present)
 ```
 
 To re-deploy config after later changes to `settings.yaml`:

--- a/packages/kindling/app_files.py
+++ b/packages/kindling/app_files.py
@@ -29,9 +29,7 @@ def is_selected_settings_overlay(
     """Return True when a settings overlay matches the selected runtime target."""
     return filename in {
         f"settings.{platform}.yaml" if platform else "",
-        f"settings.{platform}.yml" if platform else "",
         f"settings.{environment}.yaml" if environment else "",
-        f"settings.{environment}.yml" if environment else "",
     }
 
 

--- a/packages/kindling/app_files.py
+++ b/packages/kindling/app_files.py
@@ -1,14 +1,62 @@
 """Shared app artifact selection rules."""
 
 from pathlib import PurePosixPath
+from typing import Optional
 
 APP_TEXT_FILE_NAMES = {"requirements.txt", "lake-reqs.txt"}
 APP_TEXT_FILE_SUFFIXES = {".py", ".yaml", ".yml"}
+APP_MANIFEST_FILE = "app.yaml"
+APP_SETTINGS_FILE = "settings.yaml"
+LOCAL_SETTINGS_FILE = "settings.local.yaml"
+LOCAL_SETTINGS_FILES = {LOCAL_SETTINGS_FILE, "settings.local.yml"}
 
 
-def is_deployable_app_file(path: str) -> bool:
+def is_settings_overlay(filename: str) -> bool:
+    """Return True for app-local dot-style settings overlays."""
+    return (
+        filename not in {APP_SETTINGS_FILE, *LOCAL_SETTINGS_FILES}
+        and filename.startswith("settings.")
+        and filename.endswith((".yaml", ".yml"))
+    )
+
+
+def is_selected_settings_overlay(
+    filename: str,
+    *,
+    platform: Optional[str] = None,
+    environment: Optional[str] = None,
+) -> bool:
+    """Return True when a settings overlay matches the selected runtime target."""
+    return filename in {
+        f"settings.{platform}.yaml" if platform else "",
+        f"settings.{platform}.yml" if platform else "",
+        f"settings.{environment}.yaml" if environment else "",
+        f"settings.{environment}.yml" if environment else "",
+    }
+
+
+def is_deployable_app_file(
+    path: str,
+    *,
+    platform: Optional[str] = None,
+    environment: Optional[str] = None,
+) -> bool:
     """Return True when an app artifact should be deployed as text."""
     file_path = PurePosixPath(path.replace("\\", "/"))
+    if file_path.name in LOCAL_SETTINGS_FILES:
+        return False
+    if (
+        file_path.name.startswith("app.")
+        and file_path.name != APP_MANIFEST_FILE
+        and file_path.suffix.lower() in {".yaml", ".yml"}
+    ):
+        return False
+    if is_settings_overlay(file_path.name):
+        return is_selected_settings_overlay(
+            file_path.name,
+            platform=platform,
+            environment=environment,
+        )
     return (
         file_path.name in APP_TEXT_FILE_NAMES or file_path.suffix.lower() in APP_TEXT_FILE_SUFFIXES
     )

--- a/packages/kindling/bootstrap.py
+++ b/packages/kindling/bootstrap.py
@@ -352,10 +352,12 @@ def download_config_files(
     All files are optional - bootstrap config can provide everything.
     Returns list of local file paths in priority order (lowest to highest):
       1. settings.yaml (base settings)
-      2. platform_{platform}.yaml (platform-specific: fabric, synapse, databricks)
+      2. settings.{platform}.yaml (platform-specific: fabric, synapse, databricks)
       3. workspace_{workspace_id}.yaml (workspace-specific)
-      4. env_{environment}.yaml (environment-specific: dev, prod, etc)
-      5. data-apps/{app_name}/settings.yaml (app-specific - highest priority)
+      4. settings.{environment}.yaml (environment-specific: dev, prod, etc)
+      5. data-apps/{app_name}/settings.yaml (app-specific base)
+      6. data-apps/{app_name}/settings.{platform}.yaml (app-specific platform)
+      7. data-apps/{app_name}/settings.{environment}.yaml (app-specific env)
 
     Args:
         artifacts_storage_path: Base path for artifacts storage
@@ -415,7 +417,7 @@ def download_config_files(
     # Add platform-specific config if platform is known
     if platform:
         files_to_download.append(
-            (f"{base_path}/config/platform_{platform}.yaml", f"platform_{platform}.yaml")
+            (f"{base_path}/config/settings.{platform}.yaml", f"settings.{platform}.yaml")
         )
 
     # Add workspace-specific config if workspace_id is known
@@ -426,14 +428,53 @@ def download_config_files(
 
     # Add environment config
     files_to_download.append(
-        (f"{base_path}/config/env_{environment}.yaml", f"env_{environment}.yaml")
+        (f"{base_path}/config/settings.{environment}.yaml", f"settings.{environment}.yaml")
     )
 
-    # Add app-specific settings (highest priority from files)
-    # Apps deployed with settings.yaml in their directory get those loaded last
+    # Add app-specific settings last so app overlays win over workspace/global config.
+    app_config_prefix = None
     if app_name:
+        safe_app_name = str(app_name).replace("/", "_")
+        app_config_prefix = f"app_{safe_app_name}_"
         files_to_download.append(
-            (f"{base_path}/data-apps/{app_name}/settings.yaml", f"app_{app_name}_settings.yaml")
+            (
+                f"{base_path}/data-apps/{app_name}/settings.yaml",
+                f"{app_config_prefix}settings.yaml",
+            )
+        )
+        if platform:
+            files_to_download.append(
+                (
+                    f"{base_path}/data-apps/{app_name}/settings.{platform}.yaml",
+                    f"{app_config_prefix}settings.{platform}.yaml",
+                )
+            )
+        files_to_download.append(
+            (
+                f"{base_path}/data-apps/{app_name}/settings.{environment}.yaml",
+                f"{app_config_prefix}settings.{environment}.yaml",
+            )
+        )
+
+    legacy_fallbacks = {}
+    if platform:
+        legacy_fallbacks[f"settings.{platform}.yaml"] = (
+            f"{base_path}/config/platform_{platform}.yaml",
+            f"platform_{platform}.yaml",
+        )
+    legacy_fallbacks[f"settings.{environment}.yaml"] = (
+        f"{base_path}/config/env_{environment}.yaml",
+        f"env_{environment}.yaml",
+    )
+    if app_name and app_config_prefix:
+        if platform:
+            legacy_fallbacks[f"{app_config_prefix}settings.{platform}.yaml"] = (
+                f"{base_path}/data-apps/{app_name}/app.{platform}.yaml",
+                f"{app_config_prefix}app.{platform}.yaml",
+            )
+        legacy_fallbacks[f"{app_config_prefix}settings.{environment}.yaml"] = (
+            f"{base_path}/data-apps/{app_name}/app.{environment}.yaml",
+            f"{app_config_prefix}app.{environment}.yaml",
         )
 
     for remote_path, filename in files_to_download:
@@ -466,6 +507,40 @@ def download_config_files(
                 config_files.append(str(local_path))
                 _BOOTSTRAP_LOGGER.info("Downloaded config %s", filename)
         except Exception as e:
+            fallback = legacy_fallbacks.get(filename)
+            if fallback:
+                legacy_remote_path, legacy_filename = fallback
+                try:
+                    if is_databricks:
+                        content = storage_utils.fs.head(legacy_remote_path, 1024 * 1024)
+                        text_content = (
+                            content.decode("utf-8") if isinstance(content, bytes) else content
+                        )
+
+                        if volume_path:
+                            volume_file = _build_run_scoped_staging_path(
+                                volume_path, "config", f"{len(config_files)}_{legacy_filename}"
+                            )
+                            storage_utils.fs.put(volume_file, text_content, overwrite=True)
+                            config_files.append(volume_file)
+                        else:
+                            dbfs_file_path = (
+                                f"{dbfs_temp_path}/{len(config_files)}_{legacy_filename}"
+                            )
+                            storage_utils.fs.put(dbfs_file_path, text_content, overwrite=True)
+                            config_files.append(f"/dbfs{dbfs_file_path}")
+                    else:
+                        local_path = temp_path / f"{len(config_files)}_{legacy_filename}"
+                        storage_utils.fs.cp(legacy_remote_path, f"file://{str(local_path)}")
+                        config_files.append(str(local_path))
+                    _BOOTSTRAP_LOGGER.info(
+                        "Downloaded legacy config %s after %s was not found",
+                        legacy_filename,
+                        filename,
+                    )
+                    continue
+                except Exception:
+                    pass
             # All config files are optional - log error details for debugging
             error_msg = str(e)
             if "FileNotFoundException" in error_msg or "does not exist" in error_msg.lower():

--- a/packages/kindling/data_apps.py
+++ b/packages/kindling/data_apps.py
@@ -14,14 +14,14 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import yaml
-from packaging.version import InvalidVersion, Version
-
 from kindling.injection import *
 from kindling.platform_provider import *
 from kindling.spark_config import *
 from kindling.spark_log_provider import *
 from kindling.spark_trace import *
+from packaging.version import InvalidVersion, Version
 
+from .app_files import is_deployable_app_file, is_settings_overlay
 from .notebook_framework import *
 
 
@@ -32,7 +32,8 @@ class DataAppConstants:
     LAKE_REQUIREMENTS_FILE = "lake-reqs.txt"
     LOCAL_SETTINGS_FILE = "settings.local.yaml"
     BASE_CONFIG_FILE = "app.yaml"
-    ENV_CONFIG_TEMPLATE = "app.{environment}.yaml"
+    SETTINGS_FILE = "settings.yaml"
+    ENV_CONFIG_TEMPLATE = "settings.{environment}.yaml"
     DEFAULT_ENTRY_POINT = "app.py"
 
     # KDA package constants
@@ -246,17 +247,6 @@ class DataAppPackage:
         with open(config_file) as f:
             config_data = yaml.safe_load(f)
 
-        # Load and merge platform-specific config if requested
-        if merge_platform_config and target_platform:
-            platform_config_file = app_path / f"app.{target_platform}.yaml"
-            if platform_config_file.exists():
-                with open(platform_config_file) as f:
-                    platform_data = yaml.safe_load(f) or {}
-                # Deep merge platform config into base config
-                config_data = DataAppPackage._deep_merge_dicts(config_data, platform_data)
-                if logger:
-                    logger.debug(f"Merged platform config: {target_platform}")
-
         app_name = config_data.get("name", app_path.name)
         app_version = version or config_data.get("version", "1.0.0")
 
@@ -282,26 +272,25 @@ class DataAppPackage:
         # Create .kda package
         with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as kda_file:
             if merge_platform_config and target_platform:
-                # Single platform: exclude platform-specific configs, use merged version
+                # Single platform: include manifest and only selected settings overlays.
                 for file_path in app_path.rglob("*"):
                     if file_path.is_file():
-                        # Skip platform config files and base app.yaml
-                        if (
-                            DataAppPackage._is_platform_config_file(file_path)
-                            or file_path.name == "app.yaml"
+                        relative_path = file_path.relative_to(app_path)
+                        if not is_deployable_app_file(
+                            relative_path.as_posix(),
+                            platform=target_platform,
                         ):
                             continue
-                        relative_path = file_path.relative_to(app_path)
                         kda_file.write(file_path, relative_path)
-
-                # Write merged config as app.yaml
-                kda_file.writestr("app.yaml", yaml.safe_dump(config_data, indent=2))
             else:
-                # Multi-platform: include all files
+                # No selected target: keep manifest/base settings and exclude local/legacy overlays.
                 for file_path in app_path.rglob("*"):
-                    if file_path.is_file():
-                        relative_path = file_path.relative_to(app_path)
-                        kda_file.write(file_path, relative_path)
+                    if not file_path.is_file():
+                        continue
+                    relative_path = file_path.relative_to(app_path)
+                    if not is_deployable_app_file(relative_path.as_posix()):
+                        continue
+                    kda_file.write(file_path, relative_path)
 
             # Generate and add manifest
             manifest = KDAManifest(
@@ -392,7 +381,11 @@ class DataAppPackage:
     def _is_platform_config_file(file_path: Path) -> bool:
         """Check if file is a platform-specific config file"""
         filename = file_path.name
-        return filename.startswith("app.") and filename != "app.yaml" and filename.endswith(".yaml")
+        return (
+            filename.startswith("app.")
+            and filename != DataAppConstants.BASE_CONFIG_FILE
+            and filename.endswith(".yaml")
+        ) or is_settings_overlay(filename)
 
     @staticmethod
     def _load_lake_requirements(app_path: Path) -> List[str]:
@@ -519,9 +512,10 @@ class DataAppManager(DataAppRunner):
     def _prepare_app_context(self, app_name: str) -> DataAppContext:
         """Prepare all context needed for app execution"""
         environment = self.config.get("environment")
+        platform = self._get_config_platform_name()
 
         # Load config
-        app_config = self._load_app_config(app_name, environment)
+        app_config = self._load_app_config(app_name, environment, platform)
 
         # Resolve dependencies
         pypi_deps, lake_reqs = self._resolve_app_dependencies(app_name, self.config)
@@ -534,6 +528,20 @@ class DataAppManager(DataAppRunner):
     def _get_env_name(self) -> str:
         """Get current platform environment name"""
         return self.get_platform_service().get_platform_name()
+
+    def _get_config_platform_name(self) -> Optional[str]:
+        """Resolve the selected platform name for app-local settings overlays."""
+        for key in ("platform", "platform_environment"):
+            try:
+                value = self.config.get(key, None)
+            except Exception:
+                value = None
+            if value:
+                return str(value)
+        try:
+            return self._get_env_name()
+        except Exception:
+            return None
 
     def _get_app_dir(self, app_name: str) -> str:
         """Get app directory path"""
@@ -574,11 +582,6 @@ class DataAppManager(DataAppRunner):
             # Load base app config from source directory
             config = self._load_app_config_from_directory(app_path)
 
-            # If merging platform config, merge it at package time
-            if merge_platform_config and target_platform:
-                config = self._merge_platform_config_at_deploy_time(
-                    app_path, config, target_platform
-                )
             app_name = config.name
             app_version = version or config.metadata.get("version", "1.0.0")
 
@@ -605,32 +608,28 @@ class DataAppManager(DataAppRunner):
             # Create KDA package
             with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as kda_file:
                 if merge_platform_config:
-                    # Single platform: exclude platform-specific configs and base app.yaml, use merged version
+                    # Single platform: keep app.yaml manifest-only and include selected settings overlays.
                     for file_path in app_path.rglob("*"):
-                        if (
-                            file_path.is_file()
-                            and not self._is_platform_config_file(file_path)
-                            and file_path.name != "app.yaml"
-                            and file_path.name != DataAppConstants.LOCAL_SETTINGS_FILE
+                        if not file_path.is_file():
+                            continue
+                        relative_path = file_path.relative_to(app_path)
+                        if not is_deployable_app_file(
+                            relative_path.as_posix(),
+                            platform=target_platform,
                         ):
-                            relative_path = file_path.relative_to(app_path)
-                            kda_file.write(file_path, relative_path)
-                            self.logger.debug(f"Added to KDA: {relative_path}")
-
-                    # Add the merged config as app.yaml
-                    merged_config = self._create_merged_config(config)
-                    kda_file.writestr("app.yaml", merged_config)
-                    self.logger.debug("Added merged app.yaml to KDA")
+                            continue
+                        kda_file.write(file_path, relative_path)
+                        self.logger.debug(f"Added to KDA: {relative_path}")
                 else:
-                    # Multi-platform: include all files including platform configs
+                    # No selected target: keep manifest/base settings and exclude local/legacy overlays.
                     for file_path in app_path.rglob("*"):
-                        if (
-                            file_path.is_file()
-                            and file_path.name != DataAppConstants.LOCAL_SETTINGS_FILE
-                        ):
-                            relative_path = file_path.relative_to(app_path)
-                            kda_file.write(file_path, relative_path)
-                            self.logger.debug(f"Added to KDA: {relative_path}")
+                        if not file_path.is_file():
+                            continue
+                        relative_path = file_path.relative_to(app_path)
+                        if not is_deployable_app_file(relative_path.as_posix()):
+                            continue
+                        kda_file.write(file_path, relative_path)
+                        self.logger.debug(f"Added to KDA: {relative_path}")
 
                 # Generate and add manifest
                 manifest = self._create_kda_manifest(
@@ -649,7 +648,11 @@ class DataAppManager(DataAppRunner):
     def _is_platform_config_file(self, file_path: Path) -> bool:
         """Check if file is a platform-specific config file"""
         filename = file_path.name
-        return filename.startswith("app.") and filename != "app.yaml" and filename.endswith(".yaml")
+        return (
+            filename.startswith("app.")
+            and filename != DataAppConstants.BASE_CONFIG_FILE
+            and filename.endswith(".yaml")
+        ) or is_settings_overlay(filename)
 
     def _create_merged_config(self, config: "DataAppConfig") -> str:
         """Create merged YAML config from DataAppConfig"""
@@ -841,12 +844,17 @@ class DataAppManager(DataAppRunner):
             self.logger.warning(f"Failed to merge platform config for {target_platform}: {str(e)}")
             return base_config
 
-    def _load_app_config(self, app_name: str, environment: str = None) -> DataAppConfig:
+    def _load_app_config(
+        self,
+        app_name: str,
+        environment: str = None,
+        platform: Optional[str] = None,
+    ) -> DataAppConfig:
         """Load app configuration with environment override support"""
         self.logger.debug(f"Loading config for {app_name}")
 
         try:
-            config_content = self._load_config_content(app_name, environment)
+            config_content = self._load_config_content(app_name, environment, platform)
             config_data = self._parse_config_content(config_content)
             return self._create_app_config(config_data, app_name, environment)
         except Exception as e:
@@ -864,31 +872,73 @@ class DataAppManager(DataAppRunner):
                 metadata={},
             )
 
-    def _load_config_content(self, app_name: str, environment: str = None) -> str:
-        """Load config file content (with environment override)"""
+    def _load_config_content(
+        self,
+        app_name: str,
+        environment: str = None,
+        platform: Optional[str] = None,
+    ) -> str:
+        """Load app manifest plus settings overlays with environment taking precedence."""
         app_dir = self._get_app_dir(app_name)
+        merged: Dict[str, Any] = {}
 
-        # Try environment-specific config first
+        def read_yaml(filename: str) -> Optional[Dict[str, Any]]:
+            config_path = f"{app_dir}{filename}"
+            self.logger.debug(f"Loading config: {config_path}")
+            content = self.get_platform_service().read(config_path)
+            data = self._parse_config_content(content) or {}
+            return data if isinstance(data, dict) else {}
+
+        try:
+            manifest_data = read_yaml(DataAppConstants.BASE_CONFIG_FILE)
+            merged = DataAppPackage._deep_merge_dicts(merged, manifest_data or {})
+        except Exception:
+            self.logger.debug("App manifest not found, trying settings overlays")
+
+        try:
+            settings_data = read_yaml(DataAppConstants.SETTINGS_FILE)
+            merged = DataAppPackage._deep_merge_dicts(merged, settings_data or {})
+        except Exception as settings_error:
+            if not merged:
+                raise Exception(
+                    f"Failed to load app config for {app_name}: {str(settings_error)}"
+                ) from settings_error
+
+        if platform:
+            try:
+                platform_config_file = f"settings.{platform}.yaml"
+                platform_data = read_yaml(platform_config_file)
+                merged = DataAppPackage._deep_merge_dicts(merged, platform_data or {})
+                self.logger.info(f"Loaded platform config: {platform_config_file}")
+            except Exception:
+                try:
+                    legacy_platform_config_file = f"app.{platform}.yaml"
+                    legacy_platform_data = read_yaml(legacy_platform_config_file)
+                    merged = DataAppPackage._deep_merge_dicts(merged, legacy_platform_data or {})
+                    self.logger.info(
+                        f"Loaded legacy platform config: {legacy_platform_config_file}"
+                    )
+                except Exception:
+                    self.logger.debug("Platform settings overlay not found, using base settings")
+
         if environment:
             try:
-                env_config_file = f"app.{environment}.yaml"
-                env_config_path = f"{app_dir}{env_config_file}"
-                self.logger.debug(f"Loading config: {env_config_path}")
-                content = self.get_platform_service().read(env_config_path)
-                self.logger.info(f"Loaded environment config: {env_config_file}")
-                return content
-            except Exception:
-                self.logger.debug(
-                    f"Environment config {env_config_file} not found, trying base config"
+                env_config_file = DataAppConstants.ENV_CONFIG_TEMPLATE.format(
+                    environment=environment
                 )
+                env_data = read_yaml(env_config_file)
+                merged = DataAppPackage._deep_merge_dicts(merged, env_data or {})
+                self.logger.info(f"Loaded environment config: {env_config_file}")
+            except Exception:
+                try:
+                    legacy_env_config_file = f"app.{environment}.yaml"
+                    legacy_env_data = read_yaml(legacy_env_config_file)
+                    merged = DataAppPackage._deep_merge_dicts(merged, legacy_env_data or {})
+                    self.logger.info(f"Loaded legacy environment config: {legacy_env_config_file}")
+                except Exception:
+                    self.logger.debug("Environment settings overlay not found, using base settings")
 
-        # Fall back to base config
-        try:
-            config_path = f"{app_dir}{DataAppConstants.BASE_CONFIG_FILE}"
-            self.logger.debug(f"Loading config: {config_path}")
-            return self.get_platform_service().read(config_path)
-        except Exception as e:
-            raise Exception(f"Failed to load app config for {app_name}: {str(e)}")
+        return yaml.safe_dump(merged, indent=2)
 
     def _parse_config_content(self, content: str) -> Dict[str, Any]:
         """Parse config content (YAML or JSON fallback)"""

--- a/packages/kindling/data_apps.py
+++ b/packages/kindling/data_apps.py
@@ -210,7 +210,7 @@ class DataAppPackage:
     - ZIP archive with .kda extension
     - Contains app files (Python, YAML, etc.)
     - Includes kda-manifest.json with metadata
-    - May include platform-specific configs (app.<platform>.yaml)
+    - May include selected settings overlays (settings.<platform>.yaml, settings.<env>.yaml)
     """
 
     @staticmethod
@@ -231,7 +231,8 @@ class DataAppPackage:
             version: App version (from app.yaml if None)
             target_platform: Target platform (synapse, databricks, fabric)
             target_environment: Target environment settings overlay to include
-            merge_platform_config: If True, merge platform config into base config
+            merge_platform_config: If True, package only the selected platform/environment
+                                   settings overlays. If False, include all deployable app files.
             logger: Optional logger
 
         Returns:
@@ -576,8 +577,8 @@ class DataAppManager(DataAppRunner):
             version: App version (from metadata if None)
             target_platform: Target platform (synapse, databricks, fabric)
             target_environment: Target environment settings overlay to include
-            merge_platform_config: If True, merge platform config into base config.
-                                  If False, include all platform configs separately.
+            merge_platform_config: If True, package only the selected platform/environment
+                                  settings overlays. If False, include all deployable app files.
         """
         try:
             app_path = Path(app_directory)

--- a/packages/kindling/data_apps.py
+++ b/packages/kindling/data_apps.py
@@ -219,6 +219,7 @@ class DataAppPackage:
         output_path: Optional[str] = None,
         version: Optional[str] = None,
         target_platform: Optional[str] = None,
+        target_environment: Optional[str] = None,
         merge_platform_config: bool = True,
         logger=None,
     ) -> str:
@@ -229,6 +230,7 @@ class DataAppPackage:
             output_path: Output .kda file path (auto-generated if None)
             version: App version (from app.yaml if None)
             target_platform: Target platform (synapse, databricks, fabric)
+            target_environment: Target environment settings overlay to include
             merge_platform_config: If True, merge platform config into base config
             logger: Optional logger
 
@@ -279,6 +281,7 @@ class DataAppPackage:
                         if not is_deployable_app_file(
                             relative_path.as_posix(),
                             platform=target_platform,
+                            environment=target_environment,
                         ):
                             continue
                         kda_file.write(file_path, relative_path)
@@ -562,6 +565,7 @@ class DataAppManager(DataAppRunner):
         output_path: Optional[str] = None,
         version: Optional[str] = None,
         target_platform: Optional[str] = None,
+        target_environment: Optional[str] = None,
         merge_platform_config: bool = True,
     ) -> str:
         """Package a data app directory into a KDA file for a specific platform
@@ -571,6 +575,7 @@ class DataAppManager(DataAppRunner):
             output_path: Output KDA file path (auto-generated if None)
             version: App version (from metadata if None)
             target_platform: Target platform (synapse, databricks, fabric)
+            target_environment: Target environment settings overlay to include
             merge_platform_config: If True, merge platform config into base config.
                                   If False, include all platform configs separately.
         """
@@ -616,6 +621,7 @@ class DataAppManager(DataAppRunner):
                         if not is_deployable_app_file(
                             relative_path.as_posix(),
                             platform=target_platform,
+                            environment=target_environment,
                         ):
                             continue
                         kda_file.write(file_path, relative_path)
@@ -653,25 +659,6 @@ class DataAppManager(DataAppRunner):
             and filename != DataAppConstants.BASE_CONFIG_FILE
             and filename.endswith(".yaml")
         ) or is_settings_overlay(filename)
-
-    def _create_merged_config(self, config: "DataAppConfig") -> str:
-        """Create merged YAML config from DataAppConfig"""
-        try:
-            import yaml
-
-            config_dict = {
-                "name": config.name,
-                "description": config.description,
-                "entry_point": config.entry_point,
-                "environment": config.environment,
-                "dependencies": config.dependencies,
-                "metadata": config.metadata,
-            }
-
-            return yaml.safe_dump(config_dict, indent=2)
-        except ImportError:
-            # Fallback to JSON if yaml not available
-            return json.dumps(asdict(config), indent=2)
 
     def deploy_kda(self, kda_file_path: str, target_environment: Optional[str] = None) -> bool:
         """Deploy a KDA file to the artifacts storage"""
@@ -792,57 +779,6 @@ class DataAppManager(DataAppRunner):
         except Exception as e:
             self.logger.error(f"Failed to load app config from {app_path}: {str(e)}")
             raise
-
-    def _merge_platform_config_at_deploy_time(
-        self, app_path: Path, base_config: DataAppConfig, target_platform: str
-    ) -> DataAppConfig:
-        """Merge platform-specific config into base config at deploy time"""
-        try:
-            # Look for platform-specific config file
-            platform_config_file = app_path / f"app.{target_platform}.yaml"
-
-            if not platform_config_file.exists():
-                self.logger.debug(
-                    f"No platform config found for {target_platform}, using base config"
-                )
-                return base_config
-
-            # Load platform-specific overrides
-            with open(platform_config_file, "r") as f:
-                platform_content = f.read()
-
-            try:
-                platform_data = yaml.safe_load(platform_content)
-            except Exception:
-                platform_data = json.loads(platform_content)
-
-            # Create merged config (platform overrides base)
-            merged_metadata = base_config.metadata.copy()
-            if platform_data.get("metadata"):
-                merged_metadata.update(platform_data["metadata"])
-
-            merged_dependencies = base_config.dependencies.copy()
-            if platform_data.get("dependencies"):
-                # Platform dependencies extend base dependencies
-                for dep in platform_data["dependencies"]:
-                    if dep not in merged_dependencies:
-                        merged_dependencies.append(dep)
-
-            merged_config = DataAppConfig(
-                name=platform_data.get("name", base_config.name),
-                description=platform_data.get("description", base_config.description),
-                entry_point=platform_data.get("entry_point", base_config.entry_point),
-                dependencies=merged_dependencies,
-                environment=platform_data.get("environment", base_config.environment),
-                metadata=merged_metadata,
-            )
-
-            self.logger.debug(f"Merged {target_platform} config into base config")
-            return merged_config
-
-        except Exception as e:
-            self.logger.warning(f"Failed to merge platform config for {target_platform}: {str(e)}")
-            return base_config
 
     def _load_app_config(
         self,

--- a/packages/kindling/job_deployment.py
+++ b/packages/kindling/job_deployment.py
@@ -44,11 +44,18 @@ class AppPackager:
     """
 
     @staticmethod
-    def prepare_app_files(app_path: str) -> Dict[str, str]:
+    def prepare_app_files(
+        app_path: str,
+        *,
+        platform: Optional[str] = None,
+        environment: Optional[str] = None,
+    ) -> Dict[str, str]:
         """Prepare app files for deployment
 
         Args:
             app_path: Path to app directory or .kda file
+            platform: Optional target platform overlay to include
+            environment: Optional target environment overlay to include
 
         Returns:
             Dictionary of {filename: file_content}
@@ -56,14 +63,27 @@ class AppPackager:
         path = Path(app_path)
 
         if path.is_file() and path.suffix == ".kda":
-            return AppPackager.extract_kda_files(path)
+            return AppPackager.extract_kda_files(
+                path,
+                platform=platform,
+                environment=environment,
+            )
         elif path.is_dir():
-            return AppPackager.scan_directory_files(path)
+            return AppPackager.scan_directory_files(
+                path,
+                platform=platform,
+                environment=environment,
+            )
         else:
             raise ValueError(f"Invalid app path: {app_path}")
 
     @staticmethod
-    def extract_kda_files(kda_path: Path) -> Dict[str, str]:
+    def extract_kda_files(
+        kda_path: Path,
+        *,
+        platform: Optional[str] = None,
+        environment: Optional[str] = None,
+    ) -> Dict[str, str]:
         """Extract files from KDA package
 
         Args:
@@ -76,14 +96,23 @@ class AppPackager:
 
         with zipfile.ZipFile(kda_path, "r") as zf:
             for file_info in zf.filelist:
-                if is_deployable_app_file(file_info.filename):
+                if is_deployable_app_file(
+                    file_info.filename,
+                    platform=platform,
+                    environment=environment,
+                ):
                     content = zf.read(file_info.filename).decode("utf-8")
                     app_files[file_info.filename] = content
 
         return app_files
 
     @staticmethod
-    def scan_directory_files(dir_path: Path) -> Dict[str, str]:
+    def scan_directory_files(
+        dir_path: Path,
+        *,
+        platform: Optional[str] = None,
+        environment: Optional[str] = None,
+    ) -> Dict[str, str]:
         """Scan directory for Python and config files
 
         Args:
@@ -97,7 +126,11 @@ class AppPackager:
         for file_path in dir_path.rglob("*"):
             if not file_path.is_file():
                 continue
-            if not is_deployable_app_file(file_path.relative_to(dir_path).as_posix()):
+            if not is_deployable_app_file(
+                file_path.relative_to(dir_path).as_posix(),
+                platform=platform,
+                environment=environment,
+            ):
                 continue
             rel_path = file_path.relative_to(dir_path)
             with open(file_path, "r") as f:
@@ -229,7 +262,7 @@ class DataAppDeployer(SignalEmitter):
 
         try:
             # Prepare app files using utility
-            app_files = self.packager.prepare_app_files(app_path)
+            app_files = self.packager.prepare_app_files(app_path, platform=platform_name)
             self.logger.debug(f"Prepared {len(app_files)} app files")
 
             # Upload to platform storage

--- a/packages/kindling/job_deployment.py
+++ b/packages/kindling/job_deployment.py
@@ -17,6 +17,7 @@ This module contains:
     - DataAppDeployer: Service orchestrating the full lifecycle (app deploy + job create + run)
 """
 
+import os
 import time
 import uuid
 import zipfile
@@ -237,7 +238,12 @@ class DataAppDeployer(SignalEmitter):
         self.packager = AppPackager()
         self.validator = JobConfigValidator()
 
-    def deploy_app(self, app_path: str, app_name: str) -> str:
+    def deploy_app(
+        self,
+        app_path: str,
+        app_name: str,
+        environment: Optional[str] = None,
+    ) -> str:
         """Deploy app files to platform storage.
 
         This is INDEPENDENT of job creation. Apps are deployed to storage
@@ -246,11 +252,18 @@ class DataAppDeployer(SignalEmitter):
         Args:
             app_path: Path to app directory or .kda file
             app_name: Name for the deployed app (used as storage key)
+            environment: Optional target environment overlay to include
 
         Returns:
             Storage path where app was deployed
         """
         platform_name = self.platform.get_platform_name()
+        environment_name = (
+            environment
+            or os.getenv("KINDLING_ENV")
+            or os.getenv("PROJECT_ENV")
+            or os.getenv("ENVIRONMENT")
+        )
         self.logger.info(f"Deploying app '{app_name}' from: {app_path}")
 
         self.emit(
@@ -258,11 +271,16 @@ class DataAppDeployer(SignalEmitter):
             app_path=app_path,
             app_name=app_name,
             platform=platform_name,
+            environment=environment_name,
         )
 
         try:
             # Prepare app files using utility
-            app_files = self.packager.prepare_app_files(app_path, platform=platform_name)
+            app_files = self.packager.prepare_app_files(
+                app_path,
+                platform=platform_name,
+                environment=environment_name,
+            )
             self.logger.debug(f"Prepared {len(app_files)} app files")
 
             # Upload to platform storage
@@ -275,6 +293,7 @@ class DataAppDeployer(SignalEmitter):
                 app_name=app_name,
                 storage_path=storage_path,
                 platform=platform_name,
+                environment=environment_name,
             )
 
             return storage_path
@@ -365,7 +384,7 @@ class DataAppDeployer(SignalEmitter):
 
         try:
             # Step 1: Deploy app files to storage
-            self.deploy_app(app_path, app_name)
+            self.deploy_app(app_path, app_name, environment=job_config.get("environment"))
 
             # Step 2: Create job definition
             result = self.create_job(job_config)

--- a/packages/kindling_cli/kindling_cli/cli.py
+++ b/packages/kindling_cli/kindling_cli/cli.py
@@ -3218,9 +3218,15 @@ def _run_standalone_app(
     base_cfg = cfg_root / "settings.yaml"
     if base_cfg.exists():
         config_files.append(str(base_cfg))
-    platform_cfg = cfg_root / f"settings.{platform}.yaml"
-    if platform_cfg.exists():
-        config_files.append(str(platform_cfg))
+    overlay_platform = (
+        os.getenv("KINDLING_PLATFORM")
+        or os.getenv("KINDLING_PLATFORM_ENVIRONMENT")
+        or (platform if platform != "standalone" else None)
+    )
+    if overlay_platform:
+        platform_cfg = cfg_root / f"settings.{overlay_platform}.yaml"
+        if platform_cfg.exists():
+            config_files.append(str(platform_cfg))
     env_cfg = cfg_root / f"settings.{resolved_env}.yaml"
     if env_cfg.exists():
         config_files.append(str(env_cfg))

--- a/packages/kindling_cli/kindling_cli/cli.py
+++ b/packages/kindling_cli/kindling_cli/cli.py
@@ -35,8 +35,32 @@ try:
     from kindling.app_files import is_deployable_app_file
 except ImportError:  # CLI can be installed without the runtime package.
 
-    def is_deployable_app_file(path: str) -> bool:
+    def is_deployable_app_file(
+        path: str,
+        *,
+        platform: Optional[str] = None,
+        environment: Optional[str] = None,
+    ) -> bool:
         posix_path = PurePosixPath(path.replace("\\", "/"))
+        if posix_path.name in {"settings.local.yaml", "settings.local.yml"}:
+            return False
+        if (
+            posix_path.name.startswith("app.")
+            and posix_path.name != APP_CONFIG_FILE
+            and posix_path.suffix.lower() in {".yaml", ".yml"}
+        ):
+            return False
+        if (
+            posix_path.name not in {"settings.yaml", "settings.local.yaml", "settings.local.yml"}
+            and posix_path.name.startswith("settings.")
+            and posix_path.name.endswith((".yaml", ".yml"))
+        ):
+            return posix_path.name in {
+                f"settings.{platform}.yaml" if platform else "",
+                f"settings.{platform}.yml" if platform else "",
+                f"settings.{environment}.yaml" if environment else "",
+                f"settings.{environment}.yml" if environment else "",
+            }
         return posix_path.name in {"requirements.txt", "lake-reqs.txt"} or (
             posix_path.suffix.lower() in {".py", ".yaml", ".yml"}
         )
@@ -311,7 +335,12 @@ def _normalize_archive_entry_path(entry_name: str) -> str:
     return posix_path.as_posix()
 
 
-def _prepare_app_files(app_path: Path) -> Dict[str, str]:
+def _prepare_app_files(
+    app_path: Path,
+    *,
+    platform: Optional[str] = None,
+    environment: Optional[str] = None,
+) -> Dict[str, str]:
     """Collect app source files from a directory or a .kda archive."""
     resolved_path = app_path.expanduser().resolve()
 
@@ -323,7 +352,11 @@ def _prepare_app_files(app_path: Path) -> Dict[str, str]:
                     if file_info.is_dir():
                         continue
                     rel_path = _normalize_archive_entry_path(file_info.filename)
-                    if not is_deployable_app_file(rel_path):
+                    if not is_deployable_app_file(
+                        rel_path,
+                        platform=platform,
+                        environment=environment,
+                    ):
                         continue
                     app_files[rel_path] = archive.read(file_info.filename).decode("utf-8")
         except Exception as exc:
@@ -344,7 +377,11 @@ def _prepare_app_files(app_path: Path) -> Dict[str, str]:
             if not file_path.is_file():
                 continue
             rel_path = file_path.relative_to(resolved_path).as_posix()
-            if not is_deployable_app_file(rel_path):
+            if not is_deployable_app_file(
+                rel_path,
+                platform=platform,
+                environment=environment,
+            ):
                 continue
             app_files[rel_path] = _read_text_file(file_path)
 
@@ -486,9 +523,9 @@ def _resolve_config_path(
     base_dir = config_dir / "data-apps" / app_name if app_name else config_dir
 
     if level == "platform":
-        return base_dir / f"platform_{platform}.yaml"
+        return base_dir / f"settings.{platform}.yaml"
     if level == "env":
-        return base_dir / f"env_{environment}.yaml"
+        return base_dir / f"settings.{environment}.yaml"
     return base_dir / "settings.yaml"
 
 
@@ -1672,6 +1709,12 @@ def workspace_group() -> None:
     help="Kindling settings file to deploy.",
 )
 @click.option(
+    "--env",
+    "environment",
+    default=None,
+    help="Environment settings overlay to deploy. Defaults to KINDLING_ENV when set.",
+)
+@click.option(
     "--notebook-bootstrap",
     "notebook_bootstrap",
     is_flag=True,
@@ -1693,6 +1736,7 @@ def workspace_init(
     container: Optional[str],
     base_path: Optional[str],
     config_path: Path,
+    environment: Optional[str],
     notebook_bootstrap: bool,
     workspace: Optional[str],
     overwrite: bool,
@@ -1712,6 +1756,7 @@ def workspace_init(
     resolved_platform = platform or _detect_platform_from_environment()
     if not resolved_platform:
         raise click.ClickException(_PLATFORM_NOT_FOUND_MSG)
+    resolved_environment = environment or os.getenv("KINDLING_ENV")
 
     resolved_account, resolved_container, resolved_base = _resolve_storage_env(
         storage_account, container, base_path
@@ -1736,7 +1781,13 @@ def workspace_init(
     config_dest = f"{resolved_base}/config" if resolved_base else "config"
     click.echo(f"Config → {config_dest}/")
     _deploy_config(
-        blob_service_client, resolved_container, resolved_base, resolved_config, overwrite=overwrite
+        blob_service_client,
+        resolved_container,
+        resolved_base,
+        resolved_config,
+        overwrite=overwrite,
+        platform=resolved_platform,
+        environment=resolved_environment,
     )
     click.echo()
 
@@ -2215,13 +2266,26 @@ def _deploy_config(
     base_path: str,
     config_path: Path,
     overwrite: bool = True,
+    platform: Optional[str] = None,
+    environment: Optional[str] = None,
 ) -> None:
-    """Upload settings.yaml (and any platform_*/env_* companions) to storage."""
+    """Upload settings.yaml and selected dot-style settings overlays to storage."""
     config_dir = config_path.parent
     config_files = [config_path]
-    # Include platform and environment overlays from the same directory
-    config_files.extend(sorted(config_dir.glob("platform_*.yaml")))
-    config_files.extend(sorted(config_dir.glob("env_*.yaml")))
+    if platform:
+        config_files.extend(
+            [
+                config_dir / f"settings.{platform}.yaml",
+                config_dir / f"settings.{platform}.yml",
+            ]
+        )
+    if environment:
+        config_files.extend(
+            [
+                config_dir / f"settings.{environment}.yaml",
+                config_dir / f"settings.{environment}.yml",
+            ]
+        )
     # De-duplicate while preserving order
     seen: set = set()
     unique: List[Path] = []
@@ -2510,6 +2574,12 @@ def _import_notebook_to_workspace(
     help="Kindling settings file to deploy.",
 )
 @click.option(
+    "--env",
+    "environment",
+    default=None,
+    help="Environment settings overlay to deploy. Defaults to KINDLING_ENV when set.",
+)
+@click.option(
     "--storage-account",
     "storage_account",
     default=None,
@@ -2545,6 +2615,7 @@ def _import_notebook_to_workspace(
 def workspace_deploy(
     platform: Optional[str],
     config_path: Path,
+    environment: Optional[str],
     storage_account: Optional[str],
     container: Optional[str],
     base_path: Optional[str],
@@ -2576,6 +2647,7 @@ def workspace_deploy(
             "Unable to determine platform. Set --platform or one of "
             "FABRIC_WORKSPACE_ID, SYNAPSE_WORKSPACE_NAME, DATABRICKS_HOST."
         )
+    resolved_environment = environment or os.getenv("KINDLING_ENV")
 
     resolved_account, resolved_container, resolved_base = _resolve_storage_env(
         storage_account,
@@ -2610,6 +2682,8 @@ def workspace_deploy(
                 resolved_base,
                 resolved_config,
                 overwrite=overwrite,
+                platform=resolved_platform,
+                environment=resolved_environment,
             )
             click.echo()
 
@@ -2817,11 +2891,25 @@ def app_init(
     type=click.Path(path_type=Path),
     help="Destination .kda file or directory. Defaults to dist/<app-dir>.kda.",
 )
+@click.option(
+    "--platform",
+    type=click.Choice(SUPPORTED_PLATFORMS),
+    default=None,
+    help="Target platform overlay to include.",
+)
+@click.option(
+    "--env",
+    "environment",
+    default=None,
+    help="Target environment overlay to include.",
+)
 @click.option("--json", "json_output", is_flag=True, help="Emit machine-readable JSON.")
 def app_package(
     app_name: str,
     local_folder: Optional[Path],
     output_path: Optional[Path],
+    platform: Optional[str],
+    environment: Optional[str],
     json_output: bool,
 ) -> None:
     """Package an application directory into a .kda archive.
@@ -2832,7 +2920,11 @@ def app_package(
         resolved_app_path = local_folder.expanduser().resolve()
     else:
         resolved_app_path = _resolve_by_convention(app_name, "apps", "app")
-    app_files = _prepare_app_files(resolved_app_path)
+    app_files = _prepare_app_files(
+        resolved_app_path,
+        platform=platform,
+        environment=environment,
+    )
 
     if output_path is None:
         resolved_output = (Path.cwd() / "dist" / f"{resolved_app_path.name}.kda").resolve()
@@ -2851,6 +2943,8 @@ def app_package(
     payload = {
         "app_path": str(resolved_app_path),
         "package_path": str(resolved_output),
+        "platform": platform,
+        "environment": environment,
         "file_count": len(app_files),
         "files": sorted(app_files),
     }
@@ -2889,6 +2983,12 @@ def app_package(
     default=None,
     help="Target platform. Auto-detected from environment if omitted.",
 )
+@click.option(
+    "--env",
+    "environment",
+    default=None,
+    help="Target environment overlay to include.",
+)
 @click.option("--json", "json_output", is_flag=True, help="Emit machine-readable JSON.")
 def app_deploy(
     app_name: str,
@@ -2896,6 +2996,7 @@ def app_deploy(
     kda_package: Optional[Path],
     remote_app_name: Optional[str],
     platform: Optional[str],
+    environment: Optional[str],
     json_output: bool,
 ) -> None:
     """Deploy an app to a remote platform.
@@ -2913,9 +3014,14 @@ def app_deploy(
     else:
         resolved_app_path = _resolve_by_convention(app_name, "apps", "app")
 
-    app_files = _prepare_app_files(resolved_app_path)
-    _validate_app_entry_point(app_files, resolved_app_path)
     resolved_platform = _resolve_remote_platform(platform)
+    resolved_environment = environment or os.getenv("KINDLING_ENV")
+    app_files = _prepare_app_files(
+        resolved_app_path,
+        platform=resolved_platform,
+        environment=resolved_environment,
+    )
+    _validate_app_entry_point(app_files, resolved_app_path)
     api_client, resolved_platform = _create_platform_api(resolved_platform)
     resolved_name = (remote_app_name or _default_app_name(resolved_app_path)).strip()
     if not resolved_name:
@@ -2926,6 +3032,7 @@ def app_deploy(
         "app_name": resolved_name,
         "app_path": str(resolved_app_path),
         "platform": resolved_platform,
+        "environment": resolved_environment,
         "storage_path": storage_path,
         "file_count": len(app_files),
         "files": sorted(app_files),
@@ -3068,6 +3175,7 @@ def _run_standalone_app(
     app_ref: str,
     env: Optional[str],
     config_dir: Optional[Path],
+    platform: str,
     quiet: bool,
     local_packages: Tuple[Path, ...],
     parameters_path: Optional[Path],
@@ -3110,6 +3218,9 @@ def _run_standalone_app(
     base_cfg = cfg_root / "settings.yaml"
     if base_cfg.exists():
         config_files.append(str(base_cfg))
+    platform_cfg = cfg_root / f"settings.{platform}.yaml"
+    if platform_cfg.exists():
+        config_files.append(str(platform_cfg))
     env_cfg = cfg_root / f"settings.{resolved_env}.yaml"
     if env_cfg.exists():
         config_files.append(str(env_cfg))
@@ -3311,6 +3422,7 @@ def app_run(
             resolved_app_ref,
             env,
             config_dir,
+            platform,
             quiet,
             local_packages,
             parameters_path,

--- a/packages/kindling_cli/pyproject.toml
+++ b/packages/kindling_cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "spark-kindling-cli"
-version = "0.10.31"
+version = "0.10.32"
 description = "Command-line tooling for Kindling"
 authors = ["SEP Engineering <engineering@sep.com>"]
 license = "MIT"

--- a/packages/kindling_sdk/pyproject.toml
+++ b/packages/kindling_sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "spark-kindling-sdk"
-version = "0.10.31"
+version = "0.10.32"
 description = "Design-time platform SDK for Kindling"
 authors = ["SEP Engineering <engineering@sep.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "spark-kindling"
-version = "0.10.31"
+version = "0.10.32"
 description = "A unified framework for data apps across Fabric, Synapse, and Databricks"
 authors = ["SEP Engineering <engineering@sep.com>"]
 license = "MIT"

--- a/tests/unit/test_app_framework.py
+++ b/tests/unit/test_app_framework.py
@@ -15,7 +15,6 @@ from typing import Any, Dict, List
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-
 from kindling.data_apps import (
     DataAppConfig,
     DataAppConstants,
@@ -130,6 +129,50 @@ class TestAppManagerHelpers:
         """Test _get_app_dir helper"""
         result = mock_app_manager._get_app_dir("my_app")
         assert result == "/artifacts/data-apps/my_app/"
+
+    def test_load_config_content_merges_settings_platform_then_env(self):
+        """App-local runtime settings should load base, platform, then env."""
+        import yaml
+
+        files = {
+            "/artifacts/data-apps/demo/app.yaml": "name: demo\nentry_point: app.py\n",
+            "/artifacts/data-apps/demo/settings.yaml": (
+                "kindling:\n  telemetry:\n    logging:\n      level: INFO\n"
+            ),
+            "/artifacts/data-apps/demo/settings.fabric.yaml": (
+                "kindling:\n  telemetry:\n    logging:\n      level: DEBUG\n"
+            ),
+            "/artifacts/data-apps/demo/settings.prod.yaml": (
+                "kindling:\n  telemetry:\n    logging:\n      level: ERROR\n"
+            ),
+        }
+
+        platform_service = Mock()
+
+        def read(path):
+            if path not in files:
+                raise FileNotFoundError(path)
+            return files[path]
+
+        platform_service.read.side_effect = read
+
+        manager = Mock(spec=DataAppManager)
+        manager.artifacts_path = "/artifacts"
+        manager.logger = Mock()
+        manager.config = Mock()
+        manager.config.get.return_value = "data-apps"
+        manager.get_platform_service.return_value = platform_service
+        manager._get_app_dir = DataAppManager._get_app_dir.__get__(manager)
+        manager._parse_config_content = DataAppManager._parse_config_content.__get__(manager)
+        manager._load_config_content = DataAppManager._load_config_content.__get__(manager)
+
+        merged = yaml.safe_load(
+            manager._load_config_content("demo", environment="prod", platform="fabric")
+        )
+
+        assert merged["name"] == "demo"
+        assert merged["entry_point"] == "app.py"
+        assert merged["kindling"]["telemetry"]["logging"]["level"] == "ERROR"
 
     def test_extract_package_name_simple(self, mock_app_manager):
         """Test package name extraction"""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1615,6 +1615,51 @@ class TestAppRunCommand:
         assert env["KINDLING_LOG_LEVEL"] == "WARNING"
         assert "KINDLING_CONFIG_DIR" not in env
 
+    def test_standalone_config_args_include_selected_platform_then_env(self, tmp_path, monkeypatch):
+        import subprocess
+
+        app_dir = tmp_path / "myapp"
+        app_dir.mkdir()
+        (app_dir / "app.py").write_text("# stub\n", encoding="utf-8")
+        (app_dir / "settings.yaml").write_text("base: true\n", encoding="utf-8")
+        (app_dir / "settings.fabric.yaml").write_text("platform: fabric\n", encoding="utf-8")
+        (app_dir / "settings.dev.yaml").write_text("env: dev\n", encoding="utf-8")
+        (app_dir / "settings.standalone.yaml").write_text(
+            "platform: standalone\n", encoding="utf-8"
+        )
+
+        captured_cmd = []
+
+        def fake_run(cmd, env=None, **kwargs):
+            captured_cmd.extend(cmd)
+            return subprocess.CompletedProcess(cmd, returncode=0)
+
+        monkeypatch.setenv("KINDLING_PLATFORM", "fabric")
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        result = CliRunner().invoke(
+            cli,
+            [
+                "app",
+                "run",
+                "myapp",
+                "--local-folder",
+                str(app_dir),
+                "--env",
+                "dev",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        config_args = [
+            captured_cmd[i + 1] for i, arg in enumerate(captured_cmd) if arg == "--config"
+        ]
+        assert config_args == [
+            str(app_dir / "settings.yaml"),
+            str(app_dir / "settings.fabric.yaml"),
+            str(app_dir / "settings.dev.yaml"),
+        ]
+
     def test_standalone_uses_kindling_runner_module(self, tmp_path, monkeypatch):
         import subprocess
 
@@ -3159,3 +3204,50 @@ def test_migrate_plan_accepts_env_and_config_flags(tmp_path, monkeypatch):
         ["migrate", "plan", "--app", "app.py", "--env", "prod", "--config", str(tmp_path)],
     )
     assert result.exit_code == 0, result.output
+
+
+def test_deploy_config_uploads_only_selected_overlays(tmp_path):
+    from unittest.mock import MagicMock
+
+    from kindling_cli.cli import _deploy_config
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    for filename in [
+        "settings.yaml",
+        "settings.fabric.yaml",
+        "settings.synapse.yaml",
+        "settings.prod.yaml",
+        "settings.dev.yaml",
+        "settings.local.yaml",
+    ]:
+        (config_dir / filename).write_text(f"name: {filename}\n", encoding="utf-8")
+
+    uploaded = {}
+
+    def get_blob_client(container, blob):
+        blob_client = MagicMock()
+
+        def upload_blob(data, overwrite=True):
+            uploaded[blob] = data
+
+        blob_client.upload_blob.side_effect = upload_blob
+        return blob_client
+
+    blob_service_client = MagicMock()
+    blob_service_client.get_blob_client.side_effect = get_blob_client
+
+    _deploy_config(
+        blob_service_client,
+        "artifacts",
+        "base",
+        config_dir / "settings.yaml",
+        platform="fabric",
+        environment="prod",
+    )
+
+    assert sorted(uploaded) == [
+        "base/config/settings.fabric.yaml",
+        "base/config/settings.prod.yaml",
+        "base/config/settings.yaml",
+    ]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -378,7 +378,7 @@ class TestConfigSetLevelRouting:
                 ],
             )
             assert result.exit_code == 0
-            path = Path("platform_fabric.yaml")
+            path = Path("settings.fabric.yaml")
             assert path.exists()
             data = yaml.safe_load(path.read_text())
             assert data["kindling"]["secrets"]["scope"] == "fabric-scope"
@@ -400,7 +400,7 @@ class TestConfigSetLevelRouting:
                 ],
             )
             assert result.exit_code == 0
-            path = Path("env_prod.yaml")
+            path = Path("settings.prod.yaml")
             assert path.exists()
             data = yaml.safe_load(path.read_text())
             assert data["kindling"]["telemetry"]["logging"]["level"] == "ERROR"
@@ -480,7 +480,7 @@ class TestConfigSetAppScope:
                 ],
             )
             assert result.exit_code == 0
-            path = Path("data-apps/ingest-app/platform_databricks.yaml")
+            path = Path("data-apps/ingest-app/settings.databricks.yaml")
             assert path.exists()
             data = yaml.safe_load(path.read_text())
             assert data["kindling"]["secrets"]["scope"] == "db-scope"
@@ -605,6 +605,47 @@ def test_app_package_creates_kda_archive():
                 "app.py",
                 "lake-reqs.txt",
                 "nested/settings.yaml",
+            ]
+
+
+def test_app_package_includes_only_selected_settings_overlays():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        app_dir = Path("demo_app")
+        app_dir.mkdir()
+        (app_dir / "app.py").write_text("print('hello')\n", encoding="utf-8")
+        (app_dir / "app.yaml").write_text("name: demo\n", encoding="utf-8")
+        (app_dir / "app.fabric.yaml").write_text("legacy: true\n", encoding="utf-8")
+        (app_dir / "settings.yaml").write_text("name: demo\n", encoding="utf-8")
+        (app_dir / "settings.fabric.yaml").write_text("platform: fabric\n", encoding="utf-8")
+        (app_dir / "settings.synapse.yaml").write_text("platform: synapse\n", encoding="utf-8")
+        (app_dir / "settings.prod.yaml").write_text("env: prod\n", encoding="utf-8")
+        (app_dir / "settings.dev.yaml").write_text("env: dev\n", encoding="utf-8")
+        (app_dir / "settings.local.yaml").write_text("local: true\n", encoding="utf-8")
+
+        result = runner.invoke(
+            cli,
+            [
+                "app",
+                "package",
+                "demo_app",
+                "--local-folder",
+                str(app_dir),
+                "--platform",
+                "fabric",
+                "--env",
+                "prod",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        with zipfile.ZipFile(Path("dist/demo_app.kda"), "r") as archive:
+            assert sorted(archive.namelist()) == [
+                "app.py",
+                "app.yaml",
+                "settings.fabric.yaml",
+                "settings.prod.yaml",
+                "settings.yaml",
             ]
 
 
@@ -1194,7 +1235,9 @@ class TestWorkspaceInit:
         deployed = []
         monkeypatch.setattr(
             "kindling_cli.cli._deploy_config",
-            lambda client, container, base, config, overwrite=False: deployed.append(config),
+            lambda client, container, base, config, overwrite=False, **kwargs: deployed.append(
+                config
+            ),
         )
         runner = CliRunner()
         with runner.isolated_filesystem():
@@ -1236,7 +1279,9 @@ class TestWorkspaceInit:
         calls = []
         monkeypatch.setattr(
             "kindling_cli.cli._deploy_config",
-            lambda client, container, base, config, overwrite=False: calls.append(overwrite),
+            lambda client, container, base, config, overwrite=False, **kwargs: calls.append(
+                overwrite
+            ),
         )
         runner = CliRunner()
         with runner.isolated_filesystem():

--- a/tests/unit/test_job_deployment.py
+++ b/tests/unit/test_job_deployment.py
@@ -100,6 +100,7 @@ class TestDataAppDeployer:
             (app_path / "settings.yaml").write_text("base: true")
             (app_path / "settings.fabric.yaml").write_text("platform: fabric")
             (app_path / "settings.prod.yaml").write_text("env: prod")
+            (app_path / "settings.prod.yml").write_text("env: prod-yml")
             (app_path / "settings.dev.yaml").write_text("env: dev")
 
             mock_platform = Mock()
@@ -118,6 +119,7 @@ class TestDataAppDeployer:
             assert "settings.yaml" in app_files
             assert "settings.fabric.yaml" in app_files
             assert "settings.prod.yaml" in app_files
+            assert "settings.prod.yml" not in app_files
             assert "settings.dev.yaml" not in app_files
 
     def test_create_job_creates_definition(self):

--- a/tests/unit/test_job_deployment.py
+++ b/tests/unit/test_job_deployment.py
@@ -86,6 +86,40 @@ class TestDataAppDeployer:
             assert "app.yaml" in app_files
             assert storage_path == "data-apps/test-app"
 
+    def test_deploy_app_includes_selected_environment_overlay(self):
+        """DataAppDeployer should pass env selection through app file assembly."""
+        from kindling.job_deployment import (
+            AppPackager,
+            DataAppDeployer,
+            JobConfigValidator,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app_path = Path(tmpdir)
+            (app_path / "app.py").write_text("# Main file")
+            (app_path / "settings.yaml").write_text("base: true")
+            (app_path / "settings.fabric.yaml").write_text("platform: fabric")
+            (app_path / "settings.prod.yaml").write_text("env: prod")
+            (app_path / "settings.dev.yaml").write_text("env: dev")
+
+            mock_platform = Mock()
+            mock_platform.get_platform_name.return_value = "fabric"
+            mock_platform.deploy_app.return_value = "data-apps/test-app"
+
+            deployer = DataAppDeployer.__new__(DataAppDeployer)
+            deployer.platform = mock_platform
+            deployer.logger = Mock()
+            deployer.packager = AppPackager()
+            deployer.validator = JobConfigValidator()
+
+            deployer.deploy_app(str(app_path), "test-app", environment="prod")
+
+            app_files = mock_platform.deploy_app.call_args[0][1]
+            assert "settings.yaml" in app_files
+            assert "settings.fabric.yaml" in app_files
+            assert "settings.prod.yaml" in app_files
+            assert "settings.dev.yaml" not in app_files
+
     def test_create_job_creates_definition(self):
         """Test that create_job calls platform create_job"""
         from kindling.job_deployment import DataAppDeployer, JobConfigValidator

--- a/tests/unit/test_kda_integration.py
+++ b/tests/unit/test_kda_integration.py
@@ -113,6 +113,16 @@ environment_vars:
   fabric.only: "true"
 """
             )
+            (app_dir / "settings.prod.yaml").write_text(
+                """environment_vars:
+  ENVIRONMENT: prod
+"""
+            )
+            (app_dir / "settings.dev.yaml").write_text(
+                """environment_vars:
+  ENVIRONMENT: dev
+"""
+            )
 
             (app_dir / "app.py").write_text("print('test')")
 
@@ -120,6 +130,7 @@ environment_vars:
             kda_path = DataAppPackage.create(
                 app_directory=str(app_dir),
                 target_platform="synapse",
+                target_environment="prod",
                 merge_platform_config=True,
             )
 
@@ -128,8 +139,10 @@ environment_vars:
                 names = set(zf.namelist())
                 assert "app.synapse.yaml" not in names
                 assert "settings.fabric.yaml" not in names
+                assert "settings.dev.yaml" not in names
                 assert "settings.yaml" in names
                 assert "settings.synapse.yaml" in names
+                assert "settings.prod.yaml" in names
 
                 app_yaml_content = zf.read("app.yaml").decode()
                 app_config = yaml.safe_load(app_yaml_content)

--- a/tests/unit/test_kda_integration.py
+++ b/tests/unit/test_kda_integration.py
@@ -67,12 +67,11 @@ entry_point: app.py
                 assert "app.py" in names, "KDA should contain app.py"
                 assert "app.yaml" in names, "KDA should contain app.yaml"
 
-    def test_kda_platform_config_merge(self):
-        """Test that platform-specific configs are merged correctly"""
+    def test_kda_platform_settings_overlay_selection(self):
+        """Test that selected settings overlays are packaged without merging app.yaml"""
         import json
 
         import yaml
-
         from kindling.data_apps import DataAppPackage
 
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -89,12 +88,29 @@ spark_config:
 """
             )
 
-            # Create Synapse-specific config
+            # Legacy Synapse-specific app config should not be packaged into app.yaml
             (app_dir / "app.synapse.yaml").write_text(
                 """spark_config:
   spark.synapse.linkedService.useDefaultCredential: "true"
 environment_vars:
   PLATFORM: synapse
+"""
+            )
+            (app_dir / "settings.yaml").write_text(
+                """spark_config:
+  base.setting: "true"
+"""
+            )
+            (app_dir / "settings.synapse.yaml").write_text(
+                """spark_config:
+  spark.synapse.linkedService.useDefaultCredential: "true"
+environment_vars:
+  PLATFORM: synapse
+"""
+            )
+            (app_dir / "settings.fabric.yaml").write_text(
+                """spark_config:
+  fabric.only: "true"
 """
             )
 
@@ -107,25 +123,32 @@ environment_vars:
                 merge_platform_config=True,
             )
 
-            # Extract and verify merged config
+            # Extract and verify manifest/settings selection
             with zipfile.ZipFile(kda_path, "r") as zf:
-                # Read app.yaml from KDA
+                names = set(zf.namelist())
+                assert "app.synapse.yaml" not in names
+                assert "settings.fabric.yaml" not in names
+                assert "settings.yaml" in names
+                assert "settings.synapse.yaml" in names
+
                 app_yaml_content = zf.read("app.yaml").decode()
                 app_config = yaml.safe_load(app_yaml_content)
-
-                # Should have base config
                 assert "spark_config" in app_config
                 assert app_config["spark_config"]["spark.sql.shuffle.partitions"] == "10"
-
-                # Should have merged Synapse config
                 assert (
-                    app_config["spark_config"]["spark.synapse.linkedService.useDefaultCredential"]
-                    == "true"
+                    "spark.synapse.linkedService.useDefaultCredential"
+                    not in app_config["spark_config"]
                 )
 
-                # Should have environment vars from Synapse config
-                if "environment_vars" in app_config:
-                    assert app_config["environment_vars"]["PLATFORM"] == "synapse"
+                settings_content = zf.read("settings.synapse.yaml").decode()
+                settings_config = yaml.safe_load(settings_content)
+                assert (
+                    settings_config["spark_config"][
+                        "spark.synapse.linkedService.useDefaultCredential"
+                    ]
+                    == "true"
+                )
+                assert settings_config["environment_vars"]["PLATFORM"] == "synapse"
 
 
 class TestKDAAppStructure:

--- a/tests/unit/test_notebook_utilities.py
+++ b/tests/unit/test_notebook_utilities.py
@@ -272,6 +272,13 @@ entry_point: app.py
   spark.synapse.setting: "true"
 """
             )
+            (app_dir / "settings.yaml").write_text("base: true\n")
+            (app_dir / "settings.synapse.yaml").write_text(
+                """spark_config:
+  spark.synapse.setting: "true"
+"""
+            )
+            (app_dir / "settings.fabric.yaml").write_text("fabric: true\n")
 
             (app_dir / "app.py").write_text("print('test')")
 
@@ -286,7 +293,10 @@ entry_point: app.py
                 names = zf.namelist()
                 # Platform-specific config should NOT be in merged package
                 assert "app.synapse.yaml" not in names
-                # But merged app.yaml should be present
+                assert "settings.fabric.yaml" not in names
+                assert "settings.yaml" in names
+                assert "settings.synapse.yaml" in names
+                # app.yaml remains the manifest
                 assert "app.yaml" in names
 
     def test_extract_kda_package(self):

--- a/tests/unit/test_platform_workspace_config.py
+++ b/tests/unit/test_platform_workspace_config.py
@@ -24,7 +24,7 @@ class TestPlatformWorkspaceConfig:
             settings_file = config_dir / "settings.yaml"
             settings_file.write_text("kindling:\n  version: '0.2.0'\n")
 
-            dev_file = config_dir / "env_dev.yaml"
+            dev_file = config_dir / "settings.dev.yaml"
             dev_file.write_text("kindling:\n  TELEMETRY:\n    logging:\n      level: DEBUG\n")
 
             # Mock storage utils
@@ -50,10 +50,10 @@ class TestPlatformWorkspaceConfig:
                     workspace_id=None,
                 )
 
-                # Should have downloaded 2 files: settings.yaml and env_dev.yaml
+                # Should have downloaded 2 files: settings.yaml and settings.dev.yaml
                 assert len(config_files) == 2
                 assert "settings.yaml" in config_files[0]
-                assert "env_dev.yaml" in config_files[1]
+                assert "settings.dev.yaml" in config_files[1]
 
     def test_download_config_files_with_platform(self):
         """Test config file download with platform-specific config"""
@@ -67,12 +67,12 @@ class TestPlatformWorkspaceConfig:
             settings_file = config_dir / "settings.yaml"
             settings_file.write_text("kindling:\n  version: '0.2.0'\n")
 
-            platform_file = config_dir / "platform_fabric.yaml"
+            platform_file = config_dir / "settings.fabric.yaml"
             platform_file.write_text(
                 "kindling:\n  platform:\n    name: fabric\n  TELEMETRY:\n    logging:\n      level: DEBUG\n"
             )
 
-            dev_file = config_dir / "env_dev.yaml"
+            dev_file = config_dir / "settings.dev.yaml"
             dev_file.write_text("kindling:\n  TELEMETRY:\n    logging:\n      level: INFO\n")
 
             # Mock storage utils
@@ -100,8 +100,8 @@ class TestPlatformWorkspaceConfig:
                 # Should have 3 files: settings, platform_fabric, env_dev
                 assert len(config_files) == 3
                 assert "settings.yaml" in config_files[0]
-                assert "platform_fabric.yaml" in config_files[1]
-                assert "env_dev.yaml" in config_files[2]
+                assert "settings.fabric.yaml" in config_files[1]
+                assert "settings.dev.yaml" in config_files[2]
 
     def test_download_config_files_with_workspace(self):
         """Test config file download with workspace-specific config"""
@@ -115,13 +115,13 @@ class TestPlatformWorkspaceConfig:
             settings_file = config_dir / "settings.yaml"
             settings_file.write_text("kindling:\n  version: '0.2.0'\n")
 
-            platform_file = config_dir / "platform_fabric.yaml"
+            platform_file = config_dir / "settings.fabric.yaml"
             platform_file.write_text("kindling:\n  platform:\n    name: fabric\n")
 
             workspace_file = config_dir / "workspace_abc123.yaml"
             workspace_file.write_text("kindling:\n  workspace:\n    team: 'team-a'\n")
 
-            dev_file = config_dir / "env_dev.yaml"
+            dev_file = config_dir / "settings.dev.yaml"
             dev_file.write_text("kindling:\n  TELEMETRY:\n    logging:\n      level: INFO\n")
 
             # Mock storage utils
@@ -149,9 +149,57 @@ class TestPlatformWorkspaceConfig:
                 # Should have 4 files: settings, platform_fabric, workspace_abc123, env_dev
                 assert len(config_files) == 4
                 assert "settings.yaml" in config_files[0]
-                assert "platform_fabric.yaml" in config_files[1]
+                assert "settings.fabric.yaml" in config_files[1]
                 assert "workspace_abc123.yaml" in config_files[2]
-                assert "env_dev.yaml" in config_files[3]
+                assert "settings.dev.yaml" in config_files[3]
+
+    def test_download_config_files_with_app_overlays_env_wins_order(self):
+        """App-local settings overlays should load after workspace/global config."""
+        from kindling.bootstrap import download_config_files
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            config_dir = root / "config"
+            app_dir = root / "data-apps" / "demo"
+            config_dir.mkdir()
+            app_dir.mkdir(parents=True)
+
+            (config_dir / "settings.yaml").write_text("scope: global\n")
+            (config_dir / "settings.fabric.yaml").write_text("scope: global-platform\n")
+            (config_dir / "settings.dev.yaml").write_text("scope: global-env\n")
+            (app_dir / "settings.yaml").write_text("scope: app\n")
+            (app_dir / "settings.fabric.yaml").write_text("scope: app-platform\n")
+            (app_dir / "settings.dev.yaml").write_text("scope: app-env\n")
+
+            mock_storage = MagicMock()
+
+            def mock_cp(remote, local):
+                local_path = local.replace("file://", "")
+                source = Path(remote)
+                if source.exists():
+                    Path(local_path).write_text(source.read_text())
+                else:
+                    raise FileNotFoundError(f"Config file not found: {remote}")
+
+            mock_storage.fs.cp = mock_cp
+
+            with patch("kindling.bootstrap._get_storage_utils", return_value=mock_storage):
+                config_files = download_config_files(
+                    artifacts_storage_path=tmpdir,
+                    environment="dev",
+                    platform="fabric",
+                    workspace_id=None,
+                    app_name="demo",
+                )
+
+        assert [Path(path).name for path in config_files] == [
+            "0_settings.yaml",
+            "1_settings.fabric.yaml",
+            "2_settings.dev.yaml",
+            "3_app_demo_settings.yaml",
+            "4_app_demo_settings.fabric.yaml",
+            "5_app_demo_settings.dev.yaml",
+        ]
 
     def test_download_config_files_missing_optional(self):
         """Test that missing optional config files are handled gracefully"""


### PR DESCRIPTION
## Summary
- package and deploy only the selected app settings overlays
- pass environment selection through app deployment and KDA packaging
- document dot-style settings overlay names and precedence

## Tests
- poetry run pytest tests/unit/test_cli.py tests/unit/test_job_deployment.py tests/unit/test_kda_integration.py tests/unit/test_notebook_utilities.py