### PR TITLE
fix(watermarking): incremental-read correctness bugs; extract watermark logic into signal aspect

### DIFF
--- a/packages/kindling/bootstrap.py
+++ b/packages/kindling/bootstrap.py
@@ -1615,6 +1615,18 @@ def initialize_framework(config: Dict[str, Any], app_name: Optional[str] = None)
         platformservice = initialize_platform_services(platform, config_service, logger)
         logger.info("Platform services initialized")
 
+        # Attach the watermark aspect: incremental reads and watermark
+        # advancement hook into pipe execution via signals rather than being
+        # woven into the read/persist strategy. Standalone/local execution
+        # deliberately runs without it (full reads, no watermark state),
+        # matching the fixture-based local dev workflow.
+        if platform != "standalone":
+            from kindling.injection import GlobalInjector
+            from kindling.watermarking import WatermarkAspect
+
+            GlobalInjector.get(WatermarkAspect).register()
+            logger.info("Watermark aspect registered")
+
         # Apply spark_configs to the live Spark session.
         # This must happen after the session exists so conf.set() works.
         _apply_spark_configs(config_service, logger)

--- a/packages/kindling/data_entities.py
+++ b/packages/kindling/data_entities.py
@@ -7,12 +7,11 @@ from typing import Any, Callable, Dict, List, Optional
 
 from delta.tables import DeltaTable
 from injector import Binder, Injector, inject, singleton
-from pyspark.sql import DataFrame
-
 from kindling.injection import *
 from kindling.signaling import SignalEmitter, SignalProvider
 from kindling.spark_config import *
 from kindling.spark_log_provider import *
+from pyspark.sql import DataFrame
 
 ROUTING_KEY_METHODS: tuple[str, ...] = ("hash", "concat")
 
@@ -180,7 +179,7 @@ class EntityProvider(ABC):
         pass
 
     @abstractmethod
-    def read_entity_since_version(self, entity, since_version):
+    def read_entity_since_version(self, entity, since_version, end_version=None):
         pass
 
     @abstractmethod

--- a/packages/kindling/data_pipes.py
+++ b/packages/kindling/data_pipes.py
@@ -8,12 +8,11 @@ from typing import Any, Callable, Dict, List, Optional
 
 from delta.tables import DeltaTable
 from injector import Binder, Injector, inject, singleton
-from pyspark.sql import DataFrame
-
 from kindling.injection import *
 from kindling.signaling import SignalEmitter, SignalProvider
 from kindling.spark_log_provider import *
 from kindling.spark_trace import *
+from pyspark.sql import DataFrame
 
 from .data_entities import *
 from .data_entities import _raise_if_not_initialized
@@ -38,14 +37,15 @@ class EntityReadPersistStrategy(ABC):
         - persist.before_persist: Before persisting pipe output
         - persist.after_persist: After successful persist
         - persist.persist_failed: When persist fails
-        - persist.watermark_saved: After watermark is saved
+
+    (persist.watermark_saved is emitted by WatermarkAspect, which listens
+    to persist.after_persist — see kindling.watermarking.)
     """
 
     EMITS = [
         "persist.before_persist",
         "persist.after_persist",
         "persist.persist_failed",
-        "persist.watermark_saved",
     ]
 
     @abstractmethod
@@ -497,7 +497,14 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
     ) -> dict[str, DataFrame]:
         result = {}
         for i, entity_id in enumerate(pipe.input_entity_ids):
-            is_first = i == 0  # True for the first entity, False for others
+            # Driving-source convention: a pipe operates on ONE source of
+            # truth — its first input — and every other input is reference
+            # data, read in full. Only the driving source is ever read
+            # incrementally (watermarked). A multi-source output table is
+            # built by multiple pipes, each with its own driving source,
+            # never by one pipe with several watermarked inputs. See
+            # WatermarkAspect (kindling.watermarking) for the write side.
+            is_first = i == 0
             key = entity_id.replace(".", "_")
             result[key] = entity_reader(
                 self.dpe.get_entity_definition(entity_id), pipe.use_watermark and is_first

--- a/packages/kindling/entity_provider.py
+++ b/packages/kindling/entity_provider.py
@@ -227,6 +227,45 @@ class DestinationEnsuringProvider(ABC):
         pass
 
 
+class IncrementalReadableEntityProvider(ABC):
+    """
+    Optional interface for providers that can read only what changed since a
+    watermark cursor.
+
+    The cursor is an **opaque string the provider defines and interprets** —
+    the watermark framework stores and returns it verbatim, never inspects
+    it. A Delta provider encodes a table version; a REST provider might
+    encode the max ``updated_at``/``created_at`` timestamp it has served; a
+    queue-backed provider might encode offsets as JSON. All comparison
+    semantics (inclusive vs. exclusive boundaries, same-timestamp
+    collisions, lookback/overlap windows for late-arriving records, clock
+    skew of a remote system) are the provider's policy, configured per
+    entity via tags — not the framework's.
+
+    Contract:
+
+    - ``read_entity_changes(entity, None)`` is the initial load: return all
+      current data and the cursor covering it.
+    - The returned cursor must cover **exactly the data in the returned
+      DataFrame** at the time of the call. If the DataFrame is lazy, bound
+      it (e.g. Delta's ``endingVersion``) or materialize eagerly (typical
+      for REST responses) so later-arriving data cannot silently ride along
+      uncovered.
+    - ``(None, None)`` means no new data.
+    - Consumers persist the cursor only after the derived output is durably
+      written, and may re-read the same slice after a failure — providers
+      must tolerate at-least-once delivery (downstream merges are
+      idempotent by key).
+    """
+
+    @abstractmethod
+    def read_entity_changes(
+        self, entity_metadata: EntityMetadata, cursor: Optional[str]
+    ) -> "tuple[Optional[DataFrame], Optional[str]]":
+        """Read changes after ``cursor``; return ``(df, new_cursor)``."""
+        pass
+
+
 # Type aliases for checking capabilities
 def is_streamable(provider: BaseEntityProvider) -> bool:
     """Check if provider supports streaming reads."""
@@ -246,3 +285,8 @@ def is_stream_writable(provider: BaseEntityProvider) -> bool:
 def can_ensure_destination(provider: BaseEntityProvider) -> bool:
     """Check if provider supports destination ensuring."""
     return isinstance(provider, DestinationEnsuringProvider)
+
+
+def is_incremental_readable(provider: BaseEntityProvider) -> bool:
+    """Check if provider supports cursor-based incremental reads."""
+    return isinstance(provider, IncrementalReadableEntityProvider)

--- a/packages/kindling/entity_provider_delta.py
+++ b/packages/kindling/entity_provider_delta.py
@@ -7,11 +7,6 @@ from typing import Callable, Dict, Literal, Optional, Type
 
 import pyspark.sql.utils
 from delta.tables import DeltaTable
-from pyspark.errors import AnalysisException
-from pyspark.sql import DataFrame
-from pyspark.sql.functions import coalesce, col, concat_ws, lit, sha2, struct, to_json
-from pyspark.sql.types import BooleanType, StructField, StructType, TimestampType
-
 from kindling.common_transforms import *
 from kindling.features import get_feature_bool, set_runtime_feature
 
@@ -20,6 +15,10 @@ from kindling.injection import *
 from kindling.signaling import SignalEmitter, SignalProvider
 from kindling.spark_config import *
 from kindling.spark_log_provider import *
+from pyspark.errors import AnalysisException
+from pyspark.sql import DataFrame
+from pyspark.sql.functions import coalesce, col, concat_ws, lit, sha2, struct, to_json
+from pyspark.sql.types import BooleanType, StructField, StructType, TimestampType
 
 from .data_entities import *
 from .entity_provider import (
@@ -1197,19 +1196,29 @@ class DeltaEntityProvider(
         """)
 
     def _read_delta_table(
-        self, table_ref: DeltaTableReference, since_version: Optional[int] = None
+        self,
+        table_ref: DeltaTableReference,
+        since_version: Optional[int] = None,
+        end_version: Optional[int] = None,
     ) -> DataFrame:
         """Read Delta table with optional change feed"""
         self.logger.debug(f"Reading Delta Table - {table_ref.table_name} version: {since_version}")
 
         if since_version is not None:
-            self.logger.debug(f"Reading change feed since version: {since_version}")
-            return (
+            self.logger.debug(
+                f"Reading change feed for versions: {since_version}..{end_version or 'latest'}"
+            )
+            reader = (
                 self.spark.read.format("delta")
                 .option("readChangeFeed", "true")
                 .option("startingVersion", since_version)
-                .load(table_ref.get_read_path())
             )
+            if end_version is not None:
+                # Bound the slice so lazily-executed reads cover exactly the
+                # versions the caller's watermark will record, even if more
+                # commits land before an action runs the plan.
+                reader = reader.option("endingVersion", end_version)
+            return reader.load(table_ref.get_read_path())
         else:
             # Use spark.read.table for catalog-managed tables rather than DeltaTable.forName,
             # which can fail on Databricks UC for unqualified 1-part names due to catalog
@@ -1516,10 +1525,13 @@ class DeltaEntityProvider(
             )
             raise
 
-    def read_entity_since_version(self, entity, since_version: int) -> DataFrame:
-        """Read entity changes since specific version"""
+    def read_entity_since_version(
+        self, entity, since_version: int, end_version: Optional[int] = None
+    ) -> DataFrame:
+        """Read entity changes since specific version (inclusive), optionally
+        bounded to end_version (inclusive)."""
         table_ref = self._get_table_reference(entity)
-        df = self._read_delta_table(table_ref, since_version)
+        df = self._read_delta_table(table_ref, since_version, end_version)
         return self._transform_delta_feed_to_changes(df, entity.merge_columns)
 
     def read_entity_as_of(self, entity, point_in_time) -> DataFrame:

--- a/packages/kindling/entity_provider_delta.py
+++ b/packages/kindling/entity_provider_delta.py
@@ -24,6 +24,7 @@ from .data_entities import *
 from .entity_provider import (
     BaseEntityProvider,
     DestinationEnsuringProvider,
+    IncrementalReadableEntityProvider,
     StreamableEntityProvider,
     StreamWritableEntityProvider,
     WritableEntityProvider,
@@ -360,6 +361,7 @@ class DeltaEntityProvider(
     EntityProvider,
     BaseEntityProvider,
     DestinationEnsuringProvider,
+    IncrementalReadableEntityProvider,
     StreamableEntityProvider,
     WritableEntityProvider,
     StreamWritableEntityProvider,
@@ -1533,6 +1535,49 @@ class DeltaEntityProvider(
         table_ref = self._get_table_reference(entity)
         df = self._read_delta_table(table_ref, since_version, end_version)
         return self._transform_delta_feed_to_changes(df, entity.merge_columns)
+
+    def read_entity_changes(self, entity, cursor: Optional[str]):
+        """IncrementalReadableEntityProvider: Delta's cursor is a stringified
+        table version. Returns (df, new_cursor); (None, None) = no new data.
+
+        The read is bounded to the version encoded in the returned cursor
+        (CDF endingVersion), so the lazily-executed slice matches what the
+        watermark will record even if more commits land before an action.
+        """
+        watermark_version = int(cursor) if cursor is not None else None
+        current_version = self.get_entity_version(entity)
+
+        if watermark_version is None and current_version == 0:
+            # Source table does not exist yet.
+            return None, None
+
+        if watermark_version is None:
+            # Initial load: full read stamped with the version it covers.
+            from kindling.common_transforms import drop_if_exists, remove_duplicates
+            from pyspark.sql.functions import current_timestamp, date_format, lit
+            from pyspark.sql.types import IntegerType, TimestampType
+
+            df = remove_duplicates(
+                self.read_entity(entity)
+                .withColumn("SourceVersion", lit(current_version).cast(IntegerType()))
+                .transform(drop_if_exists, "SourceTimestamp")
+                .withColumn(
+                    "SourceTimestamp",
+                    lit(date_format(current_timestamp(), "yyyy-MM-dd HH:mm:ss")).cast(
+                        TimestampType()
+                    ),
+                ),
+                entity.merge_columns,
+            )
+            return df, str(current_version)
+
+        if current_version > watermark_version:
+            df = self.read_entity_since_version(
+                entity, watermark_version + 1, end_version=current_version
+            )
+            return df, str(current_version)
+
+        return None, None
 
     def read_entity_as_of(self, entity, point_in_time) -> DataFrame:
         """Read entity state at a specific point in time."""

--- a/packages/kindling/entity_provider_delta.py
+++ b/packages/kindling/entity_provider_delta.py
@@ -97,15 +97,36 @@ class SCD1MergeStrategy(DeltaMergeStrategy):
         mergeSchema), and without it MERGE silently drops source columns
         the target lacks — e.g. a column added to an entity's declared
         schema after the table was deployed would never materialize.
+
+        ``DeltaMergeBuilder.withSchemaEvolution()`` exists only from Delta
+        3.2; Kindling's floor is delta-spark 2.4 because supported managed
+        runtimes still ship older Delta. On older builders, fall back to
+        the session-conf mechanism (``schema.autoMerge.enabled``) scoped
+        to this merge and restored afterward.
         """
-        (
-            delta_table.alias("old")
-            .merge(source=df.alias("new"), condition=merge_condition)
-            .withSchemaEvolution()
-            .whenMatchedUpdateAll()
-            .whenNotMatchedInsertAll()
-            .execute()
-        )
+        builder = delta_table.alias("old").merge(source=df.alias("new"), condition=merge_condition)
+
+        if hasattr(builder, "withSchemaEvolution"):
+            (
+                builder.withSchemaEvolution()
+                .whenMatchedUpdateAll()
+                .whenNotMatchedInsertAll()
+                .execute()
+            )
+            return
+
+        # Delta < 3.2 compatibility path.
+        spark = df.sparkSession
+        conf_key = "spark.databricks.delta.schema.autoMerge.enabled"
+        previous = spark.conf.get(conf_key, None)
+        spark.conf.set(conf_key, "true")
+        try:
+            (builder.whenMatchedUpdateAll().whenNotMatchedInsertAll().execute())
+        finally:
+            if previous is None:
+                spark.conf.unset(conf_key)
+            else:
+                spark.conf.set(conf_key, previous)
 
 
 @DeltaMergeStrategies.register(name="scd2")

--- a/packages/kindling/entity_provider_delta.py
+++ b/packages/kindling/entity_provider_delta.py
@@ -90,10 +90,18 @@ class SCD1MergeStrategy(DeltaMergeStrategy):
         entity,
         merge_condition: str,
     ) -> None:
-        """Run the legacy update-all / insert-all Delta merge."""
+        """Run the legacy update-all / insert-all Delta merge.
+
+        Schema evolution is enabled explicitly: Kindling assumes additive
+        schema evolution everywhere (the write path already sets
+        mergeSchema), and without it MERGE silently drops source columns
+        the target lacks — e.g. a column added to an entity's declared
+        schema after the table was deployed would never materialize.
+        """
         (
             delta_table.alias("old")
             .merge(source=df.alias("new"), condition=merge_condition)
+            .withSchemaEvolution()
             .whenMatchedUpdateAll()
             .whenNotMatchedInsertAll()
             .execute()

--- a/packages/kindling/simple_read_persist_strategy.py
+++ b/packages/kindling/simple_read_persist_strategy.py
@@ -79,7 +79,7 @@ class SimpleReadPersistStrategy(EntityReadPersistStrategy, SignalEmitter):
     Watermark bookkeeping is deliberately NOT handled here: the
     ``WatermarkAspect`` (``kindling.watermarking``) listens to
     ``persist.after_persist`` / ``persist.persist_failed`` and advances the
-    watermark to the version it captured at read time.
+    watermark to the cursor it captured at read time.
     """
 
     EMITS = [

--- a/packages/kindling/simple_read_persist_strategy.py
+++ b/packages/kindling/simple_read_persist_strategy.py
@@ -5,8 +5,6 @@ from functools import reduce
 from pathlib import Path
 from typing import Optional
 
-from pyspark.sql.functions import col
-
 from kindling.data_entities import *
 from kindling.data_pipes import *
 from kindling.entity_provider_csv import (
@@ -18,6 +16,7 @@ from kindling.injection import *
 from kindling.signaling import SignalEmitter, SignalProvider
 from kindling.spark_log import *
 from kindling.watermarking import *
+from pyspark.sql.functions import col
 
 
 def _is_local_execution() -> bool:
@@ -56,7 +55,16 @@ def _apply_df_transforms(results, df):
 class SimpleReadPersistStrategy(EntityReadPersistStrategy, SignalEmitter):
     """Strategy for reading entities and persisting pipe results with signals.
 
-    Subscribers can intercept and transform DataFrames at two points:
+    Subscribers can intercept at three points:
+
+    ``read.resolve_read`` — fired before any read happens. Receives
+    ``entity``, ``entity_id``, ``pipe``, ``pipe_id``, ``use_watermark``.
+    A handler that takes ownership of the read returns a ``ResolvedRead``
+    (see ``kindling.watermarking``) whose ``df`` becomes the read result —
+    possibly ``None``, meaning "no new data, skip the pipe." When no
+    handler resolves, the strategy falls through to an ordinary full read
+    from the entity's provider. This is how incremental/watermark reads
+    attach (``WatermarkAspect``) without the strategy knowing about them.
 
     ``read.after_read`` — fired after reading a source entity. Receives
     ``df``, ``entity_id``, ``pipe_id``, ``used_watermark``. Return a new
@@ -65,22 +73,26 @@ class SimpleReadPersistStrategy(EntityReadPersistStrategy, SignalEmitter):
 
     ``persist.before_persist`` — fired before writing the pipe output.
     Receives ``df``, ``pipe_id``, ``source_entity_id``, ``output_entity_id``,
-    ``source_version``, ``persist_id``. Return a new DataFrame to replace
-    the one written to storage, or ``None`` to leave it unchanged.
+    ``persist_id``. Return a new DataFrame to replace the one written to
+    storage, or ``None`` to leave it unchanged.
+
+    Watermark bookkeeping is deliberately NOT handled here: the
+    ``WatermarkAspect`` (``kindling.watermarking``) listens to
+    ``persist.after_persist`` / ``persist.persist_failed`` and advances the
+    watermark to the version it captured at read time.
     """
 
     EMITS = [
+        "read.resolve_read",
         "read.after_read",
         "persist.before_persist",
         "persist.after_persist",
-        "persist.watermark_saved",
         "persist.persist_failed",
     ]
 
     @inject
     def __init__(
         self,
-        wms: WatermarkService,
         ep: EntityProvider,
         der: DataEntityRegistry,
         tp: SparkTraceProvider,
@@ -88,7 +100,6 @@ class SimpleReadPersistStrategy(EntityReadPersistStrategy, SignalEmitter):
         provider_registry: EntityProviderRegistry,
         signal_provider: Optional[SignalProvider] = None,
     ):
-        self.wms = wms
         self.der = der
         self.ep = ep  # Legacy EntityProvider for backward compatibility
         self.provider_registry = provider_registry  # New multi-provider registry
@@ -100,9 +111,24 @@ class SimpleReadPersistStrategy(EntityReadPersistStrategy, SignalEmitter):
         strategy = self
 
         def entity_reader(entity, usewm):
-            if usewm and not _is_local_execution():
-                # Watermarking uses the legacy path (Delta-specific)
-                df = strategy.wms.read_current_entity_changes(entity, pipe)
+            # Interdiction point: a handler (e.g. WatermarkAspect) may take
+            # ownership of the read entirely — including deciding there is
+            # no new data (df=None). Distinct from read.after_read, which
+            # can only transform a DataFrame that was already read.
+            resolved = None
+            for _, retval in strategy.emit(
+                "read.resolve_read",
+                entity=entity,
+                entity_id=entity.entityid,
+                pipe=pipe,
+                pipe_id=pipe.pipeid,
+                use_watermark=usewm,
+            ):
+                if retval is not None and hasattr(retval, "df"):
+                    resolved = retval
+
+            if resolved is not None:
+                df = resolved.df
             elif _is_local_execution():
                 # [implementer] tests/entities/ auto-discovery convention — ki-bsi
                 # Priority: explicit --source > kindling.yaml env mapping > fixture CSV > registry
@@ -147,26 +173,16 @@ class SimpleReadPersistStrategy(EntityReadPersistStrategy, SignalEmitter):
 
             if pipe.input_entity_ids and len(pipe.input_entity_ids) > 0:
 
+                # Driving-source convention: input 0 is the pipe's single
+                # source of truth; other inputs are reference data. See
+                # WatermarkAspect (kindling.watermarking) for the full
+                # statement of the convention.
                 src_input_entity = strategy.der.get_entity_definition(pipe.input_entity_ids[0])
                 src_input_entity_id = src_input_entity.entityid
-
-                # Get provider for source entity (version tracking may be Delta-specific)
-                src_provider = strategy.provider_registry.get_provider_for_entity(src_input_entity)
-                # Version tracking: Delta providers return actual version numbers, other providers
-                # default to 0 (no versioning). This is acceptable for watermarking as the
-                # watermark system will still track processing state via timestamps.
-                src_read_version = (
-                    src_provider.get_entity_version(src_input_entity)
-                    if hasattr(src_provider, "get_entity_version")
-                    else 0
-                )
 
                 output_entity = strategy.der.get_entity_definition(pipe.output_entity_id)
                 output_provider = strategy.provider_registry.get_provider_for_entity(output_entity)
 
-                strategy.logger.debug(
-                    f"read_version - pipe = {pipe.pipeid} - ver = {src_read_version}"
-                )
                 strategy.logger.debug(f"persist_lambda - pipe = {pipe.pipeid}")
 
                 results = strategy.emit(
@@ -175,7 +191,6 @@ class SimpleReadPersistStrategy(EntityReadPersistStrategy, SignalEmitter):
                     pipe_id=pipe.pipeid,
                     source_entity_id=src_input_entity_id,
                     output_entity_id=pipe.output_entity_id,
-                    source_version=src_read_version,
                     persist_id=persist_id,
                 )
                 df = _apply_df_transforms(results, df)
@@ -216,26 +231,6 @@ class SimpleReadPersistStrategy(EntityReadPersistStrategy, SignalEmitter):
                                 else:
                                     raise ValueError(
                                         f"Provider '{output_entity.provider_type or 'unknown'}' does not support write operations"
-                                    )
-
-                        if pipe.use_watermark:
-                            with strategy.tp.span(operation="save_watermarks"):
-                                with strategy.tp.span(
-                                    operation="save_watermark", component=f"{src_input_entity_id}"
-                                ):
-                                    strategy.wms.save_watermark(
-                                        src_input_entity_id,
-                                        pipe.pipeid,
-                                        src_read_version,
-                                        str(uuid.uuid4()),
-                                    )
-
-                                    strategy.emit(
-                                        "persist.watermark_saved",
-                                        pipe_id=pipe.pipeid,
-                                        source_entity_id=src_input_entity_id,
-                                        version=src_read_version,
-                                        persist_id=persist_id,
                                     )
 
                     duration = time.time() - start_time

--- a/packages/kindling/watermarking.py
+++ b/packages/kindling/watermarking.py
@@ -1,11 +1,18 @@
 import time
 import uuid
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from delta.tables import DeltaTable
 from injector import Binder, Injector, inject, singleton
+from kindling.common_transforms import *
+from kindling.injection import *
+from kindling.signaling import SignalEmitter, SignalProvider
+from kindling.spark_config import *
+from kindling.spark_log_provider import *
+from kindling.spark_session import *
 from pyspark.errors import AnalysisException
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.functions import col, current_timestamp, date_format, lit
@@ -17,13 +24,6 @@ from pyspark.sql.types import (
     StructType,
     TimestampType,
 )
-
-from kindling.common_transforms import *
-from kindling.injection import *
-from kindling.signaling import SignalEmitter, SignalProvider
-from kindling.spark_config import *
-from kindling.spark_log_provider import *
-from kindling.spark_session import *
 
 from .data_entities import *
 
@@ -115,6 +115,18 @@ class WatermarkService(ABC):
     @abstractmethod
     def read_current_entity_changes(self, entity, pipe):
         pass
+
+    def read_changes_with_version(self, entity, pipe) -> Tuple[Optional[DataFrame], Optional[int]]:
+        """Read unprocessed changes AND the source version the read covers.
+
+        Returns ``(DataFrame, version)``; ``(None, None)`` means no new data.
+        The returned version is the version the read is bounded to — the
+        value the caller must record as the watermark once (and only once)
+        the processed output is durably persisted. Capturing it at read
+        time is what prevents a commit landing between read and persist
+        from being marked processed without ever being read.
+        """
+        raise NotImplementedError
 
 
 @GlobalInjector.singleton_autobind()
@@ -238,6 +250,10 @@ class WatermarkManager(WatermarkService, SignalEmitter):
             raise
 
     def read_current_entity_changes(self, entity, pipe):
+        df, _ = self.read_changes_with_version(entity, pipe)
+        return df
+
+    def read_changes_with_version(self, entity, pipe) -> Tuple[Optional[DataFrame], Optional[int]]:
         key_columns = entity.merge_columns
         self.logger.debug(
             f"read_current_changes - {entity.entityid} for {pipe.name}: {str(key_columns)}"
@@ -265,7 +281,7 @@ class WatermarkManager(WatermarkService, SignalEmitter):
                 current_version=currentVersion,
                 watermark_version=watermark_version,
             )
-            return None
+            return None, None
 
         if watermark_version is None:
             self.logger.debug(
@@ -293,12 +309,20 @@ class WatermarkManager(WatermarkService, SignalEmitter):
                 has_data=True,
                 is_initial_load=True,
             )
-            return result
+            return result, currentVersion
         elif currentVersion > watermark_version:
             self.logger.debug(
-                f"read_current_changes - {entity.entityid} for {pipe.name}: Version: {currentVersion} -- Reading and transforming feed"
+                f"read_current_changes - {entity.entityid} for {pipe.name}: "
+                f"Reading changes for versions {watermark_version + 1}..{currentVersion}"
             )
-            result = self.ep.read_entity_since_version(entity, currentVersion)
+            # Read from the version AFTER the watermark (startingVersion is
+            # inclusive), bounded to currentVersion so the slice matches the
+            # version recorded once the output persists. Reading from
+            # currentVersion instead would silently skip every commit
+            # between the watermark and the latest one.
+            result = self.ep.read_entity_since_version(
+                entity, watermark_version + 1, end_version=currentVersion
+            )
             self.emit(
                 "watermark.after_read_changes",
                 entity_id=entity.entityid,
@@ -309,7 +333,7 @@ class WatermarkManager(WatermarkService, SignalEmitter):
                 has_data=True,
                 is_initial_load=False,
             )
-            return result
+            return result, currentVersion
         else:
             self.logger.debug(
                 f"read_current_changes - {entity.entityid} for {pipe.name}: No new data"
@@ -322,4 +346,113 @@ class WatermarkManager(WatermarkService, SignalEmitter):
                 current_version=currentVersion,
                 watermark_version=watermark_version,
             )
+            return None, None
+
+
+@dataclass
+class ResolvedRead:
+    """Marker returned by a ``read.resolve_read`` handler that has taken
+    ownership of the read. ``df`` may be None, meaning "resolved: no new
+    data" (the pipe should skip) — distinct from no handler resolving at
+    all, which falls through to an ordinary full provider read."""
+
+    df: Optional[DataFrame]
+
+
+@GlobalInjector.singleton_autobind()
+class WatermarkAspect(SignalEmitter):
+    """Incremental processing as a bolt-on signal aspect.
+
+    Watermark behavior attaches to pipe execution through signals instead of
+    being woven into the read/persist strategy:
+
+    - ``read.resolve_read`` (sync, interdicting): when the read is for a
+      pipe's driving source with ``use_watermark`` enabled, this aspect
+      performs the incremental changes read and records the source version
+      that read covers, keyed by pipe.
+    - ``persist.after_persist``: advances the watermark to the recorded
+      version — the version that was READ, never re-fetched at persist
+      time, so a commit landing between read and persist is never marked
+      processed without being processed.
+    - ``persist.persist_failed``: discards the recorded version; the
+      watermark stays put and the next run re-reads the same slice
+      (at-least-once, made safe by idempotent merge writes).
+
+    Driving-source convention: a pipe operates on a single source of
+    truth — its FIRST input entity — and every other input is reference
+    data, read in full. Only the driving source is watermarked. A table fed
+    by multiple sources is built by multiple pipes each contributing its
+    own driving source, not by one pipe with several watermarked inputs.
+    (``DataPipesExecuter._populate_source_dict`` implements the read side
+    of this convention by passing ``use_watermark`` only for input 0.)
+
+    The aspect is registered at bootstrap for non-standalone platforms.
+    Local/standalone execution deliberately runs without it: reads fall
+    through to fixture/provider full reads, matching prior behavior where
+    watermarking was skipped locally. An execution engine that owns its own
+    incrementality (e.g. a declarative-pipelines backend) simply never
+    registers the aspect.
+    """
+
+    EMITS = [
+        "persist.watermark_saved",
+    ]
+
+    @inject
+    def __init__(
+        self,
+        wms: WatermarkService,
+        lp: PythonLoggerProvider,
+        signal_provider: SignalProvider,
+    ):
+        self.wms = wms
+        self.logger = lp.get_logger("WatermarkAspect")
+        self._signals = signal_provider
+        self._init_signal_emitter(signal_provider)
+        self._pending: Dict[str, Tuple[str, int]] = {}
+        self._registered = False
+
+    def register(self) -> None:
+        """Connect the aspect's handlers. Idempotent."""
+        if self._registered:
+            return
+        for signal_name, handler in (
+            ("read.resolve_read", self._on_resolve_read),
+            ("persist.after_persist", self._on_after_persist),
+            ("persist.persist_failed", self._on_persist_failed),
+        ):
+            signal = self._signals.get_signal(signal_name) or self._signals.create_signal(
+                signal_name
+            )
+            signal.connect(handler, weak=False)
+        self._registered = True
+        self.logger.debug("WatermarkAspect registered")
+
+    def _on_resolve_read(self, sender, *, entity=None, pipe=None, use_watermark=False, **kwargs):
+        if not use_watermark or entity is None or pipe is None:
             return None
+        df, version = self.wms.read_changes_with_version(entity, pipe)
+        if version is not None:
+            self._pending[pipe.pipeid] = (entity.entityid, version)
+        else:
+            self._pending.pop(pipe.pipeid, None)
+        return ResolvedRead(df=df)
+
+    def _on_after_persist(self, sender, *, pipe_id=None, persist_id=None, **kwargs):
+        pending = self._pending.pop(pipe_id, None)
+        if pending is None:
+            return None
+        source_entity_id, version = pending
+        self.wms.save_watermark(source_entity_id, pipe_id, version, str(uuid.uuid4()))
+        self.emit(
+            "persist.watermark_saved",
+            pipe_id=pipe_id,
+            source_entity_id=source_entity_id,
+            version=version,
+            persist_id=persist_id,
+        )
+        return None
+
+    def _on_persist_failed(self, sender, *, pipe_id=None, **kwargs):
+        self._pending.pop(pipe_id, None)
+        return None

--- a/packages/kindling/watermarking.py
+++ b/packages/kindling/watermarking.py
@@ -8,6 +8,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from delta.tables import DeltaTable
 from injector import Binder, Injector, inject, singleton
 from kindling.common_transforms import *
+from kindling.entity_provider import IncrementalReadableEntityProvider
+from kindling.entity_provider_registry import EntityProviderRegistry
 from kindling.injection import *
 from kindling.signaling import SignalEmitter, SignalProvider
 from kindling.spark_config import *
@@ -51,7 +53,14 @@ class SimpleWatermarkEntityFinder(WatermarkEntityFinder):
                 StructField("source_entity_id", StringType(), False),
                 StructField("reader_id", StringType(), False),
                 StructField("timestamp", TimestampType(), False),
+                # Legacy column: only meaningful for integer (Delta version)
+                # cursors; -1 for providers with non-integer cursors. Kept
+                # NOT NULL for compatibility with already-deployed tables.
                 StructField("last_version_processed", IntegerType(), False),
+                # The general watermark: an opaque cursor string defined and
+                # interpreted by the source entity's provider (a Delta
+                # version, a REST updated_at timestamp, queue offsets, ...).
+                StructField("cursor", StringType(), True),
                 StructField("last_execution_id", StringType(), False),
             ]
         )
@@ -99,10 +108,51 @@ class WatermarkService(ABC):
     ]
 
     @abstractmethod
-    def get_watermark(self, source_entity_id: str, reader_id: str) -> Optional[int]:
+    def get_cursor(self, source_entity_id: str, reader_id: str) -> Optional[str]:
+        """Return the stored cursor for (source, reader), or None if this
+        reader has never processed the source. The cursor is an opaque
+        string defined and interpreted only by the source entity's provider
+        (see ``IncrementalReadableEntityProvider``) — a Delta table version,
+        a REST created/updated timestamp, queue offsets, etc."""
         pass
 
     @abstractmethod
+    def save_cursor(
+        self,
+        source_entity_id: str,
+        reader_id: str,
+        cursor: str,
+        last_execution_id: str,
+    ) -> DataFrame:
+        pass
+
+    @abstractmethod
+    def read_changes(self, entity, pipe) -> Tuple[Optional[DataFrame], Optional[str]]:
+        """Read unprocessed changes AND the cursor the read covers.
+
+        Returns ``(DataFrame, new_cursor)``; ``(None, None)`` means no new
+        data. The returned cursor covers exactly the returned data — the
+        value the caller must record as the watermark once (and only once)
+        the processed output is durably persisted. Capturing it at read
+        time is what prevents source changes landing between read and
+        persist from being marked processed without ever being read.
+        """
+        pass
+
+    # -- Legacy version-typed wrappers -----------------------------------
+    # Delta cursors are stringified table versions; these wrappers keep the
+    # historical integer-based API working for callers that know they are
+    # talking to a version-cursor source.
+
+    def get_watermark(self, source_entity_id: str, reader_id: str) -> Optional[int]:
+        cursor = self.get_cursor(source_entity_id, reader_id)
+        if cursor is None:
+            return None
+        try:
+            return int(cursor)
+        except ValueError:
+            return None
+
     def save_watermark(
         self,
         source_entity_id: str,
@@ -110,23 +160,13 @@ class WatermarkService(ABC):
         last_version_processed: int,
         last_execution_id: str,
     ) -> DataFrame:
-        pass
+        return self.save_cursor(
+            source_entity_id, reader_id, str(last_version_processed), last_execution_id
+        )
 
-    @abstractmethod
     def read_current_entity_changes(self, entity, pipe):
-        pass
-
-    def read_changes_with_version(self, entity, pipe) -> Tuple[Optional[DataFrame], Optional[int]]:
-        """Read unprocessed changes AND the source version the read covers.
-
-        Returns ``(DataFrame, version)``; ``(None, None)`` means no new data.
-        The returned version is the version the read is bounded to — the
-        value the caller must record as the watermark once (and only once)
-        the processed output is durably persisted. Capturing it at read
-        time is what prevents a commit landing between read and persist
-        from being marked processed without ever being read.
-        """
-        raise NotImplementedError
+        df, _ = self.read_changes(entity, pipe)
+        return df
 
 
 @GlobalInjector.singleton_autobind()
@@ -140,15 +180,17 @@ class WatermarkManager(WatermarkService, SignalEmitter):
         wef: WatermarkEntityFinder,
         lp: PythonLoggerProvider,
         signal_provider: Optional[SignalProvider] = None,
+        provider_registry: Optional[EntityProviderRegistry] = None,
     ):
         self.wef = wef
         self.ep = ep
+        self.provider_registry = provider_registry
         self.logger = lp.get_logger("watermark")
         self.spark = get_or_create_spark_session()
         self._init_signal_emitter(signal_provider)
 
-    def get_watermark(self, source_entity_id: str, reader_id: str) -> Optional[int]:
-        self.logger.debug(f"Getting watermark for {source_entity_id}-{reader_id}")
+    def get_cursor(self, source_entity_id: str, reader_id: str) -> Optional[str]:
+        self.logger.debug(f"Getting watermark cursor for {source_entity_id}-{reader_id}")
 
         self.emit("watermark.before_get", source_entity_id=source_entity_id, reader_id=reader_id)
 
@@ -158,9 +200,9 @@ class WatermarkManager(WatermarkService, SignalEmitter):
                 .filter(
                     (col("source_entity_id") == source_entity_id) & (col("reader_id") == reader_id)
                 )
-                .select("last_version_processed")
                 .limit(1)
             )
+            row = None if df.isEmpty() else df.first()
         except AnalysisException as e:
             if "DELTA_MISSING_DELTA_TABLE" in str(e):
                 self.logger.debug("Watermarks table does not exist yet")
@@ -172,7 +214,7 @@ class WatermarkManager(WatermarkService, SignalEmitter):
                 return None
             raise
 
-        if df.isEmpty():
+        if row is None:
             self.logger.debug("No watermark")
             self.emit(
                 "watermark.watermark_missing",
@@ -181,33 +223,47 @@ class WatermarkManager(WatermarkService, SignalEmitter):
             )
             return None
 
-        version = df.first()["last_version_processed"]
-        self.logger.debug(f"Watermark = {version}")
+        # Prefer the general cursor column; fall back to the legacy integer
+        # column for rows written before the cursor column existed.
+        cursor = row["cursor"] if "cursor" in df.columns else None
+        if cursor is None:
+            legacy = row["last_version_processed"]
+            cursor = str(legacy) if legacy is not None and legacy >= 0 else None
+
+        self.logger.debug(f"Watermark cursor = {cursor}")
         self.emit(
             "watermark.watermark_found",
             source_entity_id=source_entity_id,
             reader_id=reader_id,
-            version=version,
+            cursor=cursor,
         )
-        return version
+        return cursor
 
-    def save_watermark(
+    def save_cursor(
         self,
         source_entity_id: str,
         reader_id: str,
-        last_version_processed: int,
+        cursor: str,
         last_execution_id: str,
     ) -> DataFrame:
         self.emit(
             "watermark.before_save",
             source_entity_id=source_entity_id,
             reader_id=reader_id,
-            last_version_processed=last_version_processed,
+            cursor=cursor,
             last_execution_id=last_execution_id,
         )
 
         try:
             timestamp = datetime.fromtimestamp(time.time())
+
+            # Legacy integer column: populated when the cursor is a version
+            # number (Delta), -1 sentinel otherwise (column is NOT NULL on
+            # already-deployed tables).
+            try:
+                legacy_version = int(cursor)
+            except (TypeError, ValueError):
+                legacy_version = -1
 
             data = [
                 (
@@ -215,7 +271,8 @@ class WatermarkManager(WatermarkService, SignalEmitter):
                     source_entity_id,
                     reader_id,
                     timestamp,
-                    last_version_processed,
+                    legacy_version,
+                    cursor,
                     last_execution_id,
                 )
             ]
@@ -232,7 +289,7 @@ class WatermarkManager(WatermarkService, SignalEmitter):
                 "watermark.after_save",
                 source_entity_id=source_entity_id,
                 reader_id=reader_id,
-                last_version_processed=last_version_processed,
+                cursor=cursor,
                 last_execution_id=last_execution_id,
             )
 
@@ -243,21 +300,14 @@ class WatermarkManager(WatermarkService, SignalEmitter):
                 "watermark.save_failed",
                 source_entity_id=source_entity_id,
                 reader_id=reader_id,
-                last_version_processed=last_version_processed,
+                cursor=cursor,
                 error=str(e),
                 error_type=type(e).__name__,
             )
             raise
 
-    def read_current_entity_changes(self, entity, pipe):
-        df, _ = self.read_changes_with_version(entity, pipe)
-        return df
-
-    def read_changes_with_version(self, entity, pipe) -> Tuple[Optional[DataFrame], Optional[int]]:
-        key_columns = entity.merge_columns
-        self.logger.debug(
-            f"read_current_changes - {entity.entityid} for {pipe.name}: {str(key_columns)}"
-        )
+    def read_changes(self, entity, pipe) -> Tuple[Optional[DataFrame], Optional[str]]:
+        self.logger.debug(f"read_changes - {entity.entityid} for {pipe.name}")
 
         self.emit(
             "watermark.before_read_changes",
@@ -266,30 +316,66 @@ class WatermarkManager(WatermarkService, SignalEmitter):
             pipe_name=pipe.name,
         )
 
-        watermark_version = self.get_watermark(entity.entityid, pipe.pipeid)
-        currentVersion = self.ep.get_entity_version(entity)
+        cursor = self.get_cursor(entity.entityid, pipe.pipeid)
+        provider = self._provider_for(entity)
 
-        if watermark_version is None and currentVersion == 0:
-            self.logger.debug(
-                f"read_current_changes - {entity.entityid} for {pipe.name}: Source entity does not exist yet"
-            )
+        if isinstance(provider, IncrementalReadableEntityProvider):
+            df, new_cursor = provider.read_entity_changes(entity, cursor)
+        else:
+            df, new_cursor = self._legacy_version_read(provider, entity, cursor)
+
+        if df is None:
+            self.logger.debug(f"read_changes - {entity.entityid} for {pipe.name}: No new data")
             self.emit(
                 "watermark.no_new_data",
                 entity_id=entity.entityid,
                 pipe_id=pipe.pipeid,
                 pipe_name=pipe.name,
-                current_version=currentVersion,
-                watermark_version=watermark_version,
+                cursor=cursor,
             )
             return None, None
 
+        self.emit(
+            "watermark.after_read_changes",
+            entity_id=entity.entityid,
+            pipe_id=pipe.pipeid,
+            pipe_name=pipe.name,
+            cursor=cursor,
+            new_cursor=new_cursor,
+            has_data=True,
+            is_initial_load=cursor is None,
+        )
+        return df, new_cursor
+
+    def _provider_for(self, entity):
+        """Resolve the entity's own provider; fall back to the legacy
+        single provider when no registry is available."""
+        if self.provider_registry is not None:
+            try:
+                return self.provider_registry.get_provider_for_entity(entity)
+            except Exception:  # noqa: BLE001
+                self.logger.debug(
+                    f"Provider registry lookup failed for {entity.entityid}; "
+                    f"falling back to legacy provider"
+                )
+        return self.ep
+
+    def _legacy_version_read(
+        self, provider, entity, cursor: Optional[str]
+    ) -> Tuple[Optional[DataFrame], Optional[str]]:
+        """Version-based incremental read for providers that implement the
+        legacy EntityProvider interface but not
+        IncrementalReadableEntityProvider."""
+        watermark_version = int(cursor) if cursor is not None else None
+        current_version = provider.get_entity_version(entity)
+
+        if watermark_version is None and current_version == 0:
+            return None, None
+
         if watermark_version is None:
-            self.logger.debug(
-                f"read_current_changes - {entity.entityid} for {pipe.name}: No watermark"
-            )
-            result = remove_duplicates(
-                self.ep.read_entity(entity)
-                .withColumn("SourceVersion", lit(currentVersion).cast(IntegerType()))
+            df = remove_duplicates(
+                provider.read_entity(entity)
+                .withColumn("SourceVersion", lit(current_version).cast(IntegerType()))
                 .transform(drop_if_exists, "SourceTimestamp")
                 .withColumn(
                     "SourceTimestamp",
@@ -297,56 +383,17 @@ class WatermarkManager(WatermarkService, SignalEmitter):
                         TimestampType()
                     ),
                 ),
-                key_columns,
+                entity.merge_columns,
             )
-            self.emit(
-                "watermark.after_read_changes",
-                entity_id=entity.entityid,
-                pipe_id=pipe.pipeid,
-                pipe_name=pipe.name,
-                current_version=currentVersion,
-                watermark_version=None,
-                has_data=True,
-                is_initial_load=True,
+            return df, str(current_version)
+
+        if current_version > watermark_version:
+            df = provider.read_entity_since_version(
+                entity, watermark_version + 1, end_version=current_version
             )
-            return result, currentVersion
-        elif currentVersion > watermark_version:
-            self.logger.debug(
-                f"read_current_changes - {entity.entityid} for {pipe.name}: "
-                f"Reading changes for versions {watermark_version + 1}..{currentVersion}"
-            )
-            # Read from the version AFTER the watermark (startingVersion is
-            # inclusive), bounded to currentVersion so the slice matches the
-            # version recorded once the output persists. Reading from
-            # currentVersion instead would silently skip every commit
-            # between the watermark and the latest one.
-            result = self.ep.read_entity_since_version(
-                entity, watermark_version + 1, end_version=currentVersion
-            )
-            self.emit(
-                "watermark.after_read_changes",
-                entity_id=entity.entityid,
-                pipe_id=pipe.pipeid,
-                pipe_name=pipe.name,
-                current_version=currentVersion,
-                watermark_version=watermark_version,
-                has_data=True,
-                is_initial_load=False,
-            )
-            return result, currentVersion
-        else:
-            self.logger.debug(
-                f"read_current_changes - {entity.entityid} for {pipe.name}: No new data"
-            )
-            self.emit(
-                "watermark.no_new_data",
-                entity_id=entity.entityid,
-                pipe_id=pipe.pipeid,
-                pipe_name=pipe.name,
-                current_version=currentVersion,
-                watermark_version=watermark_version,
-            )
-            return None, None
+            return df, str(current_version)
+
+        return None, None
 
 
 @dataclass
@@ -368,12 +415,16 @@ class WatermarkAspect(SignalEmitter):
 
     - ``read.resolve_read`` (sync, interdicting): when the read is for a
       pipe's driving source with ``use_watermark`` enabled, this aspect
-      performs the incremental changes read and records the source version
-      that read covers, keyed by pipe.
+      performs the incremental changes read and records the **cursor** that
+      read covers, keyed by pipe. The cursor is an opaque, provider-defined
+      incremental position — a Delta table version, a REST provider's
+      created/updated timestamp, queue offsets — which this aspect stores
+      and returns verbatim, never interprets (see
+      ``IncrementalReadableEntityProvider``).
     - ``persist.after_persist``: advances the watermark to the recorded
-      version — the version that was READ, never re-fetched at persist
-      time, so a commit landing between read and persist is never marked
-      processed without being processed.
+      cursor — the cursor that was READ, never re-derived at persist
+      time, so source changes landing between read and persist are never
+      marked processed without being processed.
     - ``persist.persist_failed``: discards the recorded version; the
       watermark stays put and the next run re-reads the same slice
       (at-least-once, made safe by idempotent merge writes).
@@ -415,7 +466,8 @@ class WatermarkAspect(SignalEmitter):
         self.logger = lp.get_logger("WatermarkAspect")
         self._signals = signal_provider
         self._init_signal_emitter(signal_provider)
-        self._pending: Dict[str, Tuple[str, int]] = {}
+        # pipe_id -> (source_entity_id, cursor) captured at read time
+        self._pending: Dict[str, Tuple[str, str]] = {}
         self._registered = False
 
     def register(self) -> None:
@@ -454,9 +506,9 @@ class WatermarkAspect(SignalEmitter):
             if input_ids and entity.entityid == input_ids[0]:
                 self._pending.pop(pipe.pipeid, None)
             return None
-        df, version = self.wms.read_changes_with_version(entity, pipe)
-        if version is not None:
-            self._pending[pipe.pipeid] = (entity.entityid, version)
+        df, cursor = self.wms.read_changes(entity, pipe)
+        if cursor is not None:
+            self._pending[pipe.pipeid] = (entity.entityid, cursor)
         else:
             self._pending.pop(pipe.pipeid, None)
         return ResolvedRead(df=df)
@@ -465,13 +517,18 @@ class WatermarkAspect(SignalEmitter):
         pending = self._pending.pop(pipe_id, None)
         if pending is None:
             return None
-        source_entity_id, version = pending
-        self.wms.save_watermark(source_entity_id, pipe_id, version, str(uuid.uuid4()))
+        source_entity_id, cursor = pending
+        self.wms.save_cursor(source_entity_id, pipe_id, cursor, str(uuid.uuid4()))
+        try:
+            legacy_version = int(cursor)
+        except (TypeError, ValueError):
+            legacy_version = None
         self.emit(
             "persist.watermark_saved",
             pipe_id=pipe_id,
             source_entity_id=source_entity_id,
-            version=version,
+            cursor=cursor,
+            version=legacy_version,
             persist_id=persist_id,
         )
         return None

--- a/packages/kindling/watermarking.py
+++ b/packages/kindling/watermarking.py
@@ -430,10 +430,28 @@ class WatermarkAspect(SignalEmitter):
       (at-least-once, made safe by idempotent merge writes).
     - ``datapipes.pipe_failed`` / ``orchestrator.pipe_failed``: a pipe can
       fail BEFORE its persist runs (a reference-input read fails, the
-      transform raises) — these discard the recorded version too, so a
+      transform raises) — these discard the recorded cursor too, so a
       capture can never outlive the execution that made it. As a second
       guard, a non-watermarked read of a pipe's driving source (a
       full-refresh run) also clears any stale capture for that pipe.
+    - ``datapipes.pipe_skipped`` / ``orchestrator.pipe_skipped``: a pipe
+      whose driving read produced data can still be skipped when another
+      input is unavailable — nothing persists, so the capture is discarded
+      for the same reason.
+
+    Concurrency contract: **concurrent executions of the same pipe within
+    one process are unsupported.** This is inherent to the watermark
+    model — there is exactly one cursor per (source, reader), so two
+    concurrent incremental executions of one pipe would race on the cursor
+    and merge overlapping slices regardless of this aspect's bookkeeping.
+    Pending captures are therefore keyed by pipe id alone; both executers
+    run a pipe at most once per run. If a watermarked capture replaces an
+    existing one (a crashed run that emitted no lifecycle signals, or a
+    genuinely concurrent overlapping run), the aspect logs a warning and
+    last-capture-wins. If concurrent same-pipe execution ever becomes a
+    requirement, the right shape is an execution-scoped token minted at
+    read time and carried through the persist/failure signals — a
+    deliberate future design, not something to approximate here.
 
     Driving-source convention: a pipe operates on a single source of
     truth — its FIRST input entity — and every other input is reference
@@ -484,6 +502,10 @@ class WatermarkAspect(SignalEmitter):
             # cannot outlive the execution that captured it.
             ("datapipes.pipe_failed", self._on_pipe_failed),
             ("orchestrator.pipe_failed", self._on_pipe_failed),
+            # A skipped pipe (driving read had data, another input didn't)
+            # never persists — its capture dies with the execution too.
+            ("datapipes.pipe_skipped", self._on_pipe_failed),
+            ("orchestrator.pipe_skipped", self._on_pipe_failed),
         ):
             signal = self._signals.get_signal(signal_name) or self._signals.create_signal(
                 signal_name
@@ -508,6 +530,20 @@ class WatermarkAspect(SignalEmitter):
             return None
         df, cursor = self.wms.read_changes(entity, pipe)
         if cursor is not None:
+            if pipe.pipeid in self._pending:
+                # Every normal lifecycle path (persist, persist-failure,
+                # pipe-failure, skip, full-refresh) clears the capture, so
+                # finding one here means a prior run crashed without
+                # emitting signals — or two executions of this pipe are
+                # overlapping in this process, which the watermark model
+                # does not support (one cursor per source/reader). See the
+                # class docstring's concurrency contract.
+                self.logger.warning(
+                    f"Replacing existing pending watermark capture for pipe "
+                    f"'{pipe.pipeid}' — prior execution ended without a "
+                    f"lifecycle signal, or concurrent same-pipe executions "
+                    f"are overlapping (unsupported). Last capture wins."
+                )
             self._pending[pipe.pipeid] = (entity.entityid, cursor)
         else:
             self._pending.pop(pipe.pipeid, None)

--- a/packages/kindling/watermarking.py
+++ b/packages/kindling/watermarking.py
@@ -377,6 +377,12 @@ class WatermarkAspect(SignalEmitter):
     - ``persist.persist_failed``: discards the recorded version; the
       watermark stays put and the next run re-reads the same slice
       (at-least-once, made safe by idempotent merge writes).
+    - ``datapipes.pipe_failed`` / ``orchestrator.pipe_failed``: a pipe can
+      fail BEFORE its persist runs (a reference-input read fails, the
+      transform raises) — these discard the recorded version too, so a
+      capture can never outlive the execution that made it. As a second
+      guard, a non-watermarked read of a pipe's driving source (a
+      full-refresh run) also clears any stale capture for that pipe.
 
     Driving-source convention: a pipe operates on a single source of
     truth — its FIRST input entity — and every other input is reference
@@ -420,6 +426,12 @@ class WatermarkAspect(SignalEmitter):
             ("read.resolve_read", self._on_resolve_read),
             ("persist.after_persist", self._on_after_persist),
             ("persist.persist_failed", self._on_persist_failed),
+            # A pipe can fail before its persist ever runs (a reference
+            # input read fails, the transform raises). Both executers emit
+            # a pipe-level failure signal; clear the captured version so it
+            # cannot outlive the execution that captured it.
+            ("datapipes.pipe_failed", self._on_pipe_failed),
+            ("orchestrator.pipe_failed", self._on_pipe_failed),
         ):
             signal = self._signals.get_signal(signal_name) or self._signals.create_signal(
                 signal_name
@@ -429,7 +441,18 @@ class WatermarkAspect(SignalEmitter):
         self.logger.debug("WatermarkAspect registered")
 
     def _on_resolve_read(self, sender, *, entity=None, pipe=None, use_watermark=False, **kwargs):
-        if not use_watermark or entity is None or pipe is None:
+        if entity is None or pipe is None:
+            return None
+        if not use_watermark:
+            # A non-watermarked read of the pipe's DRIVING source (a
+            # full-refresh run, or a pipe with watermarking disabled)
+            # supersedes any version captured by an earlier failed
+            # watermarked execution. Clear it so the persist that follows
+            # this read cannot save a stale watermark. Reference-input
+            # reads (non-driving) must not clear the driving capture.
+            input_ids = getattr(pipe, "input_entity_ids", None) or []
+            if input_ids and entity.entityid == input_ids[0]:
+                self._pending.pop(pipe.pipeid, None)
             return None
         df, version = self.wms.read_changes_with_version(entity, pipe)
         if version is not None:
@@ -454,5 +477,9 @@ class WatermarkAspect(SignalEmitter):
         return None
 
     def _on_persist_failed(self, sender, *, pipe_id=None, **kwargs):
+        self._pending.pop(pipe_id, None)
+        return None
+
+    def _on_pipe_failed(self, sender, *, pipe_id=None, **kwargs):
         self._pending.pop(pipe_id, None)
         return None

--- a/tests/integration/test_watermark_incremental_correctness.py
+++ b/tests/integration/test_watermark_incremental_correctness.py
@@ -49,6 +49,7 @@ from pyspark.sql.types import (
     StringType,
     StructField,
     StructType,
+    TimestampType,
 )
 
 
@@ -400,3 +401,57 @@ class TestTimestampCursorProvider:
         manager.save_cursor(rest_entity.entityid, pipe.pipeid, cursor2, "exec-2")
         df3, cursor3 = manager.read_changes(rest_entity, pipe)
         assert df3 is None and cursor3 is None
+
+
+class TestWatermarkSchemaUpgrade:
+    """Already-deployed watermark tables predate the cursor column. The
+    merge path's schema evolution must add it on first save — without
+    that, save_cursor appears to succeed while the cursor is silently
+    dropped, and non-integer (REST/timestamp) cursors are lost, causing
+    repeated initial loads."""
+
+    def test_save_cursor_onto_old_schema_watermark_table(
+        self, spark, delta_provider, watermark_manager
+    ):
+        from datetime import datetime
+
+        # Pre-create system.watermarks with the OLD schema (no cursor
+        # column), as an upgraded environment would have it.
+        old_schema = StructType(
+            [
+                StructField("watermark_id", StringType(), False),
+                StructField("source_entity_id", StringType(), False),
+                StructField("reader_id", StringType(), False),
+                StructField("timestamp", TimestampType(), False),
+                StructField("last_version_processed", IntegerType(), False),
+                StructField("last_execution_id", StringType(), False),
+            ]
+        )
+        wm_entity = SimpleWatermarkEntityFinder().get_watermark_entity_for_entity("any")
+        old_entity = SimpleNamespace(**vars(wm_entity))
+        old_entity.schema = old_schema
+        legacy_row = spark.createDataFrame(
+            [
+                (
+                    "legacy_src_legacy_reader",
+                    "legacy_src",
+                    "legacy_reader",
+                    datetime(2026, 1, 1, 0, 0, 0),
+                    5,
+                    "exec-0",
+                )
+            ],
+            old_schema,
+        )
+        delta_provider.write_to_entity(legacy_row, old_entity)
+        assert "cursor" not in delta_provider.read_entity(wm_entity).columns
+
+        # A non-integer cursor saved through the manager must survive the
+        # round trip — the merge must ADD the cursor column, not silently
+        # drop it.
+        watermark_manager.save_cursor("bronze.api", "pipe.rest", "2026-07-13T10:00:00Z", "exec-1")
+        assert watermark_manager.get_cursor("bronze.api", "pipe.rest") == "2026-07-13T10:00:00Z"
+
+        # The pre-upgrade row (NULL cursor after evolution) still resolves
+        # through the legacy integer fallback.
+        assert watermark_manager.get_cursor("legacy_src", "legacy_reader") == "5"

--- a/tests/integration/test_watermark_incremental_correctness.py
+++ b/tests/integration/test_watermark_incremental_correctness.py
@@ -32,6 +32,7 @@ from kindling.data_entities import (
     EntityNameMapper,
     EntityPathLocator,
 )
+from kindling.entity_provider import IncrementalReadableEntityProvider
 from kindling.entity_provider_delta import DeltaEntityProvider
 from kindling.signaling import BlinkerSignalProvider
 from kindling.simple_read_persist_strategy import SimpleReadPersistStrategy
@@ -140,11 +141,14 @@ def delta_provider(spark, temp_dir, mock_logger_provider, monkeypatch):
 @pytest.fixture
 def watermark_manager(spark, delta_provider, mock_logger_provider, monkeypatch):
     monkeypatch.setattr("kindling.watermarking.get_or_create_spark_session", lambda: spark)
+    provider_registry = MagicMock()
+    provider_registry.get_provider_for_entity.return_value = delta_provider
     return WatermarkManager(
         ep=delta_provider,
         wef=SimpleWatermarkEntityFinder(),
         lp=mock_logger_provider,
         signal_provider=None,
+        provider_registry=provider_registry,
     )
 
 
@@ -202,8 +206,8 @@ class TestSkippedIntermediateVersions:
         # Watermark says: processed through the version that wrote row A.
         monkeypatch.setattr(
             watermark_manager,
-            "get_watermark",
-            lambda source_entity_id, reader_id: version_after_a,
+            "get_cursor",
+            lambda source_entity_id, reader_id: str(version_after_a),
         )
 
         pipe = SimpleNamespace(pipeid="pipe.skip_test", name="skip_test")
@@ -323,3 +327,76 @@ class TestWatermarkOverAdvance:
         )
         labels = {row["label"] for row in next_read.collect()}
         assert "B" in labels
+
+
+class _FakeRestProvider(IncrementalReadableEntityProvider):
+    """REST-style read-only provider: rows carry an updated_at field, and
+    the cursor is the max updated_at ISO string served so far. Strictly-
+    greater comparison; overlap/lookback policy would be provider config
+    in a real implementation."""
+
+    def __init__(self, spark):
+        self.spark = spark
+        self.rows = []
+
+    def read_entity_changes(self, entity, cursor):
+        new_rows = [r for r in self.rows if cursor is None or r[2] > cursor]
+        if not new_rows:
+            return None, None
+        df = self.spark.createDataFrame(new_rows, ["id", "label", "updated_at"])
+        return df, max(r[2] for r in new_rows)
+
+
+class TestTimestampCursorProvider:
+    """The watermark framework must treat cursors as opaque: a provider
+    whose incremental position is a timestamp (e.g. a read-only REST
+    provider keyed on created/updated fields) round-trips through the same
+    manager, aspect contract, and Delta-backed watermark storage as
+    version-cursor providers."""
+
+    def test_timestamp_cursor_round_trip(
+        self, spark, delta_provider, mock_logger_provider, monkeypatch
+    ):
+        monkeypatch.setattr("kindling.watermarking.get_or_create_spark_session", lambda: spark)
+        rest_provider = _FakeRestProvider(spark)
+        rest_entity = _make_source_entity("bronze.api_readings")
+
+        provider_registry = MagicMock()
+        provider_registry.get_provider_for_entity.return_value = rest_provider
+
+        manager = WatermarkManager(
+            ep=delta_provider,  # watermark storage stays Delta
+            wef=SimpleWatermarkEntityFinder(),
+            lp=mock_logger_provider,
+            signal_provider=None,
+            provider_registry=provider_registry,
+        )
+        pipe = SimpleNamespace(pipeid="pipe.api_test", name="api_test")
+
+        # Initial load: two rows, cursor = max updated_at.
+        rest_provider.rows = [
+            (1, "A", "2026-07-13T08:00:00Z"),
+            (2, "B", "2026-07-13T09:00:00Z"),
+        ]
+        df, cursor = manager.read_changes(rest_entity, pipe)
+        assert {r["label"] for r in df.collect()} == {"A", "B"}
+        assert cursor == "2026-07-13T09:00:00Z"
+
+        # Persist succeeded -> cursor recorded (what the aspect does).
+        manager.save_cursor(rest_entity.entityid, pipe.pipeid, cursor, "exec-1")
+
+        # The stored cursor survives the round trip through Delta storage
+        # verbatim; the legacy integer accessor degrades gracefully.
+        assert manager.get_cursor(rest_entity.entityid, pipe.pipeid) == cursor
+        assert manager.get_watermark(rest_entity.entityid, pipe.pipeid) is None
+
+        # A new row lands upstream; the next read returns only it.
+        rest_provider.rows.append((3, "C", "2026-07-13T10:30:00Z"))
+        df2, cursor2 = manager.read_changes(rest_entity, pipe)
+        assert {r["label"] for r in df2.collect()} == {"C"}
+        assert cursor2 == "2026-07-13T10:30:00Z"
+
+        # And with nothing new, no data and no cursor movement.
+        manager.save_cursor(rest_entity.entityid, pipe.pipeid, cursor2, "exec-2")
+        df3, cursor3 = manager.read_changes(rest_entity, pipe)
+        assert df3 is None and cursor3 is None

--- a/tests/integration/test_watermark_incremental_correctness.py
+++ b/tests/integration/test_watermark_incremental_correctness.py
@@ -1,0 +1,325 @@
+"""Integration tests exposing incremental-read correctness bugs in the
+watermark path, using real Delta tables with Change Data Feed.
+
+Bug 1 — skipped intermediate versions (watermarking.py):
+    ``read_current_entity_changes`` passes the table's *latest* version to
+    ``read_entity_since_version`` instead of ``watermark + 1``. CDF's
+    ``startingVersion`` is inclusive, so when the source advanced more than
+    one commit since the watermark, every commit except the last is silently
+    never read.
+
+Bug 2 — watermark over-advance (simple_read_persist_strategy.py):
+    ``persist_lambda`` re-fetches ``get_entity_version`` at persist time
+    rather than using the version that was actually read. A commit landing
+    on the source between read and persist gets its version recorded as
+    processed without its data ever being read — the next incremental read
+    reports "no new data" and the commit is lost.
+
+Both tests drive the real DeltaEntityProvider against local Delta tables so
+the change-feed semantics are Delta's own, not a mock's.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from delta import configure_spark_with_delta_pip
+from kindling.data_entities import (
+    DataEntityManager,
+    EntityNameMapper,
+    EntityPathLocator,
+)
+from kindling.entity_provider_delta import DeltaEntityProvider
+from kindling.signaling import BlinkerSignalProvider
+from kindling.simple_read_persist_strategy import SimpleReadPersistStrategy
+from kindling.spark_config import ConfigService
+from kindling.spark_log_provider import PythonLoggerProvider
+from kindling.watermarking import (
+    SimpleWatermarkEntityFinder,
+    WatermarkAspect,
+    WatermarkManager,
+)
+from pyspark.sql import SparkSession
+from pyspark.sql.types import (
+    IntegerType,
+    StringType,
+    StructField,
+    StructType,
+)
+
+
+def _teardown_existing_spark_jvm():
+    """Stop any session created by earlier test modules and shut down the
+    py4j gateway so a NEW JVM launches with the Delta jars on its classpath.
+
+    Spark's JVM is a process-wide singleton: ``spark.jars.packages`` is only
+    honored at gateway launch, so a plain session created by another module
+    would leave this module without the Delta data source no matter what
+    configs we pass to ``getOrCreate``.
+    """
+    from pyspark import SparkContext
+
+    active = SparkSession.getActiveSession()
+    if active is not None:
+        active.stop()
+    if SparkContext._gateway is not None:
+        try:
+            SparkContext._gateway.shutdown()
+        except Exception:
+            pass
+        SparkContext._gateway = None
+        SparkContext._jvm = None
+
+
+@pytest.fixture(scope="module")
+def spark():
+    _teardown_existing_spark_jvm()
+    builder = (
+        SparkSession.builder.appName("WatermarkIncrementalCorrectness")
+        .master("local[2]")
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+        # Every table created in these tests gets CDF from version 0.
+        .config("spark.databricks.delta.properties.defaults.enableChangeDataFeed", "true")
+        .config("spark.sql.shuffle.partitions", "2")
+        .config("spark.ui.enabled", "false")
+    )
+    spark = configure_spark_with_delta_pip(builder).getOrCreate()
+    spark.sparkContext.setLogLevel("ERROR")
+    yield spark
+    spark.stop()
+
+
+@pytest.fixture
+def temp_dir():
+    temp_path = tempfile.mkdtemp(prefix="kindling-wm-test-")
+    yield Path(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
+
+
+@pytest.fixture
+def mock_logger_provider():
+    provider = MagicMock(spec=PythonLoggerProvider)
+    provider.get_logger.return_value = MagicMock()
+    return provider
+
+
+@pytest.fixture
+def delta_provider(spark, temp_dir, mock_logger_provider, monkeypatch):
+    """Real DeltaEntityProvider in storage mode, rooted at a temp dir."""
+    monkeypatch.setattr("kindling.entity_provider_delta.get_or_create_spark_session", lambda: spark)
+
+    config = MagicMock(spec=ConfigService)
+    config.get.side_effect = lambda key, default=None: (
+        "storage" if key == "kindling.delta.access_mode" else default
+    )
+
+    name_mapper = MagicMock(spec=EntityNameMapper)
+    name_mapper.get_table_name.side_effect = lambda entity: entity.entityid.replace(".", "_")
+
+    path_locator = MagicMock(spec=EntityPathLocator)
+    path_locator.get_table_path.side_effect = lambda entity: str(
+        Path(str(temp_dir)) / entity.entityid
+    )
+
+    return DeltaEntityProvider(
+        config=config,
+        entity_name_mapper=name_mapper,
+        path_locator=path_locator,
+        tp=mock_logger_provider,
+        signal_provider=None,
+    )
+
+
+@pytest.fixture
+def watermark_manager(spark, delta_provider, mock_logger_provider, monkeypatch):
+    monkeypatch.setattr("kindling.watermarking.get_or_create_spark_session", lambda: spark)
+    return WatermarkManager(
+        ep=delta_provider,
+        wef=SimpleWatermarkEntityFinder(),
+        lp=mock_logger_provider,
+        signal_provider=None,
+    )
+
+
+SOURCE_SCHEMA = StructType(
+    [
+        StructField("id", IntegerType(), False),
+        StructField("label", StringType(), True),
+    ]
+)
+
+
+def _make_source_entity(entityid="bronze.readings"):
+    return SimpleNamespace(
+        entityid=entityid,
+        name=entityid.split(".")[-1],
+        partition_columns=[],
+        merge_columns=["id"],
+        tags={"provider_type": "delta"},
+        schema=SOURCE_SCHEMA,
+        cluster_columns=None,
+    )
+
+
+def _append_commit(spark, delta_provider, entity, rows):
+    """One append = exactly one Delta commit."""
+    df = spark.createDataFrame(rows, SOURCE_SCHEMA)
+    if delta_provider.check_entity_exists(entity):
+        delta_provider.append_to_entity(df, entity)
+    else:
+        delta_provider.write_to_entity(df, entity)
+
+
+class TestSkippedIntermediateVersions:
+    """Bug 1: read_current_entity_changes must return changes from EVERY
+    commit after the watermark, not only the latest one."""
+
+    def test_read_changes_includes_all_commits_since_watermark(
+        self, spark, delta_provider, watermark_manager, monkeypatch
+    ):
+        entity = _make_source_entity("bronze.readings_skip_test")
+
+        # Three separate writes with distinct keys so latest-change-per-key
+        # dedup cannot mask a skipped commit. Capture the actual version
+        # after each write (a single provider write can produce more than
+        # one Delta commit).
+        _append_commit(spark, delta_provider, entity, [(1, "A")])
+        version_after_a = delta_provider.get_entity_version(entity)
+        _append_commit(spark, delta_provider, entity, [(2, "B")])
+        version_after_b = delta_provider.get_entity_version(entity)
+        _append_commit(spark, delta_provider, entity, [(3, "C")])
+        version_after_c = delta_provider.get_entity_version(entity)
+
+        assert version_after_a < version_after_b < version_after_c
+
+        # Watermark says: processed through the version that wrote row A.
+        monkeypatch.setattr(
+            watermark_manager,
+            "get_watermark",
+            lambda source_entity_id, reader_id: version_after_a,
+        )
+
+        pipe = SimpleNamespace(pipeid="pipe.skip_test", name="skip_test")
+        result = watermark_manager.read_current_entity_changes(entity, pipe)
+
+        assert result is not None, "There ARE unprocessed changes (versions 1 and 2)"
+        labels = {row["label"] for row in result.collect()}
+
+        # Versions 1 (B) and 2 (C) are both after the watermark; both must
+        # be returned. The bug reads CDF from startingVersion=<latest>,
+        # returning only C and silently dropping B.
+        assert labels == {"B", "C"}, (
+            f"Expected changes from every commit after the watermark "
+            f"(B from v1, C from v2), got {labels} — intermediate commits "
+            f"were silently skipped"
+        )
+
+
+class TestWatermarkOverAdvance:
+    """Bug 2: the watermark saved after persist must reflect the version
+    that was READ, not the source version at persist time."""
+
+    def _make_strategy(
+        self, watermark_manager, delta_provider, entity_registry, mock_logger_provider
+    ):
+        """Wire the strategy and the WatermarkAspect exactly as production
+        does: a shared signal provider, aspect registered on it."""
+        trace_provider = Mock()
+        trace_provider.span.return_value.__enter__ = Mock()
+        trace_provider.span.return_value.__exit__ = Mock(return_value=False)
+
+        provider_registry = MagicMock()
+        provider_registry.get_provider_for_entity.return_value = delta_provider
+
+        signal_provider = BlinkerSignalProvider()
+        strategy = SimpleReadPersistStrategy(
+            ep=delta_provider,
+            der=entity_registry,
+            tp=trace_provider,
+            lp=mock_logger_provider,
+            provider_registry=provider_registry,
+            signal_provider=signal_provider,
+        )
+        aspect = WatermarkAspect(
+            wms=watermark_manager,
+            lp=mock_logger_provider,
+            signal_provider=signal_provider,
+        )
+        aspect.register()
+        return strategy
+
+    def test_commit_between_read_and_persist_is_not_marked_processed(
+        self, spark, delta_provider, watermark_manager, mock_logger_provider
+    ):
+        source_entity = _make_source_entity("bronze.readings_race_test")
+        output_entity = _make_source_entity("silver.readings_race_test")
+
+        entity_registry = DataEntityManager()
+        for e in (source_entity, output_entity):
+            entity_registry.register_entity(
+                e.entityid,
+                name=e.name,
+                partition_columns=[],
+                merge_columns=["id"],
+                tags={"provider_type": "delta"},
+                schema=SOURCE_SCHEMA,
+            )
+
+        strategy = self._make_strategy(
+            watermark_manager, delta_provider, entity_registry, mock_logger_provider
+        )
+
+        pipe = SimpleNamespace(
+            pipeid="pipe.race_test",
+            name="race_test",
+            input_entity_ids=[source_entity.entityid],
+            output_entity_id=output_entity.entityid,
+            use_watermark=True,
+        )
+
+        # Write row A; this state (version_at_read) is what the pipe reads,
+        # through the strategy's real read path so the aspect captures the
+        # version at read time.
+        _append_commit(spark, delta_provider, source_entity, [(1, "A")])
+        source_def = entity_registry.get_entity_definition(source_entity.entityid)
+        version_at_read = delta_provider.get_entity_version(source_def)
+        reader = strategy.create_pipe_entity_reader(pipe)
+        df_read = reader(source_def, True)
+        assert df_read is not None
+
+        # A concurrent commit lands AFTER the read, BEFORE the persist.
+        _append_commit(spark, delta_provider, source_entity, [(2, "B")])
+        assert delta_provider.get_entity_version(source_def) > version_at_read
+
+        # Persist the (version-0) read result.
+        persist = strategy.create_pipe_persist_activator(pipe)
+        persist(df_read)
+
+        # The watermark must record the version that was read. Recording the
+        # persist-time version marks row B processed though it was never read.
+        saved = watermark_manager.get_watermark(source_entity.entityid, pipe.pipeid)
+        assert saved == version_at_read, (
+            f"Watermark advanced to {saved}, but only version "
+            f"{version_at_read} was read — row B's commit is now marked "
+            f"processed without ever being processed"
+        )
+
+        # The observable consequence: the next incremental read must surface
+        # row B. With the over-advanced watermark it returns None ("no new
+        # data") and row B is lost forever.
+        next_read = watermark_manager.read_current_entity_changes(
+            entity_registry.get_entity_definition(source_entity.entityid), pipe
+        )
+        assert next_read is not None, (
+            "Next incremental read reported 'no new data' — the commit that "
+            "landed between read and persist was silently lost"
+        )
+        labels = {row["label"] for row in next_read.collect()}
+        assert "B" in labels

--- a/tests/unit/test_scd_merge_strategies.py
+++ b/tests/unit/test_scd_merge_strategies.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from kindling.entity_provider_delta import (
     DeltaMergeStrategies,
     DeltaMergeStrategy,
@@ -59,22 +58,28 @@ def _apply_scd1_strategy():
     return delta_table, df, merge_builder
 
 
+def test_scd1_strategy_apply_enables_schema_evolution():
+    _, _, merge_builder = _apply_scd1_strategy()
+
+    merge_builder.withSchemaEvolution.assert_called_once_with()
+
+
 def test_scd1_strategy_apply_calls_when_matched_update_all():
     _, _, merge_builder = _apply_scd1_strategy()
 
-    merge_builder.whenMatchedUpdateAll.assert_called_once_with()
+    merge_builder.withSchemaEvolution.return_value.whenMatchedUpdateAll.assert_called_once_with()
 
 
 def test_scd1_strategy_apply_calls_when_not_matched_insert_all():
     _, _, merge_builder = _apply_scd1_strategy()
 
-    merge_builder.whenMatchedUpdateAll.return_value.whenNotMatchedInsertAll.assert_called_once_with()
+    merge_builder.withSchemaEvolution.return_value.whenMatchedUpdateAll.return_value.whenNotMatchedInsertAll.assert_called_once_with()
 
 
 def test_scd1_strategy_apply_calls_execute():
     _, _, merge_builder = _apply_scd1_strategy()
 
-    merge_builder.whenMatchedUpdateAll.return_value.whenNotMatchedInsertAll.return_value.execute.assert_called_once_with()
+    merge_builder.withSchemaEvolution.return_value.whenMatchedUpdateAll.return_value.whenNotMatchedInsertAll.return_value.execute.assert_called_once_with()
 
 
 def test_scd1_strategy_apply_uses_provided_merge_condition():

--- a/tests/unit/test_scd_merge_strategies.py
+++ b/tests/unit/test_scd_merge_strategies.py
@@ -91,3 +91,67 @@ def test_scd1_strategy_apply_uses_provided_merge_condition():
         source=df.alias.return_value,
         condition="old.`id` = new.`id`",
     )
+
+
+def _apply_scd1_strategy_legacy_delta(existing_conf_value=None):
+    """Apply SCD1 against a merge builder WITHOUT withSchemaEvolution
+    (Delta < 3.2), returning the builder and the session conf mock."""
+    delta_table = MagicMock()
+    aliased_delta = delta_table.alias.return_value
+    merge_builder = aliased_delta.merge.return_value
+    del merge_builder.withSchemaEvolution  # hasattr() -> False
+
+    df = MagicMock()
+    conf = df.sparkSession.conf
+    conf.get.return_value = existing_conf_value
+    entity = MagicMock()
+
+    SCD1MergeStrategy().apply(delta_table, df, entity, "old.`id` = new.`id`")
+
+    return merge_builder, conf
+
+
+def test_scd1_strategy_legacy_delta_executes_merge_chain():
+    merge_builder, _ = _apply_scd1_strategy_legacy_delta()
+
+    merge_builder.whenMatchedUpdateAll.return_value.whenNotMatchedInsertAll.return_value.execute.assert_called_once_with()
+
+
+def test_scd1_strategy_legacy_delta_enables_automerge_conf():
+    _, conf = _apply_scd1_strategy_legacy_delta()
+
+    conf.set.assert_called_once_with("spark.databricks.delta.schema.autoMerge.enabled", "true")
+
+
+def test_scd1_strategy_legacy_delta_unsets_conf_when_previously_absent():
+    _, conf = _apply_scd1_strategy_legacy_delta(existing_conf_value=None)
+
+    conf.unset.assert_called_once_with("spark.databricks.delta.schema.autoMerge.enabled")
+
+
+def test_scd1_strategy_legacy_delta_restores_previous_conf_value():
+    _, conf = _apply_scd1_strategy_legacy_delta(existing_conf_value="false")
+
+    conf.unset.assert_not_called()
+    assert conf.set.call_args_list[-1].args == (
+        "spark.databricks.delta.schema.autoMerge.enabled",
+        "false",
+    )
+
+
+def test_scd1_strategy_legacy_delta_restores_conf_even_when_merge_fails():
+    delta_table = MagicMock()
+    merge_builder = delta_table.alias.return_value.merge.return_value
+    del merge_builder.withSchemaEvolution
+    merge_builder.whenMatchedUpdateAll.return_value.whenNotMatchedInsertAll.return_value.execute.side_effect = RuntimeError(
+        "merge failed"
+    )
+
+    df = MagicMock()
+    conf = df.sparkSession.conf
+    conf.get.return_value = None
+
+    with pytest.raises(RuntimeError, match="merge failed"):
+        SCD1MergeStrategy().apply(delta_table, df, MagicMock(), "old.`id` = new.`id`")
+
+    conf.unset.assert_called_once_with("spark.databricks.delta.schema.autoMerge.enabled")

--- a/tests/unit/test_watermark_aspect.py
+++ b/tests/unit/test_watermark_aspect.py
@@ -29,9 +29,14 @@ def wms():
 
 
 @pytest.fixture
-def aspect(wms, signal_provider):
+def aspect_logger():
+    return MagicMock()
+
+
+@pytest.fixture
+def aspect(wms, signal_provider, aspect_logger):
     logger_provider = MagicMock(spec=PythonLoggerProvider)
-    logger_provider.get_logger.return_value = MagicMock()
+    logger_provider.get_logger.return_value = aspect_logger
     aspect = WatermarkAspect(wms=wms, lp=logger_provider, signal_provider=signal_provider)
     aspect.register()
     return aspect
@@ -197,6 +202,54 @@ class TestStalePendingLifecycle:
         )
         _emit(signal_provider, "persist.after_persist", pipe_id=pipe.pipeid, persist_id="z")
         wms.save_cursor.assert_not_called()
+
+    @pytest.mark.parametrize("skip_signal", ["datapipes.pipe_skipped", "orchestrator.pipe_skipped"])
+    def test_pipe_skip_clears_pending(self, aspect, wms, signal_provider, skip_signal):
+        """Driving read had data, but the pipe was skipped (e.g. a
+        reference input was unavailable) — nothing persisted, so the
+        capture must not survive to a later after_persist."""
+        pipe = _pipe()
+        self._capture_then_fail_before_persist(signal_provider, pipe)
+        _emit(signal_provider, skip_signal, pipe_id=pipe.pipeid, skip_reason="no_data")
+
+        _emit(signal_provider, "persist.after_persist", pipe_id=pipe.pipeid, persist_id="z")
+        wms.save_cursor.assert_not_called()
+
+    def test_overlapping_same_pipe_captures_warn_and_last_wins(
+        self, aspect, wms, signal_provider, aspect_logger
+    ):
+        """Concurrent same-pipe execution is unsupported (one cursor per
+        source/reader). The aspect's documented behavior when captures
+        overlap anyway: warn, last capture wins, single save."""
+        pipe = _pipe()
+        wms.read_changes.return_value = (MagicMock(name="df"), "10")
+        _emit(
+            signal_provider,
+            "read.resolve_read",
+            entity=_entity("bronze.src"),
+            pipe=pipe,
+            pipe_id=pipe.pipeid,
+            use_watermark=True,
+        )
+        aspect_logger.warning.assert_not_called()
+
+        # A second capture for the same pipe before the first persists.
+        wms.read_changes.return_value = (MagicMock(name="df"), "12")
+        _emit(
+            signal_provider,
+            "read.resolve_read",
+            entity=_entity("bronze.src"),
+            pipe=pipe,
+            pipe_id=pipe.pipeid,
+            use_watermark=True,
+        )
+        aspect_logger.warning.assert_called_once()
+
+        _emit(signal_provider, "persist.after_persist", pipe_id=pipe.pipeid, persist_id="a")
+        _emit(signal_provider, "persist.after_persist", pipe_id=pipe.pipeid, persist_id="b")
+
+        wms.save_cursor.assert_called_once()
+        assert wms.save_cursor.call_args[0][2] == "12"
 
     def test_failure_in_one_pipe_does_not_affect_another(self, aspect, wms, signal_provider):
         pipe_a = _pipe("pipe.a")

--- a/tests/unit/test_watermark_aspect.py
+++ b/tests/unit/test_watermark_aspect.py
@@ -1,0 +1,197 @@
+"""Unit tests for WatermarkAspect pending-state lifecycle.
+
+The aspect captures (source_entity_id, version) per pipe at read time and
+advances the watermark only after a successful persist. These tests pin
+the lifecycle guarantees around failure and full-refresh paths — in
+particular that a version captured by a FAILED execution can never be
+saved by a later execution of the same pipe.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from kindling.signaling import BlinkerSignalProvider
+from kindling.spark_log_provider import PythonLoggerProvider
+from kindling.watermarking import ResolvedRead, WatermarkAspect, WatermarkService
+
+
+@pytest.fixture
+def signal_provider():
+    return BlinkerSignalProvider()
+
+
+@pytest.fixture
+def wms():
+    wms = MagicMock(spec=WatermarkService)
+    wms.read_changes_with_version.return_value = (MagicMock(name="df"), 7)
+    return wms
+
+
+@pytest.fixture
+def aspect(wms, signal_provider):
+    logger_provider = MagicMock(spec=PythonLoggerProvider)
+    logger_provider.get_logger.return_value = MagicMock()
+    aspect = WatermarkAspect(wms=wms, lp=logger_provider, signal_provider=signal_provider)
+    aspect.register()
+    return aspect
+
+
+def _emit(signal_provider, name, **kwargs):
+    signal = signal_provider.get_signal(name) or signal_provider.create_signal(name)
+    return signal.send(None, **kwargs)
+
+
+def _pipe(pipeid="pipe.p1", inputs=("bronze.src", "bronze.ref")):
+    return SimpleNamespace(pipeid=pipeid, name=pipeid, input_entity_ids=list(inputs))
+
+
+def _entity(entityid="bronze.src"):
+    return SimpleNamespace(entityid=entityid, name=entityid)
+
+
+class TestHappyPath:
+    def test_watermarked_read_then_persist_saves_captured_version(
+        self, aspect, wms, signal_provider
+    ):
+        pipe = _pipe()
+        results = _emit(
+            signal_provider,
+            "read.resolve_read",
+            entity=_entity("bronze.src"),
+            pipe=pipe,
+            pipe_id=pipe.pipeid,
+            use_watermark=True,
+        )
+        resolved = [r for _, r in results if isinstance(r, ResolvedRead)]
+        assert len(resolved) == 1
+
+        _emit(signal_provider, "persist.after_persist", pipe_id=pipe.pipeid, persist_id="x")
+
+        wms.save_watermark.assert_called_once()
+        args = wms.save_watermark.call_args[0]
+        assert args[0] == "bronze.src"
+        assert args[1] == pipe.pipeid
+        assert args[2] == 7  # the version captured at read time
+
+    def test_reference_input_read_does_not_clear_driving_capture(
+        self, aspect, wms, signal_provider
+    ):
+        pipe = _pipe()
+        _emit(
+            signal_provider,
+            "read.resolve_read",
+            entity=_entity("bronze.src"),
+            pipe=pipe,
+            pipe_id=pipe.pipeid,
+            use_watermark=True,
+        )
+        # Reference input is read in full (use_watermark=False) AFTER the
+        # driving input — it must not disturb the driving capture.
+        _emit(
+            signal_provider,
+            "read.resolve_read",
+            entity=_entity("bronze.ref"),
+            pipe=pipe,
+            pipe_id=pipe.pipeid,
+            use_watermark=False,
+        )
+        _emit(signal_provider, "persist.after_persist", pipe_id=pipe.pipeid, persist_id="x")
+
+        wms.save_watermark.assert_called_once()
+
+
+class TestStalePendingLifecycle:
+    """A version captured by a failed execution must never be saved later."""
+
+    def _capture_then_fail_before_persist(self, signal_provider, pipe):
+        """Simulate: watermarked driving read succeeds (capture recorded),
+        then the pipe dies before persist — no persist.* signal fires."""
+        _emit(
+            signal_provider,
+            "read.resolve_read",
+            entity=_entity("bronze.src"),
+            pipe=pipe,
+            pipe_id=pipe.pipeid,
+            use_watermark=True,
+        )
+
+    def test_full_refresh_after_failed_run_does_not_save_stale_watermark(
+        self, aspect, wms, signal_provider
+    ):
+        pipe = _pipe()
+        self._capture_then_fail_before_persist(signal_provider, pipe)
+
+        # Later: a full-refresh run of the same pipe (use_watermark=False
+        # for the DRIVING input) reads everything and persists.
+        _emit(
+            signal_provider,
+            "read.resolve_read",
+            entity=_entity("bronze.src"),
+            pipe=pipe,
+            pipe_id=pipe.pipeid,
+            use_watermark=False,
+        )
+        _emit(signal_provider, "persist.after_persist", pipe_id=pipe.pipeid, persist_id="y")
+
+        # Full-refresh runs never save watermarks — and in particular must
+        # not save the version captured by the earlier failed execution.
+        wms.save_watermark.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "failure_signal", ["datapipes.pipe_failed", "orchestrator.pipe_failed"]
+    )
+    def test_pipe_failure_clears_pending(self, aspect, wms, signal_provider, failure_signal):
+        pipe = _pipe()
+        self._capture_then_fail_before_persist(signal_provider, pipe)
+        _emit(signal_provider, failure_signal, pipe_id=pipe.pipeid, error="boom")
+
+        # Even a bare after_persist for this pipe (no fresh resolve_read)
+        # must now find nothing to save.
+        _emit(signal_provider, "persist.after_persist", pipe_id=pipe.pipeid, persist_id="z")
+        wms.save_watermark.assert_not_called()
+
+    def test_persist_failed_clears_pending(self, aspect, wms, signal_provider):
+        pipe = _pipe()
+        self._capture_then_fail_before_persist(signal_provider, pipe)
+        _emit(signal_provider, "persist.persist_failed", pipe_id=pipe.pipeid, error="boom")
+
+        _emit(signal_provider, "persist.after_persist", pipe_id=pipe.pipeid, persist_id="z")
+        wms.save_watermark.assert_not_called()
+
+    def test_no_new_data_read_clears_prior_pending(self, aspect, wms, signal_provider):
+        pipe = _pipe()
+        self._capture_then_fail_before_persist(signal_provider, pipe)
+
+        # Next watermarked run finds no new data — capture must be cleared,
+        # not left pointing at the failed run's version.
+        wms.read_changes_with_version.return_value = (None, None)
+        _emit(
+            signal_provider,
+            "read.resolve_read",
+            entity=_entity("bronze.src"),
+            pipe=pipe,
+            pipe_id=pipe.pipeid,
+            use_watermark=True,
+        )
+        _emit(signal_provider, "persist.after_persist", pipe_id=pipe.pipeid, persist_id="z")
+        wms.save_watermark.assert_not_called()
+
+    def test_failure_in_one_pipe_does_not_affect_another(self, aspect, wms, signal_provider):
+        pipe_a = _pipe("pipe.a")
+        pipe_b = _pipe("pipe.b")
+        self._capture_then_fail_before_persist(signal_provider, pipe_a)
+        _emit(signal_provider, "datapipes.pipe_failed", pipe_id=pipe_a.pipeid, error="boom")
+
+        _emit(
+            signal_provider,
+            "read.resolve_read",
+            entity=_entity("bronze.src"),
+            pipe=pipe_b,
+            pipe_id=pipe_b.pipeid,
+            use_watermark=True,
+        )
+        _emit(signal_provider, "persist.after_persist", pipe_id=pipe_b.pipeid, persist_id="w")
+
+        wms.save_watermark.assert_called_once()
+        assert wms.save_watermark.call_args[0][1] == pipe_b.pipeid

--- a/tests/unit/test_watermark_aspect.py
+++ b/tests/unit/test_watermark_aspect.py
@@ -24,7 +24,7 @@ def signal_provider():
 @pytest.fixture
 def wms():
     wms = MagicMock(spec=WatermarkService)
-    wms.read_changes_with_version.return_value = (MagicMock(name="df"), 7)
+    wms.read_changes.return_value = (MagicMock(name="df"), "7")
     return wms
 
 
@@ -68,11 +68,32 @@ class TestHappyPath:
 
         _emit(signal_provider, "persist.after_persist", pipe_id=pipe.pipeid, persist_id="x")
 
-        wms.save_watermark.assert_called_once()
-        args = wms.save_watermark.call_args[0]
+        wms.save_cursor.assert_called_once()
+        args = wms.save_cursor.call_args[0]
         assert args[0] == "bronze.src"
         assert args[1] == pipe.pipeid
-        assert args[2] == 7  # the version captured at read time
+        assert args[2] == "7"  # the cursor captured at read time
+
+    def test_non_integer_cursor_round_trips_opaquely(self, aspect, wms, signal_provider):
+        """A REST-style timestamp cursor is stored verbatim — the aspect
+        never interprets cursor contents."""
+        pipe = _pipe()
+        wms.read_changes.return_value = (
+            MagicMock(name="df"),
+            "2026-07-13T10:00:00Z",
+        )
+        _emit(
+            signal_provider,
+            "read.resolve_read",
+            entity=_entity("bronze.src"),
+            pipe=pipe,
+            pipe_id=pipe.pipeid,
+            use_watermark=True,
+        )
+        _emit(signal_provider, "persist.after_persist", pipe_id=pipe.pipeid, persist_id="x")
+
+        wms.save_cursor.assert_called_once()
+        assert wms.save_cursor.call_args[0][2] == "2026-07-13T10:00:00Z"
 
     def test_reference_input_read_does_not_clear_driving_capture(
         self, aspect, wms, signal_provider
@@ -98,7 +119,7 @@ class TestHappyPath:
         )
         _emit(signal_provider, "persist.after_persist", pipe_id=pipe.pipeid, persist_id="x")
 
-        wms.save_watermark.assert_called_once()
+        wms.save_cursor.assert_called_once()
 
 
 class TestStalePendingLifecycle:
@@ -136,7 +157,7 @@ class TestStalePendingLifecycle:
 
         # Full-refresh runs never save watermarks — and in particular must
         # not save the version captured by the earlier failed execution.
-        wms.save_watermark.assert_not_called()
+        wms.save_cursor.assert_not_called()
 
     @pytest.mark.parametrize(
         "failure_signal", ["datapipes.pipe_failed", "orchestrator.pipe_failed"]
@@ -149,7 +170,7 @@ class TestStalePendingLifecycle:
         # Even a bare after_persist for this pipe (no fresh resolve_read)
         # must now find nothing to save.
         _emit(signal_provider, "persist.after_persist", pipe_id=pipe.pipeid, persist_id="z")
-        wms.save_watermark.assert_not_called()
+        wms.save_cursor.assert_not_called()
 
     def test_persist_failed_clears_pending(self, aspect, wms, signal_provider):
         pipe = _pipe()
@@ -157,7 +178,7 @@ class TestStalePendingLifecycle:
         _emit(signal_provider, "persist.persist_failed", pipe_id=pipe.pipeid, error="boom")
 
         _emit(signal_provider, "persist.after_persist", pipe_id=pipe.pipeid, persist_id="z")
-        wms.save_watermark.assert_not_called()
+        wms.save_cursor.assert_not_called()
 
     def test_no_new_data_read_clears_prior_pending(self, aspect, wms, signal_provider):
         pipe = _pipe()
@@ -165,7 +186,7 @@ class TestStalePendingLifecycle:
 
         # Next watermarked run finds no new data — capture must be cleared,
         # not left pointing at the failed run's version.
-        wms.read_changes_with_version.return_value = (None, None)
+        wms.read_changes.return_value = (None, None)
         _emit(
             signal_provider,
             "read.resolve_read",
@@ -175,7 +196,7 @@ class TestStalePendingLifecycle:
             use_watermark=True,
         )
         _emit(signal_provider, "persist.after_persist", pipe_id=pipe.pipeid, persist_id="z")
-        wms.save_watermark.assert_not_called()
+        wms.save_cursor.assert_not_called()
 
     def test_failure_in_one_pipe_does_not_affect_another(self, aspect, wms, signal_provider):
         pipe_a = _pipe("pipe.a")
@@ -193,5 +214,5 @@ class TestStalePendingLifecycle:
         )
         _emit(signal_provider, "persist.after_persist", pipe_id=pipe_b.pipeid, persist_id="w")
 
-        wms.save_watermark.assert_called_once()
-        assert wms.save_watermark.call_args[0][1] == pipe_b.pipeid
+        wms.save_cursor.assert_called_once()
+        assert wms.save_cursor.call_args[0][1] == pipe_b.pipeid


### PR DESCRIPTION
## Summary

Two incremental-read correctness bugs, each proven by an integration test against **real Delta CDF** that failed before the fix and passes after:

1. **Skipped intermediate versions** — `read_current_entity_changes` passed the source's *latest* version as CDF `startingVersion` instead of `watermark + 1`. Any time a source advanced more than one commit between runs, every commit except the last was silently never processed.
2. **Watermark over-advance** — the persist path re-fetched `get_entity_version` at persist time instead of using the version captured at read time. A commit landing between read and persist was recorded as processed without its data ever being read; the next run reported "no new data" and the commit was lost permanently.

## Refactor: watermarking as a signal aspect

Watermark behavior now attaches to pipe execution through signals instead of being woven into the read/persist strategy:

- **`WatermarkAspect`** (new, `kindling/watermarking.py`) connects to `read.resolve_read` (performs the incremental read, captures the covered version per pipe), `persist.after_persist` (advances the watermark to the **captured** version), and `persist.persist_failed` (discards it — at-least-once semantics).
- **`read.resolve_read`** is a new interdiction point in `SimpleReadPersistStrategy`: a handler returning a `ResolvedRead` takes ownership of the read, including "no new data" (`df=None`). No handler → ordinary full read. The strategy no longer knows watermarks exist.
- Incremental reads are bounded with CDF `endingVersion` so the lazily-executed slice matches the recorded watermark exactly.
- Bootstrap registers the aspect on non-standalone platforms; local/standalone keeps its full-read fixture behavior. A future execution engine that owns incrementality (e.g. declarative pipelines) simply never registers the aspect.
- Driving-source convention (input 0 is the pipe's single watermarked source of truth; other inputs are reference data, read in full) is now documented at both the executer and the aspect.

## Breaking changes (release notes)

- `persist.before_persist` payload no longer includes `source_version` (no in-repo consumers).
- `SimpleReadPersistStrategy.__init__` no longer takes `wms: WatermarkService` (DI-resolved; only direct constructors are affected).
- `persist.watermark_saved` is now emitted by `WatermarkAspect`, not the strategy (same signal name and payload).

## Testing

- New `tests/integration/test_watermark_incremental_correctness.py` — drives the real `DeltaEntityProvider` + `WatermarkManager` + strategy + aspect against local Delta tables with CDF; both tests reproduce the bugs pre-fix and pass post-fix. Note: the module fixture relaunches the Spark JVM gateway because `spark.jars.packages` (Delta) is only honored at gateway launch and an earlier suite module may have launched it without Delta.
- Full suites green: 1,540 unit / 71 integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)