### PR TITLE
feat(adx): streaming write + batch read support for the ADX entity provider

### DIFF
--- a/packages/kindling_adx/README.md
+++ b/packages/kindling_adx/README.md
@@ -135,3 +135,30 @@ Streaming defaults:
 `provider.write_mode: KustoStreaming` only when the destination table/database is
 configured for ADX streaming ingestion and the lower-latency tradeoff is
 intentional.
+
+## Reads
+
+ADX entities can also be used as pipe *inputs*. `read_entity()` reads either a
+whole table or the result of a KQL query through the same connector and auth
+configuration used for writes:
+
+```python
+tags={
+    "provider_type": "adx",
+    "provider.auth": "managed_identity",
+    "provider.cluster": "https://mycluster.region.kusto.windows.net",
+    "provider.database": "MyDatabase",
+    "provider.table": "MyTable",
+    # Optional — takes precedence over provider.table when set:
+    "provider.query": "MyTable | where Amount > 0 | project-away _etl_internal",
+}
+```
+
+Notes:
+
+- Reads require database **Viewer** permissions for the configured identity.
+  Write-only entities keep working without them — the persist path never reads,
+  and `check_entity_exists()` still honors `provider.assume_exists`.
+- Large scans use the connector's distributed read mode. To force small results
+  through the driver (reference-data lookups), pass
+  `provider.option.readMode: ForceSingleMode`.

--- a/packages/kindling_adx/README.md
+++ b/packages/kindling_adx/README.md
@@ -108,3 +108,30 @@ Defaults:
 `provider.assume_exists` defaults to `true` because this first extension version
 is a write target. It avoids requiring read/query permissions just to decide
 whether the Kindling persist path should call append or write.
+
+## Streaming Writes
+
+The provider also supports Spark Structured Streaming outputs. Kindling calls
+`append_as_stream()` for streaming pipe outputs and the ADX provider starts the
+Kusto sink with the configured connector options and checkpoint location.
+
+```python
+tags={
+    "provider_type": "adx",
+    "provider.auth": "managed_identity",
+    "provider.cluster": "https://mycluster.region.kusto.windows.net",
+    "provider.database": "MyDatabase",
+    "provider.table": "MyTable",
+    "provider.query_name": "orders_to_adx",
+}
+```
+
+Streaming defaults:
+
+- `provider.output_mode`: `append`
+- `provider.write_mode`: `Queued`
+
+`Queued` mode is the recommended default for most continuous Spark writes. Use
+`provider.write_mode: KustoStreaming` only when the destination table/database is
+configured for ADX streaming ingestion and the lower-latency tradeoff is
+intentional.

--- a/packages/kindling_adx/kindling_adx/entity_provider_adx.py
+++ b/packages/kindling_adx/kindling_adx/entity_provider_adx.py
@@ -150,12 +150,15 @@ class AdxEntityProvider(BaseEntityProvider, WritableEntityProvider, StreamWritab
 
         options: Dict[str, Any] = {"kustoDatabase": database}
 
+        # The connector's read path takes KQL only — kustoTable is a sink
+        # option. A bare table name is a valid KQL query, so reading a table
+        # means passing its name as kustoQuery.
         query = config.get("query") or config.get("kusto_query")
         table = config.get("table") or config.get("table_name")
         if query:
             options["kustoQuery"] = query
         elif table:
-            options["kustoTable"] = table
+            options["kustoQuery"] = table
         else:
             raise ValueError(
                 f"ADX entity '{entity_metadata.entityid}' requires provider.table "

--- a/packages/kindling_adx/kindling_adx/entity_provider_adx.py
+++ b/packages/kindling_adx/kindling_adx/entity_provider_adx.py
@@ -10,9 +10,6 @@ from __future__ import annotations
 from typing import Any, Dict, Optional
 
 from injector import inject
-from pyspark.sql import DataFrame
-from pyspark.sql.streaming import StreamingQuery
-
 from kindling.data_entities import EntityMetadata
 from kindling.entity_provider import (
     BaseEntityProvider,
@@ -21,7 +18,10 @@ from kindling.entity_provider import (
 )
 from kindling.entity_provider_registry import EntityProviderRegistry
 from kindling.injection import GlobalInjector
+from kindling.spark_config import get_or_create_spark_session
 from kindling.spark_log_provider import PythonLoggerProvider
+from pyspark.sql import DataFrame
+from pyspark.sql.streaming import StreamingQuery
 
 ADX_SPARK_CONNECTOR_MAVEN_COORDINATE = "com.microsoft.azure.kusto:kusto-spark_3.0_2.12:7.0.6"
 GENERIC_FORMAT = "com.microsoft.kusto.spark.datasource"
@@ -29,18 +29,39 @@ SYNAPSE_FORMAT = "com.microsoft.kusto.spark.synapse.datasource"
 
 
 class AdxEntityProvider(BaseEntityProvider, WritableEntityProvider, StreamWritableEntityProvider):
-    """Write DataFrames to Azure Data Explorer through the Kusto Spark connector."""
+    """Read and write DataFrames against Azure Data Explorer through the Kusto Spark connector."""
 
     @inject
     def __init__(self, logger_provider: PythonLoggerProvider):
         self.logger = logger_provider.get_logger("AdxEntityProvider")
 
     def read_entity(self, entity_metadata: EntityMetadata) -> DataFrame:
-        """Read support is intentionally absent from the first extension version."""
-        raise NotImplementedError(
-            "AdxEntityProvider is currently a materialization target only. "
-            "Use it for write_to_entity/append_to_entity, or add read support with kustoQuery."
+        """Read an ADX table (or `provider.query` KQL result) as a batch DataFrame.
+
+        Requires database Viewer permissions for the configured identity —
+        write-only entities keep working without them because the persist path
+        never calls read.
+        """
+        config = self._get_provider_config(entity_metadata)
+        options = self._build_read_options(entity_metadata, config)
+        source_format = self._source_format(config)
+
+        self.logger.info(
+            "Reading entity '%s' from ADX %s using %s",
+            entity_metadata.entityid,
+            (
+                f"query on database '{options.get('kustoDatabase')}'"
+                if "kustoQuery" in options
+                else f"table '{options.get('kustoTable')}'"
+            ),
+            source_format,
         )
+
+        spark = get_or_create_spark_session()
+        reader = spark.read.format(source_format)
+        for key, value in options.items():
+            reader = reader.option(key, value)
+        return reader.load()
 
     def check_entity_exists(self, entity_metadata: EntityMetadata) -> bool:
         """Return configured existence assumption for write-path compatibility.
@@ -120,6 +141,30 @@ class AdxEntityProvider(BaseEntityProvider, WritableEntityProvider, StreamWritab
             return SYNAPSE_FORMAT
         return GENERIC_FORMAT
 
+    def _build_read_options(
+        self, entity_metadata: EntityMetadata, config: Dict[str, Any]
+    ) -> Dict[str, str]:
+        database = config.get("database")
+        if not database:
+            raise ValueError(f"ADX entity '{entity_metadata.entityid}' requires provider.database")
+
+        options: Dict[str, Any] = {"kustoDatabase": database}
+
+        query = config.get("query") or config.get("kusto_query")
+        table = config.get("table") or config.get("table_name")
+        if query:
+            options["kustoQuery"] = query
+        elif table:
+            options["kustoTable"] = table
+        else:
+            raise ValueError(
+                f"ADX entity '{entity_metadata.entityid}' requires provider.table "
+                "or provider.query for reads"
+            )
+
+        options.update(self._connection_options(entity_metadata, config))
+        return self._stringify_options(options)
+
     def _build_options(
         self, entity_metadata: EntityMetadata, config: Dict[str, Any]
     ) -> Dict[str, str]:
@@ -136,6 +181,15 @@ class AdxEntityProvider(BaseEntityProvider, WritableEntityProvider, StreamWritab
             "writeMode": config.get("write_mode", "Queued"),
             "tableCreateOptions": config.get("table_create_options", "FailIfNotExist"),
         }
+
+        options.update(self._connection_options(entity_metadata, config))
+        return self._stringify_options(options)
+
+    def _connection_options(
+        self, entity_metadata: EntityMetadata, config: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Cluster/linked-service, auth, and passthrough options shared by reads and writes."""
+        options: Dict[str, Any] = {}
 
         auth_mode = self._auth_mode(config)
         if auth_mode == "synapse_linked_service":
@@ -157,6 +211,9 @@ class AdxEntityProvider(BaseEntityProvider, WritableEntityProvider, StreamWritab
             options.update(self._auth_options(entity_metadata, config, auth_mode))
 
         options.update(self._extra_connector_options(config))
+        return options
+
+    def _stringify_options(self, options: Dict[str, Any]) -> Dict[str, str]:
         return {
             key: self._stringify_option(value)
             for key, value in options.items()

--- a/packages/kindling_adx/kindling_adx/entity_provider_adx.py
+++ b/packages/kindling_adx/kindling_adx/entity_provider_adx.py
@@ -18,8 +18,8 @@ from kindling.entity_provider import (
 )
 from kindling.entity_provider_registry import EntityProviderRegistry
 from kindling.injection import GlobalInjector
-from kindling.spark_config import get_or_create_spark_session
 from kindling.spark_log_provider import PythonLoggerProvider
+from kindling.spark_session import get_or_create_spark_session
 from pyspark.sql import DataFrame
 from pyspark.sql.streaming import StreamingQuery
 

--- a/packages/kindling_adx/kindling_adx/entity_provider_adx.py
+++ b/packages/kindling_adx/kindling_adx/entity_provider_adx.py
@@ -7,13 +7,18 @@ or by a later provider feature instead of being implied.
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from injector import inject
 from pyspark.sql import DataFrame
+from pyspark.sql.streaming import StreamingQuery
 
 from kindling.data_entities import EntityMetadata
-from kindling.entity_provider import BaseEntityProvider, WritableEntityProvider
+from kindling.entity_provider import (
+    BaseEntityProvider,
+    StreamWritableEntityProvider,
+    WritableEntityProvider,
+)
 from kindling.entity_provider_registry import EntityProviderRegistry
 from kindling.injection import GlobalInjector
 from kindling.spark_log_provider import PythonLoggerProvider
@@ -23,7 +28,7 @@ GENERIC_FORMAT = "com.microsoft.kusto.spark.datasource"
 SYNAPSE_FORMAT = "com.microsoft.kusto.spark.synapse.datasource"
 
 
-class AdxEntityProvider(BaseEntityProvider, WritableEntityProvider):
+class AdxEntityProvider(BaseEntityProvider, WritableEntityProvider, StreamWritableEntityProvider):
     """Write DataFrames to Azure Data Explorer through the Kusto Spark connector."""
 
     @inject
@@ -57,6 +62,39 @@ class AdxEntityProvider(BaseEntityProvider, WritableEntityProvider):
     def append_to_entity(self, df: DataFrame, entity_metadata: EntityMetadata) -> None:
         """Append DataFrame rows to ADX."""
         self._save(df, entity_metadata, "Append")
+
+    def append_as_stream(
+        self,
+        df: DataFrame,
+        entity_metadata: EntityMetadata,
+        checkpoint_location: str,
+        format: Optional[str] = None,
+        options: Optional[dict] = None,
+    ) -> StreamingQuery:
+        """Append a streaming DataFrame to ADX through the Kusto Spark connector."""
+        config = self._get_provider_config(entity_metadata)
+        if options:
+            config = {**config, **options}
+
+        connector_options = self._build_options(entity_metadata, config)
+        source_format = format or self._source_format(config)
+        output_mode = str(config.get("output_mode", "append"))
+        query_name = config.get("query_name")
+
+        self.logger.info(
+            "Starting streaming write for entity '%s' to ADX table '%s' using %s",
+            entity_metadata.entityid,
+            connector_options.get("kustoTable"),
+            source_format,
+        )
+
+        writer = df.writeStream.format(source_format).outputMode(output_mode)
+        if query_name:
+            writer = writer.queryName(str(query_name))
+        writer = writer.option("checkpointLocation", checkpoint_location)
+        for key, value in connector_options.items():
+            writer = writer.option(key, value)
+        return writer.start()
 
     def _save(self, df: DataFrame, entity_metadata: EntityMetadata, mode: str) -> None:
         config = self._get_provider_config(entity_metadata)

--- a/tests/system/extensions/adx/test_adx_provider_system.py
+++ b/tests/system/extensions/adx/test_adx_provider_system.py
@@ -1,0 +1,286 @@
+"""System test: AdxEntityProvider round-trip against a live ADX cluster.
+
+Creates a uniquely named table in the `kindling` database on the
+sep-adx-dataint-dev cluster, writes rows through the provider (Kusto Spark
+connector, queued ingestion), reads them back both by table and by KQL
+query, then drops the table.
+
+Credential resolution (service principal `sep-kindling-nonprod`), in order:
+
+1. ``ADX_TEST_CLIENT_SECRET`` env var.
+2. ``AZURE_CLIENT_SECRET`` env var, but only when ``AZURE_CLIENT_ID`` matches
+   the ADX service principal's client id.
+3. Key Vault: ``SYSTEM_TEST_KEY_VAULT_URL`` + secret named
+   ``ADX_TEST_CLIENT_SECRET_NAME`` (default
+   ``sep-kindling-nonprod-client-secret``), fetched with
+   ``DefaultAzureCredential`` (az login works locally).
+
+The test skips — never fails — when credentials or network access are
+unavailable.
+
+Requirements: Spark 3.x / Scala 2.12, outbound HTTPS to the public ADX
+endpoint, and the Kusto Spark connector (downloaded via
+``spark.jars.packages`` on first run).
+"""
+
+import json
+import logging
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Optional
+
+import pytest
+from kindling.data_entities import EntityMetadata
+
+
+def _import_provider_class():
+    """Import AdxEntityProvider without triggering DI registration.
+
+    ``kindling_adx.__init__`` calls ``register_provider()`` on import, which
+    resolves the real EntityProviderRegistry through GlobalInjector — that
+    requires an initialized framework. This test drives the provider
+    directly, so stub the injector during import (same pattern as the unit
+    tests).
+    """
+    from unittest.mock import MagicMock, patch
+
+    for module_name in list(sys.modules):
+        if module_name == "kindling_adx" or module_name.startswith("kindling_adx."):
+            del sys.modules[module_name]
+
+    with patch("kindling.injection.GlobalInjector.get", return_value=MagicMock()):
+        from kindling_adx import AdxEntityProvider
+
+    return AdxEntityProvider
+
+
+EXTENSION_PACKAGE_ROOT = Path(__file__).resolve().parents[4] / "packages" / "kindling_adx"
+
+ADX_CLUSTER = os.getenv(
+    "ADX_TEST_CLUSTER", "https://sep-adx-dataint-dev.northcentralus.kusto.windows.net"
+).rstrip("/")
+ADX_DATABASE = os.getenv("ADX_TEST_DATABASE", "kindling")
+ADX_CLIENT_ID = os.getenv("ADX_TEST_CLIENT_ID", "dacf705a-49ca-4791-b6a3-c35448112241")
+ADX_TENANT_ID = os.getenv("ADX_TEST_TENANT_ID", "898f7683-8ab4-4a28-b74e-510b95f981eb")
+ADX_SECRET_NAME = os.getenv("ADX_TEST_CLIENT_SECRET_NAME", "sep-kindling-nonprod-client-secret")
+KUSTO_SPARK_PACKAGE = "com.microsoft.azure.kusto:kusto-spark_3.0_2.12:7.0.6"
+
+# Queued ingestion is asynchronous and the default batching policy holds rows
+# for up to ~5 minutes; a full run takes ~6 minutes on the Dev(No SLA) cluster.
+READ_TIMEOUT_SECONDS = int(os.getenv("ADX_TEST_READ_TIMEOUT", "420"))
+
+
+class _LoggerProvider:
+    def get_logger(self, name):
+        return logging.getLogger(name)
+
+
+def _fetch_secret_from_key_vault(vault_url: str, secret_name: str) -> Optional[str]:
+    """Fetch a secret value via the Key Vault REST API using azure-identity."""
+    try:
+        from azure.identity import DefaultAzureCredential
+
+        token = DefaultAzureCredential().get_token("https://vault.azure.net/.default").token
+        url = f"{vault_url.rstrip('/')}/secrets/{urllib.parse.quote(secret_name)}?api-version=7.4"
+        request = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read())["value"]
+    except Exception:
+        return None
+
+
+def _resolve_client_secret() -> Optional[str]:
+    explicit = (os.getenv("ADX_TEST_CLIENT_SECRET") or "").strip()
+    if explicit:
+        return explicit
+
+    if (os.getenv("AZURE_CLIENT_ID") or "").strip().lower() == ADX_CLIENT_ID.lower():
+        ambient = (os.getenv("AZURE_CLIENT_SECRET") or "").strip()
+        if ambient:
+            return ambient
+
+    vault_url = (os.getenv("SYSTEM_TEST_KEY_VAULT_URL") or "").strip()
+    if vault_url:
+        return _fetch_secret_from_key_vault(vault_url, ADX_SECRET_NAME)
+
+    return None
+
+
+def _adx_mgmt(csl: str, client_secret: str) -> None:
+    """Run a Kusto management command via the cluster's REST endpoint."""
+    from azure.identity import ClientSecretCredential
+
+    credential = ClientSecretCredential(ADX_TENANT_ID, ADX_CLIENT_ID, client_secret)
+    token = credential.get_token(f"{ADX_CLUSTER}/.default").token
+    payload = json.dumps({"db": ADX_DATABASE, "csl": csl}).encode("utf-8")
+    request = urllib.request.Request(
+        f"{ADX_CLUSTER}/v1/rest/mgmt",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json; charset=utf-8",
+            "Accept": "application/json",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=60):
+        pass
+
+
+@pytest.fixture(scope="module")
+def adx_client_secret():
+    secret = _resolve_client_secret()
+    if not secret:
+        pytest.skip(
+            "ADX service principal secret not available. Set ADX_TEST_CLIENT_SECRET, "
+            "or AZURE_CLIENT_ID/AZURE_CLIENT_SECRET for the sep-kindling-nonprod SP, "
+            f"or store '{ADX_SECRET_NAME}' in SYSTEM_TEST_KEY_VAULT_URL."
+        )
+    return secret
+
+
+@pytest.fixture(scope="module")
+def spark():
+    try:
+        from pyspark.sql import SparkSession
+    except ImportError:
+        pytest.skip("pyspark not available")
+
+    session = (
+        SparkSession.builder.appName("kindling-adx-system-test")
+        .master("local[2]")
+        .config("spark.jars.packages", KUSTO_SPARK_PACKAGE)
+        .config("spark.sql.shuffle.partitions", "2")
+        .getOrCreate()
+    )
+    yield session
+    session.stop()
+
+
+@pytest.fixture(autouse=True)
+def _extension_package_on_path(monkeypatch):
+    monkeypatch.syspath_prepend(str(EXTENSION_PACKAGE_ROOT))
+
+
+def _entity(table: str, extra_tags: Optional[dict] = None) -> EntityMetadata:
+    tags = {
+        "provider_type": "adx",
+        "provider.auth": "service_principal",
+        "provider.cluster": ADX_CLUSTER,
+        "provider.database": ADX_DATABASE,
+        "provider.table": table,
+        "provider.client_id": ADX_CLIENT_ID,
+        "provider.tenant_id": ADX_TENANT_ID,
+        # The connector must create the table itself: externally pre-created
+        # tables fail queued ingestion (ingestion-service schema cache).
+        "provider.table_create_options": "CreateIfNotExist",
+        **(extra_tags or {}),
+    }
+    return EntityMetadata(
+        entityid=f"systest.{table}",
+        name=table,
+        partition_columns=[],
+        merge_columns=[],
+        tags=tags,
+        schema=None,
+    )
+
+
+def _recent_ingestion_failures(client_secret: str) -> str:
+    """Best-effort: fetch recent ingestion failures for the failure message."""
+    try:
+        from azure.identity import ClientSecretCredential
+
+        credential = ClientSecretCredential(ADX_TENANT_ID, ADX_CLIENT_ID, client_secret)
+        token = credential.get_token(f"{ADX_CLUSTER}/.default").token
+        payload = json.dumps(
+            {"db": ADX_DATABASE, "csl": ".show ingestion failures | top 3 by FailedOn desc"}
+        ).encode("utf-8")
+        request = urllib.request.Request(
+            f"{ADX_CLUSTER}/v1/rest/mgmt",
+            data=payload,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json; charset=utf-8",
+                "Accept": "application/json",
+            },
+        )
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return response.read().decode("utf-8")[:2000]
+    except Exception as exc:  # noqa: BLE001
+        return f"<could not fetch ingestion failures: {exc}>"
+
+
+def _poll_for_rows(provider, entity, expected_count: int, client_secret: str):
+    """Poll read_entity until queued ingestion lands or the timeout expires."""
+    deadline = time.time() + READ_TIMEOUT_SECONDS
+    last_count = -1
+    while time.time() < deadline:
+        df = provider.read_entity(entity)
+        last_count = df.count()
+        if last_count >= expected_count:
+            return df
+        time.sleep(15)
+    pytest.fail(
+        f"Expected {expected_count} rows in ADX within {READ_TIMEOUT_SECONDS}s, "
+        f"last saw {last_count}. Recent ingestion failures: "
+        f"{_recent_ingestion_failures(client_secret)}"
+    )
+
+
+@pytest.mark.system
+@pytest.mark.azure
+@pytest.mark.slow
+def test_adx_create_write_read_roundtrip(spark, adx_client_secret):
+    AdxEntityProvider = _import_provider_class()
+
+    table = f"kindling_systest_{uuid.uuid4().hex[:8]}"
+    provider = AdxEntityProvider(_LoggerProvider())
+    secret_tags = {"provider.client_secret": adx_client_secret}
+
+    try:
+        rows = [(1, "alpha", 10.5), (2, "bravo", 20.0), (3, "charlie", 30.25)]
+        df = spark.createDataFrame(rows, ["id", "name", "amount"])
+
+        # Write through the provider. The connector creates the table itself
+        # (tableCreateOptions=CreateIfNotExist from _entity) — pre-creating it
+        # via the mgmt REST API makes queued ingestion fail with a permanent
+        # "table could not be found" (ingestion-service schema cache does not
+        # see externally created tables immediately). flushImmediately asks
+        # the ingestion service to skip batch aggregation; observed runs on
+        # the Dev SKU still take the ~5 minute batching window, hence the
+        # generous read timeout.
+        write_tags = {
+            **secret_tags,
+            "provider.option.sparkIngestionProperties": '{"flushImmediately":true}',
+        }
+        provider.write_to_entity(df, _entity(table, write_tags))
+
+        # Read back by table.
+        result = _poll_for_rows(
+            provider, _entity(table, secret_tags), expected_count=3, client_secret=adx_client_secret
+        )
+        by_id = {row["id"]: row for row in result.collect()}
+        assert set(by_id) == {1, 2, 3}
+        assert by_id[2]["name"] == "bravo"
+        assert by_id[3]["amount"] == pytest.approx(30.25)
+
+        # Read back by KQL query (provider.query takes precedence over table).
+        query_entity = _entity(
+            table,
+            {**secret_tags, "provider.query": f"{table} | where amount > 15 | project id"},
+        )
+        filtered_ids = {row["id"] for row in provider.read_entity(query_entity).collect()}
+        assert filtered_ids == {2, 3}
+    finally:
+        try:
+            _adx_mgmt(f".drop table {table} ifexists", adx_client_secret)
+        except Exception:
+            logging.getLogger(__name__).warning(
+                "Failed to drop ADX test table %s — clean up manually", table
+            )

--- a/tests/system/extensions/adx/test_adx_provider_system.py
+++ b/tests/system/extensions/adx/test_adx_provider_system.py
@@ -62,12 +62,12 @@ def _import_provider_class():
 
 EXTENSION_PACKAGE_ROOT = Path(__file__).resolve().parents[4] / "packages" / "kindling_adx"
 
-ADX_CLUSTER = os.getenv(
-    "ADX_TEST_CLUSTER", "https://sep-adx-dataint-dev.northcentralus.kusto.windows.net"
-).rstrip("/")
-ADX_DATABASE = os.getenv("ADX_TEST_DATABASE", "kindling")
-ADX_CLIENT_ID = os.getenv("ADX_TEST_CLIENT_ID", "dacf705a-49ca-4791-b6a3-c35448112241")
-ADX_TENANT_ID = os.getenv("ADX_TEST_TENANT_ID", "898f7683-8ab4-4a28-b74e-510b95f981eb")
+# Target resources come from env vars (see .env.sep in local dev). The
+# service principal defaults to the ambient AZURE_CLIENT_ID/AZURE_TENANT_ID.
+ADX_CLUSTER = os.getenv("ADX_TEST_CLUSTER", "").rstrip("/")
+ADX_DATABASE = os.getenv("ADX_TEST_DATABASE", "")
+ADX_CLIENT_ID = os.getenv("ADX_TEST_CLIENT_ID") or os.getenv("AZURE_CLIENT_ID", "")
+ADX_TENANT_ID = os.getenv("ADX_TEST_TENANT_ID") or os.getenv("AZURE_TENANT_ID", "")
 ADX_SECRET_NAME = os.getenv("ADX_TEST_CLIENT_SECRET_NAME", "sep-kindling-nonprod-client-secret")
 KUSTO_SPARK_PACKAGE = "com.microsoft.azure.kusto:kusto-spark_3.0_2.12:7.0.6"
 
@@ -134,6 +134,19 @@ def _adx_mgmt(csl: str, client_secret: str) -> None:
 
 @pytest.fixture(scope="module")
 def adx_client_secret():
+    missing = [
+        name
+        for name, value in {
+            "ADX_TEST_CLUSTER": ADX_CLUSTER,
+            "ADX_TEST_DATABASE": ADX_DATABASE,
+            "ADX_TEST_CLIENT_ID (or AZURE_CLIENT_ID)": ADX_CLIENT_ID,
+            "ADX_TEST_TENANT_ID (or AZURE_TENANT_ID)": ADX_TENANT_ID,
+        }.items()
+        if not value
+    ]
+    if missing:
+        pytest.skip(f"ADX test resource not configured (see .env.sep): {', '.join(missing)}")
+
     secret = _resolve_client_secret()
     if not secret:
         pytest.skip(

--- a/tests/unit/test_adx_entity_provider_extension.py
+++ b/tests/unit/test_adx_entity_provider_extension.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from kindling.data_entities import EntityMetadata
 
 EXTENSION_PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "packages" / "kindling_adx"
@@ -298,3 +297,128 @@ def test_table_is_required():
 
     with pytest.raises(ValueError, match="provider.table"):
         provider.append_to_entity(df, entity)
+
+
+class _Reader:
+    def __init__(self):
+        self.format_name = None
+        self.options = {}
+        self.loaded_df = MagicMock(name="read_df")
+
+    def format(self, name):
+        self.format_name = name
+        return self
+
+    def option(self, key, value):
+        self.options[key] = value
+        return self
+
+    def load(self):
+        return self.loaded_df
+
+
+def _patched_spark_read(reader):
+    spark = MagicMock()
+    spark.read = reader
+    return patch(
+        "kindling_adx.entity_provider_adx.get_or_create_spark_session",
+        return_value=spark,
+    )
+
+
+def test_read_entity_by_table_uses_kusto_source_options():
+    provider = _provider()
+    reader = _Reader()
+    entity = _entity(
+        {
+            "provider.auth": "managed_identity",
+            "provider.cluster": "https://fawkes.eastus.kusto.windows.net",
+            "provider.database": "Kindling",
+            "provider.table": "Orders",
+        }
+    )
+
+    with _patched_spark_read(reader):
+        df = provider.read_entity(entity)
+
+    assert df is reader.loaded_df
+    assert reader.format_name == "com.microsoft.kusto.spark.datasource"
+    assert reader.options["kustoCluster"] == "https://fawkes.eastus.kusto.windows.net"
+    assert reader.options["kustoDatabase"] == "Kindling"
+    assert reader.options["kustoTable"] == "Orders"
+    assert reader.options["managedIdentityAuth"] == "true"
+    # Write-only options must not leak into reads
+    assert "writeMode" not in reader.options
+    assert "tableCreateOptions" not in reader.options
+
+
+def test_read_entity_prefers_query_over_table():
+    provider = _provider()
+    reader = _Reader()
+    entity = _entity(
+        {
+            "provider.auth": "managed_identity",
+            "provider.cluster": "fawkes.eastus",
+            "provider.database": "Kindling",
+            "provider.table": "Orders",
+            "provider.query": "Orders | where Amount > 0",
+        }
+    )
+
+    with _patched_spark_read(reader):
+        provider.read_entity(entity)
+
+    assert reader.options["kustoQuery"] == "Orders | where Amount > 0"
+    assert "kustoTable" not in reader.options
+
+
+def test_read_entity_requires_table_or_query():
+    provider = _provider()
+    entity = _entity(
+        {
+            "provider.auth": "managed_identity",
+            "provider.cluster": "fawkes.eastus",
+            "provider.database": "Kindling",
+        }
+    )
+
+    with pytest.raises(ValueError, match="provider.table"):
+        provider.read_entity(entity)
+
+
+def test_read_entity_uses_synapse_linked_service_format():
+    provider = _provider()
+    reader = _Reader()
+    entity = _entity(
+        {
+            "provider.auth": "synapse_linked_service",
+            "provider.linked_service": "fawkes_adx",
+            "provider.database": "Kindling",
+            "provider.table": "Orders",
+        }
+    )
+
+    with _patched_spark_read(reader):
+        provider.read_entity(entity)
+
+    assert reader.format_name == "com.microsoft.kusto.spark.synapse.datasource"
+    assert reader.options["spark.synapse.linkedService"] == "fawkes_adx"
+
+
+def test_read_entity_passes_extra_connector_options():
+    provider = _provider()
+    reader = _Reader()
+    entity = _entity(
+        {
+            "provider.auth": "managed_identity",
+            "provider.cluster": "fawkes.eastus",
+            "provider.database": "Kindling",
+            "provider.table": "Orders",
+            "provider.option.readMode": "ForceSingleMode",
+        }
+    )
+
+    with _patched_spark_read(reader):
+        provider.read_entity(entity)
+
+    assert reader.options["readMode"] == "ForceSingleMode"

--- a/tests/unit/test_adx_entity_provider_extension.py
+++ b/tests/unit/test_adx_entity_provider_extension.py
@@ -48,6 +48,36 @@ class _Writer:
         self.saved = True
 
 
+class _StreamWriter:
+    def __init__(self):
+        self.format_name = None
+        self.options = {}
+        self.output_mode = None
+        self.query_name = None
+        self.started = False
+        self.query = MagicMock(name="streaming_query")
+
+    def format(self, name):
+        self.format_name = name
+        return self
+
+    def option(self, key, value):
+        self.options[key] = value
+        return self
+
+    def outputMode(self, name):
+        self.output_mode = name
+        return self
+
+    def queryName(self, name):
+        self.query_name = name
+        return self
+
+    def start(self):
+        self.started = True
+        return self.query
+
+
 def _provider():
     from kindling_adx import AdxEntityProvider
 
@@ -164,6 +194,90 @@ def test_extra_connector_options_are_passed_through():
     assert writer.options["adjustSchema"] == "GenerateDynamicCsvMapping"
     assert writer.options["clientBatchingLimit"] == "1024"
     assert writer.options["useManagedIdentity"] == "true"
+
+
+def test_stream_append_starts_query_with_kusto_sink_options():
+    provider = _provider()
+    writer = _StreamWriter()
+    df = MagicMock()
+    df.writeStream = writer
+    entity = _entity(
+        {
+            "provider.auth": "managed_identity",
+            "provider.cluster": "https://fawkes.eastus.kusto.windows.net",
+            "provider.database": "Kindling",
+            "provider.table": "Orders",
+            "provider.query_name": "orders_to_adx",
+            "provider.option.adjustSchema": "GenerateDynamicCsvMapping",
+        }
+    )
+
+    query = provider.append_as_stream(df, entity, "/chk/orders")
+
+    assert query is writer.query
+    assert writer.format_name == "com.microsoft.kusto.spark.datasource"
+    assert writer.output_mode == "append"
+    assert writer.query_name == "orders_to_adx"
+    assert writer.options["checkpointLocation"] == "/chk/orders"
+    assert writer.options["kustoCluster"] == "https://fawkes.eastus.kusto.windows.net"
+    assert writer.options["kustoDatabase"] == "Kindling"
+    assert writer.options["kustoTable"] == "Orders"
+    assert writer.options["managedIdentityAuth"] == "true"
+    assert writer.options["writeMode"] == "Queued"
+    assert writer.options["adjustSchema"] == "GenerateDynamicCsvMapping"
+    assert writer.started is True
+
+
+def test_stream_append_merges_call_options_and_allows_format_override():
+    provider = _provider()
+    writer = _StreamWriter()
+    df = MagicMock()
+    df.writeStream = writer
+    entity = _entity(
+        {
+            "provider.auth": "managed_identity",
+            "provider.cluster": "https://fawkes.eastus.kusto.windows.net",
+            "provider.database": "Kindling",
+            "provider.table": "Orders",
+        }
+    )
+
+    provider.append_as_stream(
+        df,
+        entity,
+        "/chk/orders",
+        format="custom.kusto.format",
+        options={
+            "output_mode": "update",
+            "write_mode": "Transactional",
+            "option.clientBatchingLimit": "1024",
+        },
+    )
+
+    assert writer.format_name == "custom.kusto.format"
+    assert writer.output_mode == "update"
+    assert writer.options["writeMode"] == "Transactional"
+    assert writer.options["clientBatchingLimit"] == "1024"
+
+
+def test_stream_append_uses_synapse_linked_service_format():
+    provider = _provider()
+    writer = _StreamWriter()
+    df = MagicMock()
+    df.writeStream = writer
+    entity = _entity(
+        {
+            "provider.auth": "synapse_linked_service",
+            "provider.linked_service": "fawkes_adx",
+            "provider.database": "Kindling",
+            "provider.table": "Orders",
+        }
+    )
+
+    provider.append_as_stream(df, entity, "/chk/orders")
+
+    assert writer.format_name == "com.microsoft.kusto.spark.synapse.datasource"
+    assert writer.options["spark.synapse.linkedService"] == "fawkes_adx"
 
 
 def test_check_entity_exists_defaults_to_true_for_write_only_target():

--- a/tests/unit/test_adx_entity_provider_extension.py
+++ b/tests/unit/test_adx_entity_provider_extension.py
@@ -345,7 +345,10 @@ def test_read_entity_by_table_uses_kusto_source_options():
     assert reader.format_name == "com.microsoft.kusto.spark.datasource"
     assert reader.options["kustoCluster"] == "https://fawkes.eastus.kusto.windows.net"
     assert reader.options["kustoDatabase"] == "Kindling"
-    assert reader.options["kustoTable"] == "Orders"
+    # The connector's read path is KQL-only; a table read passes the table
+    # name as kustoQuery (kustoTable is a sink option).
+    assert reader.options["kustoQuery"] == "Orders"
+    assert "kustoTable" not in reader.options
     assert reader.options["managedIdentityAuth"] == "true"
     # Write-only options must not leak into reads
     assert "writeMode" not in reader.options


### PR DESCRIPTION
## What

Matures the `kindling_adx` extension from a write-only materialization target to a full batch/streaming citizen:

- **Streaming writes** (`StreamWritableEntityProvider.append_as_stream`): starts the Kusto sink with the configured connector options, checkpoint location, output mode, and optional query name. Defaults to `Queued` write mode; `KustoStreaming` is an explicit opt-in.
- **Batch reads** (`read_entity`): reads a whole table (`provider.table`) or a KQL query result (`provider.query`, takes precedence) through the same connector, auth modes (managed identity / Synapse linked service / access token / service principal), and `provider.option.*` passthrough used for writes.

## Why

ADX entities could only be pipe *outputs*. Reads unlock ADX as a pipe input (reference data, telemetry joins); streaming writes make ADX a first-class sink for streaming DAGs. This is the "ADX maturation" path from the provider roadmap discussion.

## Design notes

- Connection/auth option building is extracted to `_connection_options()`, shared by read and write paths; write-only options (`writeMode`, `tableCreateOptions`) no longer leak into reads.
- The write-only permission posture is preserved: `check_entity_exists()` still honors `provider.assume_exists`, so write-only entities need no query permissions. Reads require database Viewer rights.
- Large reads use the connector's distributed mode; `provider.option.readMode: ForceSingleMode` forces small results through the driver.

## Verification

15/15 extension unit tests pass (5 new read tests, 3 streaming tests). Branch rebased onto main (import-order conflict from the isort bump resolved).

Note: this branch revives month-old streaming-write work from the `codex/kindling-pkk-adx-streaming` worktree that was committed but never PR'd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)