### PR TITLE
feat(cosmos): Cosmos DB entity provider extension

### DIFF
--- a/packages/kindling_cosmos/README.md
+++ b/packages/kindling_cosmos/README.md
@@ -1,0 +1,65 @@
+# kindling-cosmos
+
+Azure Cosmos DB (NoSQL API) entity provider extension for Kindling.
+
+Entities tagged `provider_type: "cosmos"` read and write through the
+[Cosmos DB Spark connector](https://learn.microsoft.com/azure/cosmos-db/nosql/quickstart-spark)
+(`com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12:4.37.2` — a JVM package
+that must be available on the Spark pool, e.g. via `spark.jars.packages`).
+
+## Upsert semantics
+
+Writes use the connector's `ItemOverwrite` strategy by default: documents are
+**upserted by `(id, partition key)`**. Writes are therefore idempotent — a
+retried persist converges instead of duplicating rows. Map your entity's
+logical key onto the document `id` column (Cosmos ids are strings) to get
+merge-like behavior. Set `provider.write_strategy: ItemAppend` for
+insert-only, or `ItemDelete` to delete by id.
+
+## Configuration
+
+```python
+tags={
+    "provider_type": "cosmos",
+    "provider.auth": "service_principal",          # or master_key
+    "provider.account_endpoint": "https://myaccount.documents.azure.com:443/",
+    "provider.database": "MyDatabase",
+    "provider.container": "MyContainer",
+    "provider.client_id": "<app id>",              # service_principal auth
+    "provider.client_secret": "<secret>",
+    "provider.tenant_id": "<tenant id>",
+    # "provider.account_key": "<key>",             # master_key auth instead
+}
+```
+
+The service principal needs a Cosmos DB **data-plane RBAC** role assignment
+(e.g. *Cosmos DB Built-in Data Contributor*) scoped to the account or
+database — control-plane roles are not sufficient.
+
+Any connector option can be passed through verbatim with the `provider.option.`
+prefix, e.g. `provider.option.spark.cosmos.write.bulk.enabled: "false"`.
+
+## Reads
+
+`read_entity()` reads the whole container, or the result of a Cosmos SQL
+query when `provider.query` is set:
+
+```python
+"provider.query": "SELECT c.id, c.amount FROM c WHERE c.amount > 15",
+```
+
+Schema inference is enabled by default (`provider.infer_schema: false` to
+disable). Heterogeneous containers usually want a `provider.query` that
+projects the relevant fields, so inference sees a consistent shape.
+
+## Streaming writes
+
+Kindling calls `append_as_stream()` for streaming pipe outputs; the provider
+starts the Cosmos sink with the configured options and checkpoint location.
+Streaming defaults: `provider.output_mode: append`.
+
+## Existence checks
+
+`check_entity_exists()` returns `provider.assume_exists` (default `true`):
+Cosmos writes are upserts to a pre-provisioned container, so append and write
+behave identically and no query permission is needed for write-only targets.

--- a/packages/kindling_cosmos/README.md
+++ b/packages/kindling_cosmos/README.md
@@ -28,6 +28,9 @@ tags={
     "provider.client_id": "<app id>",              # service_principal auth
     "provider.client_secret": "<secret>",
     "provider.tenant_id": "<tenant id>",
+    "provider.subscription_id": "<subscription>",  # required for service_principal:
+    "provider.resource_group": "<resource group>", # the connector resolves account
+                                                   # metadata through ARM
     # "provider.account_key": "<key>",             # master_key auth instead
 }
 ```

--- a/packages/kindling_cosmos/kindling_cosmos/__init__.py
+++ b/packages/kindling_cosmos/kindling_cosmos/__init__.py
@@ -1,0 +1,18 @@
+"""Azure Cosmos DB entity provider extension for Kindling."""
+
+from .entity_provider_cosmos import (
+    COSMOS_SPARK_CONNECTOR_MAVEN_COORDINATE,
+    CosmosEntityProvider,
+    register_provider,
+)
+
+__all__ = [
+    "COSMOS_SPARK_CONNECTOR_MAVEN_COORDINATE",
+    "CosmosEntityProvider",
+    "register_provider",
+]
+
+__version__ = "0.1.0"
+
+
+register_provider()

--- a/packages/kindling_cosmos/kindling_cosmos/entity_provider_cosmos.py
+++ b/packages/kindling_cosmos/kindling_cosmos/entity_provider_cosmos.py
@@ -185,6 +185,8 @@ class CosmosEntityProvider(
         auth_mode = str(config.get("auth", config.get("auth_mode", "service_principal"))).lower()
 
         if auth_mode in ("service_principal", "spn"):
+            # The connector requires subscription id and resource group for
+            # ServicePrincipal auth (it resolves account metadata through ARM).
             required = {
                 "spark.cosmos.auth.aad.clientId": config.get("client_id") or config.get("app_id"),
                 "spark.cosmos.auth.aad.clientSecret": (
@@ -193,6 +195,8 @@ class CosmosEntityProvider(
                 "spark.cosmos.account.tenantId": (
                     config.get("tenant_id") or config.get("authority_id")
                 ),
+                "spark.cosmos.account.subscriptionId": config.get("subscription_id"),
+                "spark.cosmos.account.resourceGroupName": config.get("resource_group"),
             }
             missing = [key for key, value in required.items() if not value]
             if missing:
@@ -201,12 +205,6 @@ class CosmosEntityProvider(
                     f"is missing options: {', '.join(missing)}"
                 )
             required["spark.cosmos.auth.type"] = "ServicePrincipal"
-            subscription_id = config.get("subscription_id")
-            if subscription_id:
-                required["spark.cosmos.account.subscriptionId"] = subscription_id
-            resource_group = config.get("resource_group")
-            if resource_group:
-                required["spark.cosmos.account.resourceGroupName"] = resource_group
             return required
 
         if auth_mode in ("master_key", "key", "account_key"):

--- a/packages/kindling_cosmos/kindling_cosmos/entity_provider_cosmos.py
+++ b/packages/kindling_cosmos/kindling_cosmos/entity_provider_cosmos.py
@@ -1,0 +1,250 @@
+"""Azure Cosmos DB (NoSQL API) entity provider for Kindling.
+
+Writes are upserts: the Cosmos Spark connector's default ``ItemOverwrite``
+strategy overwrites by ``(id, partition key)``, which makes writes naturally
+idempotent — a retried persist converges instead of duplicating. Map the
+entity's logical key onto the document ``id`` to get merge-like semantics.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from injector import inject
+from pyspark.sql import DataFrame
+from pyspark.sql.streaming import StreamingQuery
+
+from kindling.data_entities import EntityMetadata
+from kindling.entity_provider import (
+    BaseEntityProvider,
+    StreamWritableEntityProvider,
+    WritableEntityProvider,
+)
+from kindling.entity_provider_registry import EntityProviderRegistry
+from kindling.injection import GlobalInjector
+from kindling.spark_log_provider import PythonLoggerProvider
+from kindling.spark_session import get_or_create_spark_session
+
+COSMOS_SPARK_CONNECTOR_MAVEN_COORDINATE = (
+    "com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12:4.37.2"
+)
+COSMOS_FORMAT = "cosmos.oltp"
+
+
+class CosmosEntityProvider(
+    BaseEntityProvider, WritableEntityProvider, StreamWritableEntityProvider
+):
+    """Read and write DataFrames against Cosmos DB through the Cosmos Spark connector."""
+
+    @inject
+    def __init__(self, logger_provider: PythonLoggerProvider):
+        self.logger = logger_provider.get_logger("CosmosEntityProvider")
+
+    def read_entity(self, entity_metadata: EntityMetadata) -> DataFrame:
+        """Read a Cosmos container (or `provider.query` SQL result) as a batch DataFrame.
+
+        Schema inference is enabled by default (`provider.infer_schema`);
+        heterogeneous containers usually want a `provider.query` that projects
+        the relevant fields.
+        """
+        config = self._get_provider_config(entity_metadata)
+        options = self._build_read_options(entity_metadata, config)
+
+        self.logger.info(
+            "Reading entity '%s' from Cosmos container '%s'%s",
+            entity_metadata.entityid,
+            options.get("spark.cosmos.container"),
+            " via custom query" if "spark.cosmos.read.customQuery" in options else "",
+        )
+
+        spark = get_or_create_spark_session()
+        reader = spark.read.format(COSMOS_FORMAT)
+        for key, value in options.items():
+            reader = reader.option(key, value)
+        return reader.load()
+
+    def check_entity_exists(self, entity_metadata: EntityMetadata) -> bool:
+        """Return configured existence assumption for write-path compatibility.
+
+        Cosmos writes are upserts to a pre-provisioned container, so append
+        and write behave identically; assuming existence keeps the persist
+        path append-oriented (same posture as the ADX provider).
+        """
+        config = self._get_provider_config(entity_metadata)
+        return bool(config.get("assume_exists", True))
+
+    def write_to_entity(self, df: DataFrame, entity_metadata: EntityMetadata) -> None:
+        """Write (upsert) DataFrame documents into the Cosmos container."""
+        self._save(df, entity_metadata)
+
+    def append_to_entity(self, df: DataFrame, entity_metadata: EntityMetadata) -> None:
+        """Append DataFrame documents into the Cosmos container.
+
+        Uses the configured write strategy (default ``ItemOverwrite`` = upsert,
+        idempotent under retry). Set ``provider.write_strategy: ItemAppend``
+        for insert-only semantics.
+        """
+        self._save(df, entity_metadata)
+
+    def append_as_stream(
+        self,
+        df: DataFrame,
+        entity_metadata: EntityMetadata,
+        checkpoint_location: str,
+        format: Optional[str] = None,
+        options: Optional[dict] = None,
+    ) -> StreamingQuery:
+        """Append a streaming DataFrame to Cosmos through the connector sink."""
+        config = self._get_provider_config(entity_metadata)
+        if options:
+            config = {**config, **options}
+
+        connector_options = self._build_write_options(entity_metadata, config)
+        output_mode = str(config.get("output_mode", "append"))
+        query_name = config.get("query_name")
+
+        self.logger.info(
+            "Starting streaming write for entity '%s' to Cosmos container '%s'",
+            entity_metadata.entityid,
+            connector_options.get("spark.cosmos.container"),
+        )
+
+        writer = df.writeStream.format(format or COSMOS_FORMAT).outputMode(output_mode)
+        if query_name:
+            writer = writer.queryName(str(query_name))
+        writer = writer.option("checkpointLocation", checkpoint_location)
+        for key, value in connector_options.items():
+            writer = writer.option(key, value)
+        return writer.start()
+
+    def _save(self, df: DataFrame, entity_metadata: EntityMetadata) -> None:
+        config = self._get_provider_config(entity_metadata)
+        options = self._build_write_options(entity_metadata, config)
+        # The Cosmos Spark sink requires mode Append; write semantics are
+        # controlled by spark.cosmos.write.strategy, not the save mode.
+        writer = df.write.format(COSMOS_FORMAT)
+        for key, value in options.items():
+            writer = writer.option(key, value)
+
+        self.logger.info(
+            "Writing entity '%s' to Cosmos container '%s' (strategy=%s)",
+            entity_metadata.entityid,
+            options.get("spark.cosmos.container"),
+            options.get("spark.cosmos.write.strategy"),
+        )
+        writer.mode("Append").save()
+
+    def _build_read_options(
+        self, entity_metadata: EntityMetadata, config: Dict[str, Any]
+    ) -> Dict[str, str]:
+        options = self._connection_options(entity_metadata, config)
+
+        infer_schema = config.get("infer_schema", True)
+        options["spark.cosmos.read.inferSchema.enabled"] = infer_schema
+
+        query = config.get("query") or config.get("custom_query")
+        if query:
+            options["spark.cosmos.read.customQuery"] = query
+
+        return self._stringify_options(options)
+
+    def _build_write_options(
+        self, entity_metadata: EntityMetadata, config: Dict[str, Any]
+    ) -> Dict[str, str]:
+        options = self._connection_options(entity_metadata, config)
+        options["spark.cosmos.write.strategy"] = config.get("write_strategy", "ItemOverwrite")
+        return self._stringify_options(options)
+
+    def _connection_options(
+        self, entity_metadata: EntityMetadata, config: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Endpoint, database/container, auth, and passthrough options."""
+        endpoint = config.get("account_endpoint") or config.get("endpoint")
+        database = config.get("database")
+        container = config.get("container")
+        for name, value in (
+            ("provider.account_endpoint", endpoint),
+            ("provider.database", database),
+            ("provider.container", container),
+        ):
+            if not value:
+                raise ValueError(f"Cosmos entity '{entity_metadata.entityid}' requires {name}")
+
+        options: Dict[str, Any] = {
+            "spark.cosmos.accountEndpoint": endpoint,
+            "spark.cosmos.database": database,
+            "spark.cosmos.container": container,
+        }
+        options.update(self._auth_options(entity_metadata, config))
+        options.update(self._extra_connector_options(config))
+        return options
+
+    def _auth_options(
+        self, entity_metadata: EntityMetadata, config: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        auth_mode = str(config.get("auth", config.get("auth_mode", "service_principal"))).lower()
+
+        if auth_mode in ("service_principal", "spn"):
+            required = {
+                "spark.cosmos.auth.aad.clientId": config.get("client_id") or config.get("app_id"),
+                "spark.cosmos.auth.aad.clientSecret": (
+                    config.get("client_secret") or config.get("app_secret")
+                ),
+                "spark.cosmos.account.tenantId": (
+                    config.get("tenant_id") or config.get("authority_id")
+                ),
+            }
+            missing = [key for key, value in required.items() if not value]
+            if missing:
+                raise ValueError(
+                    f"Cosmos entity '{entity_metadata.entityid}' service principal auth "
+                    f"is missing options: {', '.join(missing)}"
+                )
+            required["spark.cosmos.auth.type"] = "ServicePrincipal"
+            subscription_id = config.get("subscription_id")
+            if subscription_id:
+                required["spark.cosmos.account.subscriptionId"] = subscription_id
+            resource_group = config.get("resource_group")
+            if resource_group:
+                required["spark.cosmos.account.resourceGroupName"] = resource_group
+            return required
+
+        if auth_mode in ("master_key", "key", "account_key"):
+            account_key = config.get("account_key") or config.get("key")
+            if not account_key:
+                raise ValueError(
+                    f"Cosmos entity '{entity_metadata.entityid}' uses master_key auth "
+                    "but provider.account_key is not set"
+                )
+            return {"spark.cosmos.accountKey": account_key}
+
+        raise ValueError(
+            f"Unsupported Cosmos auth mode '{auth_mode}'. Supported modes: "
+            "service_principal, master_key."
+        )
+
+    def _extra_connector_options(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        prefix = "option."
+        return {
+            key[len(prefix) :]: value
+            for key, value in config.items()
+            if key.startswith(prefix) and value is not None
+        }
+
+    def _stringify_options(self, options: Dict[str, Any]) -> Dict[str, str]:
+        return {
+            key: self._stringify_option(value)
+            for key, value in options.items()
+            if value is not None
+        }
+
+    def _stringify_option(self, value: Any) -> str:
+        if isinstance(value, bool):
+            return str(value).lower()
+        return str(value)
+
+
+def register_provider(provider_type: str = "cosmos") -> None:
+    """Register the Cosmos provider with Kindling's entity provider registry."""
+    registry = GlobalInjector.get(EntityProviderRegistry)
+    registry.register_provider(provider_type, CosmosEntityProvider)

--- a/packages/kindling_cosmos/pyproject.toml
+++ b/packages/kindling_cosmos/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "kindling-cosmos"
+version = "0.1.0"
+description = "Azure Cosmos DB entity provider extension for Kindling"
+authors = ["SEP Engineering <engineering@sep.com>"]
+license = "MIT"
+readme = "README.md"
+packages = [
+    {include = "kindling_cosmos"},
+]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+# Kindling and Spark are provided by the target runtime. The Cosmos Spark
+# connector is a JVM/Spark package and must be installed as a Maven coordinate
+# on the pool.
+
+[tool.poetry.group.dev.dependencies]
+pytest = ">=7.0.0"
+black = ">=23.0.0"

--- a/tests/system/extensions/cosmos/test_cosmos_provider_system.py
+++ b/tests/system/extensions/cosmos/test_cosmos_provider_system.py
@@ -37,6 +37,10 @@ COSMOS_DATABASE = os.getenv("COSMOS_TEST_DATABASE", "").strip()
 COSMOS_CONTAINER = os.getenv("COSMOS_TEST_CONTAINER", "").strip()
 COSMOS_CLIENT_ID = os.getenv("COSMOS_TEST_CLIENT_ID") or os.getenv("AZURE_CLIENT_ID", "")
 COSMOS_TENANT_ID = os.getenv("COSMOS_TEST_TENANT_ID") or os.getenv("AZURE_TENANT_ID", "")
+COSMOS_SUBSCRIPTION_ID = os.getenv("COSMOS_TEST_SUBSCRIPTION_ID") or os.getenv(
+    "AZURE_SUBSCRIPTION_ID", ""
+)
+COSMOS_RESOURCE_GROUP = os.getenv("COSMOS_TEST_RESOURCE_GROUP", "")
 COSMOS_SPARK_PACKAGE = "com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12:4.37.2"
 
 # Single-region account with eventual consistency: reads usually see writes
@@ -93,6 +97,8 @@ def cosmos_client_secret():
             "COSMOS_TEST_CONTAINER": COSMOS_CONTAINER,
             "COSMOS_TEST_CLIENT_ID (or AZURE_CLIENT_ID)": COSMOS_CLIENT_ID,
             "COSMOS_TEST_TENANT_ID (or AZURE_TENANT_ID)": COSMOS_TENANT_ID,
+            "COSMOS_TEST_SUBSCRIPTION_ID (or AZURE_SUBSCRIPTION_ID)": COSMOS_SUBSCRIPTION_ID,
+            "COSMOS_TEST_RESOURCE_GROUP": COSMOS_RESOURCE_GROUP,
         }.items()
         if not value
     ]
@@ -140,6 +146,8 @@ def _entity(client_secret: str, extra_tags: Optional[dict] = None) -> EntityMeta
         "provider.container": COSMOS_CONTAINER,
         "provider.client_id": COSMOS_CLIENT_ID,
         "provider.tenant_id": COSMOS_TENANT_ID,
+        "provider.subscription_id": COSMOS_SUBSCRIPTION_ID,
+        "provider.resource_group": COSMOS_RESOURCE_GROUP,
         "provider.client_secret": client_secret,
         **(extra_tags or {}),
     }

--- a/tests/system/extensions/cosmos/test_cosmos_provider_system.py
+++ b/tests/system/extensions/cosmos/test_cosmos_provider_system.py
@@ -1,0 +1,235 @@
+"""System test: CosmosEntityProvider round-trip against a live Cosmos DB account.
+
+Upserts uniquely marked documents into the configured container through the
+provider (Cosmos Spark connector), reads them back with a Cosmos SQL query,
+verifies upsert-by-id semantics by overwriting one document, then deletes the
+test documents via the connector's ItemDelete strategy.
+
+Target resources come from env vars (see .env.sep in local dev):
+``COSMOS_TEST_ACCOUNT_ENDPOINT``, ``COSMOS_TEST_DATABASE``,
+``COSMOS_TEST_CONTAINER``. The service principal defaults to the ambient
+``AZURE_CLIENT_ID``/``AZURE_TENANT_ID``/``AZURE_CLIENT_SECRET`` (overridable
+via ``COSMOS_TEST_CLIENT_ID`` etc.); the SP needs a Cosmos **data-plane**
+RBAC role (e.g. Cosmos DB Built-in Data Contributor). The test skips — never
+fails — when configuration or credentials are unavailable.
+
+Requirements: Spark 3.5 / Scala 2.12, outbound HTTPS to the public Cosmos
+endpoint, and the Cosmos Spark connector (downloaded via
+``spark.jars.packages`` on first run).
+"""
+
+import logging
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from kindling.data_entities import EntityMetadata
+
+EXTENSION_PACKAGE_ROOT = Path(__file__).resolve().parents[4] / "packages" / "kindling_cosmos"
+
+COSMOS_ENDPOINT = os.getenv("COSMOS_TEST_ACCOUNT_ENDPOINT", "").strip()
+COSMOS_DATABASE = os.getenv("COSMOS_TEST_DATABASE", "").strip()
+COSMOS_CONTAINER = os.getenv("COSMOS_TEST_CONTAINER", "").strip()
+COSMOS_CLIENT_ID = os.getenv("COSMOS_TEST_CLIENT_ID") or os.getenv("AZURE_CLIENT_ID", "")
+COSMOS_TENANT_ID = os.getenv("COSMOS_TEST_TENANT_ID") or os.getenv("AZURE_TENANT_ID", "")
+COSMOS_SPARK_PACKAGE = "com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12:4.37.2"
+
+# Single-region account with eventual consistency: reads usually see writes
+# within seconds; poll defensively.
+READ_TIMEOUT_SECONDS = int(os.getenv("COSMOS_TEST_READ_TIMEOUT", "120"))
+
+
+def _import_provider_class():
+    """Import CosmosEntityProvider without triggering DI registration.
+
+    ``kindling_cosmos.__init__`` calls ``register_provider()`` on import,
+    which resolves the real EntityProviderRegistry through GlobalInjector —
+    that requires an initialized framework. This test drives the provider
+    directly, so stub the injector during import (same pattern as the unit
+    tests and the ADX system test).
+    """
+    from unittest.mock import MagicMock, patch
+
+    for module_name in list(sys.modules):
+        if module_name == "kindling_cosmos" or module_name.startswith("kindling_cosmos."):
+            del sys.modules[module_name]
+
+    with patch("kindling.injection.GlobalInjector.get", return_value=MagicMock()):
+        from kindling_cosmos import CosmosEntityProvider
+
+    return CosmosEntityProvider
+
+
+class _LoggerProvider:
+    def get_logger(self, name):
+        return logging.getLogger(name)
+
+
+def _resolve_client_secret() -> Optional[str]:
+    explicit = (os.getenv("COSMOS_TEST_CLIENT_SECRET") or "").strip()
+    if explicit:
+        return explicit
+
+    if (os.getenv("AZURE_CLIENT_ID") or "").strip().lower() == COSMOS_CLIENT_ID.lower():
+        ambient = (os.getenv("AZURE_CLIENT_SECRET") or "").strip()
+        if ambient:
+            return ambient
+
+    return None
+
+
+@pytest.fixture(scope="module")
+def cosmos_client_secret():
+    missing = [
+        name
+        for name, value in {
+            "COSMOS_TEST_ACCOUNT_ENDPOINT": COSMOS_ENDPOINT,
+            "COSMOS_TEST_DATABASE": COSMOS_DATABASE,
+            "COSMOS_TEST_CONTAINER": COSMOS_CONTAINER,
+            "COSMOS_TEST_CLIENT_ID (or AZURE_CLIENT_ID)": COSMOS_CLIENT_ID,
+            "COSMOS_TEST_TENANT_ID (or AZURE_TENANT_ID)": COSMOS_TENANT_ID,
+        }.items()
+        if not value
+    ]
+    if missing:
+        pytest.skip(f"Cosmos test resource not configured (see .env.sep): {', '.join(missing)}")
+
+    secret = _resolve_client_secret()
+    if not secret:
+        pytest.skip(
+            "Cosmos service principal secret not available. Set COSMOS_TEST_CLIENT_SECRET "
+            "or AZURE_CLIENT_ID/AZURE_CLIENT_SECRET for the shared service principal."
+        )
+    return secret
+
+
+@pytest.fixture(scope="module")
+def spark():
+    try:
+        from pyspark.sql import SparkSession
+    except ImportError:
+        pytest.skip("pyspark not available")
+
+    session = (
+        SparkSession.builder.appName("kindling-cosmos-system-test")
+        .master("local[2]")
+        .config("spark.jars.packages", COSMOS_SPARK_PACKAGE)
+        .config("spark.sql.shuffle.partitions", "2")
+        .getOrCreate()
+    )
+    yield session
+    session.stop()
+
+
+@pytest.fixture(autouse=True)
+def _extension_package_on_path(monkeypatch):
+    monkeypatch.syspath_prepend(str(EXTENSION_PACKAGE_ROOT))
+
+
+def _entity(client_secret: str, extra_tags: Optional[dict] = None) -> EntityMetadata:
+    tags = {
+        "provider_type": "cosmos",
+        "provider.auth": "service_principal",
+        "provider.account_endpoint": COSMOS_ENDPOINT,
+        "provider.database": COSMOS_DATABASE,
+        "provider.container": COSMOS_CONTAINER,
+        "provider.client_id": COSMOS_CLIENT_ID,
+        "provider.tenant_id": COSMOS_TENANT_ID,
+        "provider.client_secret": client_secret,
+        **(extra_tags or {}),
+    }
+    return EntityMetadata(
+        entityid=f"systest.{COSMOS_CONTAINER}",
+        name=COSMOS_CONTAINER,
+        partition_columns=[],
+        merge_columns=["id"],
+        tags=tags,
+        schema=None,
+    )
+
+
+def _query_entity(client_secret: str, run_id: str) -> EntityMetadata:
+    return _entity(
+        client_secret,
+        {
+            "provider.query": (
+                "SELECT c.id, c.name, c.amount, c.run_id FROM c " f"WHERE c.run_id = '{run_id}'"
+            )
+        },
+    )
+
+
+def _poll_for_rows(provider, entity, expected_count: int):
+    """Poll read_entity until the expected documents are visible."""
+    deadline = time.time() + READ_TIMEOUT_SECONDS
+    last_count = -1
+    while time.time() < deadline:
+        df = provider.read_entity(entity)
+        last_count = df.count()
+        if last_count >= expected_count:
+            return df
+        time.sleep(5)
+    pytest.fail(
+        f"Expected {expected_count} documents in Cosmos within {READ_TIMEOUT_SECONDS}s, "
+        f"last saw {last_count}"
+    )
+
+
+@pytest.mark.system
+@pytest.mark.azure
+@pytest.mark.slow
+def test_cosmos_write_read_upsert_roundtrip(spark, cosmos_client_secret):
+    CosmosEntityProvider = _import_provider_class()
+
+    run_id = f"kindling-systest-{uuid.uuid4().hex[:8]}"
+    provider = CosmosEntityProvider(_LoggerProvider())
+
+    columns = ["id", "name", "amount", "run_id"]
+    rows = [
+        (f"{run_id}-1", "alpha", 10.5, run_id),
+        (f"{run_id}-2", "bravo", 20.0, run_id),
+        (f"{run_id}-3", "charlie", 30.25, run_id),
+    ]
+    df = spark.createDataFrame(rows, columns)
+
+    try:
+        # Upsert documents through the provider.
+        provider.write_to_entity(df, _entity(cosmos_client_secret))
+
+        # Read back via Cosmos SQL query scoped to this run.
+        result = _poll_for_rows(provider, _query_entity(cosmos_client_secret, run_id), 3)
+        by_id = {row["id"]: row for row in result.collect()}
+        assert set(by_id) == {f"{run_id}-1", f"{run_id}-2", f"{run_id}-3"}
+        assert by_id[f"{run_id}-2"]["name"] == "bravo"
+        assert by_id[f"{run_id}-3"]["amount"] == pytest.approx(30.25)
+
+        # Upsert semantics: rewriting an existing id updates, never duplicates.
+        updated = spark.createDataFrame([(f"{run_id}-2", "bravo", 99.75, run_id)], columns)
+        provider.write_to_entity(updated, _entity(cosmos_client_secret))
+
+        deadline = time.time() + READ_TIMEOUT_SECONDS
+        while time.time() < deadline:
+            rows_now = provider.read_entity(_query_entity(cosmos_client_secret, run_id)).collect()
+            amounts = {row["id"]: row["amount"] for row in rows_now}
+            if len(rows_now) == 3 and amounts.get(f"{run_id}-2") == pytest.approx(99.75):
+                break
+            time.sleep(5)
+        else:
+            pytest.fail(f"Upsert of {run_id}-2 not visible within {READ_TIMEOUT_SECONDS}s")
+    finally:
+        # Delete the test documents (partition key is /id, so id suffices).
+        try:
+            cleanup = spark.createDataFrame(rows, columns)
+            provider.write_to_entity(
+                cleanup,
+                _entity(cosmos_client_secret, {"provider.write_strategy": "ItemDelete"}),
+            )
+        except Exception:  # noqa: BLE001
+            logging.getLogger(__name__).warning(
+                "Failed to delete Cosmos test documents for run %s — clean up manually", run_id
+            )

--- a/tests/system/extensions/cosmos/test_cosmos_provider_system.py
+++ b/tests/system/extensions/cosmos/test_cosmos_provider_system.py
@@ -32,15 +32,23 @@ from kindling.data_entities import EntityMetadata
 
 EXTENSION_PACKAGE_ROOT = Path(__file__).resolve().parents[4] / "packages" / "kindling_cosmos"
 
-COSMOS_ENDPOINT = os.getenv("COSMOS_TEST_ACCOUNT_ENDPOINT", "").strip()
-COSMOS_DATABASE = os.getenv("COSMOS_TEST_DATABASE", "").strip()
-COSMOS_CONTAINER = os.getenv("COSMOS_TEST_CONTAINER", "").strip()
-COSMOS_CLIENT_ID = os.getenv("COSMOS_TEST_CLIENT_ID") or os.getenv("AZURE_CLIENT_ID", "")
-COSMOS_TENANT_ID = os.getenv("COSMOS_TEST_TENANT_ID") or os.getenv("AZURE_TENANT_ID", "")
-COSMOS_SUBSCRIPTION_ID = os.getenv("COSMOS_TEST_SUBSCRIPTION_ID") or os.getenv(
-    "AZURE_SUBSCRIPTION_ID", ""
-)
-COSMOS_RESOURCE_GROUP = os.getenv("COSMOS_TEST_RESOURCE_GROUP", "")
+
+def _env(*names: str) -> str:
+    """First non-blank env var among names, stripped."""
+    for name in names:
+        value = (os.getenv(name) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+COSMOS_ENDPOINT = _env("COSMOS_TEST_ACCOUNT_ENDPOINT")
+COSMOS_DATABASE = _env("COSMOS_TEST_DATABASE")
+COSMOS_CONTAINER = _env("COSMOS_TEST_CONTAINER")
+COSMOS_CLIENT_ID = _env("COSMOS_TEST_CLIENT_ID", "AZURE_CLIENT_ID")
+COSMOS_TENANT_ID = _env("COSMOS_TEST_TENANT_ID", "AZURE_TENANT_ID")
+COSMOS_SUBSCRIPTION_ID = _env("COSMOS_TEST_SUBSCRIPTION_ID", "AZURE_SUBSCRIPTION_ID")
+COSMOS_RESOURCE_GROUP = _env("COSMOS_TEST_RESOURCE_GROUP", "AZURE_RESOURCE_GROUP")
 COSMOS_SPARK_PACKAGE = "com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12:4.37.2"
 
 # Single-region account with eventual consistency: reads usually see writes
@@ -75,12 +83,12 @@ class _LoggerProvider:
 
 
 def _resolve_client_secret() -> Optional[str]:
-    explicit = (os.getenv("COSMOS_TEST_CLIENT_SECRET") or "").strip()
+    explicit = _env("COSMOS_TEST_CLIENT_SECRET")
     if explicit:
         return explicit
 
-    if (os.getenv("AZURE_CLIENT_ID") or "").strip().lower() == COSMOS_CLIENT_ID.lower():
-        ambient = (os.getenv("AZURE_CLIENT_SECRET") or "").strip()
+    if COSMOS_CLIENT_ID and _env("AZURE_CLIENT_ID").lower() == COSMOS_CLIENT_ID.lower():
+        ambient = _env("AZURE_CLIENT_SECRET")
         if ambient:
             return ambient
 
@@ -191,7 +199,9 @@ def _poll_for_rows(provider, entity, expected_count: int):
 @pytest.mark.system
 @pytest.mark.azure
 @pytest.mark.slow
-def test_cosmos_write_read_upsert_roundtrip(spark, cosmos_client_secret):
+def test_cosmos_write_read_upsert_roundtrip(cosmos_client_secret, spark):
+    # Fixture order matters: cosmos_client_secret first, so an unconfigured
+    # environment skips before the spark fixture downloads the connector.
     CosmosEntityProvider = _import_provider_class()
 
     run_id = f"kindling-systest-{uuid.uuid4().hex[:8]}"

--- a/tests/unit/test_cosmos_entity_provider_extension.py
+++ b/tests/unit/test_cosmos_entity_provider_extension.py
@@ -33,6 +33,8 @@ BASE_TAGS = {
     "provider.client_id": "client-id",
     "provider.client_secret": "client-secret",
     "provider.tenant_id": "tenant-id",
+    "provider.subscription_id": "sub-id",
+    "provider.resource_group": "rg-name",
 }
 
 
@@ -157,6 +159,8 @@ def test_write_upserts_with_service_principal_options():
     assert writer.options["spark.cosmos.auth.aad.clientId"] == "client-id"
     assert writer.options["spark.cosmos.auth.aad.clientSecret"] == "client-secret"
     assert writer.options["spark.cosmos.account.tenantId"] == "tenant-id"
+    assert writer.options["spark.cosmos.account.subscriptionId"] == "sub-id"
+    assert writer.options["spark.cosmos.account.resourceGroupName"] == "rg-name"
     assert writer.options["spark.cosmos.write.strategy"] == "ItemOverwrite"
     assert writer.mode_name == "Append"
     assert writer.saved is True

--- a/tests/unit/test_cosmos_entity_provider_extension.py
+++ b/tests/unit/test_cosmos_entity_provider_extension.py
@@ -1,0 +1,299 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kindling.data_entities import EntityMetadata
+
+EXTENSION_PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "packages" / "kindling_cosmos"
+
+
+@pytest.fixture(autouse=True)
+def _extension_package_on_path(monkeypatch):
+    monkeypatch.syspath_prepend(str(EXTENSION_PACKAGE_ROOT))
+
+
+def _entity(tags):
+    return EntityMetadata(
+        entityid="gold.orders",
+        name="orders",
+        partition_columns=[],
+        merge_columns=[],
+        tags={"provider_type": "cosmos", **tags},
+        schema=None,
+    )
+
+
+BASE_TAGS = {
+    "provider.auth": "service_principal",
+    "provider.account_endpoint": "https://fawkes.documents.azure.com:443/",
+    "provider.database": "Kindling",
+    "provider.container": "Orders",
+    "provider.client_id": "client-id",
+    "provider.client_secret": "client-secret",
+    "provider.tenant_id": "tenant-id",
+}
+
+
+class _Writer:
+    def __init__(self):
+        self.format_name = None
+        self.options = {}
+        self.mode_name = None
+        self.saved = False
+
+    def format(self, name):
+        self.format_name = name
+        return self
+
+    def option(self, key, value):
+        self.options[key] = value
+        return self
+
+    def mode(self, name):
+        self.mode_name = name
+        return self
+
+    def save(self):
+        self.saved = True
+
+
+class _StreamWriter:
+    def __init__(self):
+        self.format_name = None
+        self.options = {}
+        self.output_mode = None
+        self.query_name = None
+        self.started = False
+        self.query = MagicMock(name="streaming_query")
+
+    def format(self, name):
+        self.format_name = name
+        return self
+
+    def option(self, key, value):
+        self.options[key] = value
+        return self
+
+    def outputMode(self, name):
+        self.output_mode = name
+        return self
+
+    def queryName(self, name):
+        self.query_name = name
+        return self
+
+    def start(self):
+        self.started = True
+        return self.query
+
+
+class _Reader:
+    def __init__(self):
+        self.format_name = None
+        self.options = {}
+        self.loaded_df = MagicMock(name="read_df")
+
+    def format(self, name):
+        self.format_name = name
+        return self
+
+    def option(self, key, value):
+        self.options[key] = value
+        return self
+
+    def load(self):
+        return self.loaded_df
+
+
+def _provider():
+    from kindling_cosmos import CosmosEntityProvider
+
+    logger_provider = MagicMock()
+    logger_provider.get_logger.return_value = MagicMock()
+    return CosmosEntityProvider(logger_provider)
+
+
+def _patched_spark_read(reader):
+    spark = MagicMock()
+    spark.read = reader
+    return patch(
+        "kindling_cosmos.entity_provider_cosmos.get_or_create_spark_session",
+        return_value=spark,
+    )
+
+
+def test_import_registers_cosmos_provider():
+    for module_name in list(sys.modules):
+        if module_name == "kindling_cosmos" or module_name.startswith("kindling_cosmos."):
+            del sys.modules[module_name]
+
+    registry = MagicMock()
+
+    with patch("kindling.injection.GlobalInjector.get", return_value=registry):
+        import kindling_cosmos  # noqa: F401
+
+    provider_class = registry.register_provider.call_args.args[1]
+    assert registry.register_provider.call_args.args[0] == "cosmos"
+    assert provider_class.__name__ == "CosmosEntityProvider"
+
+
+def test_write_upserts_with_service_principal_options():
+    provider = _provider()
+    writer = _Writer()
+    df = MagicMock()
+    df.write = writer
+
+    provider.write_to_entity(df, _entity(BASE_TAGS))
+
+    assert writer.format_name == "cosmos.oltp"
+    assert writer.options["spark.cosmos.accountEndpoint"] == (
+        "https://fawkes.documents.azure.com:443/"
+    )
+    assert writer.options["spark.cosmos.database"] == "Kindling"
+    assert writer.options["spark.cosmos.container"] == "Orders"
+    assert writer.options["spark.cosmos.auth.type"] == "ServicePrincipal"
+    assert writer.options["spark.cosmos.auth.aad.clientId"] == "client-id"
+    assert writer.options["spark.cosmos.auth.aad.clientSecret"] == "client-secret"
+    assert writer.options["spark.cosmos.account.tenantId"] == "tenant-id"
+    assert writer.options["spark.cosmos.write.strategy"] == "ItemOverwrite"
+    assert writer.mode_name == "Append"
+    assert writer.saved is True
+
+
+def test_write_strategy_is_configurable():
+    provider = _provider()
+    writer = _Writer()
+    df = MagicMock()
+    df.write = writer
+
+    provider.append_to_entity(df, _entity({**BASE_TAGS, "provider.write_strategy": "ItemAppend"}))
+
+    assert writer.options["spark.cosmos.write.strategy"] == "ItemAppend"
+
+
+def test_master_key_auth():
+    provider = _provider()
+    writer = _Writer()
+    df = MagicMock()
+    df.write = writer
+    tags = {
+        "provider.auth": "master_key",
+        "provider.account_endpoint": "https://fawkes.documents.azure.com:443/",
+        "provider.database": "Kindling",
+        "provider.container": "Orders",
+        "provider.account_key": "s3cret==",
+    }
+
+    provider.write_to_entity(df, _entity(tags))
+
+    assert writer.options["spark.cosmos.accountKey"] == "s3cret=="
+    assert "spark.cosmos.auth.type" not in writer.options
+
+
+def test_service_principal_requires_all_auth_fields():
+    provider = _provider()
+    df = MagicMock()
+    df.write = _Writer()
+    tags = {key: value for key, value in BASE_TAGS.items() if key != "provider.client_secret"}
+
+    with pytest.raises(ValueError, match="clientSecret"):
+        provider.write_to_entity(df, _entity(tags))
+
+
+def test_container_is_required():
+    provider = _provider()
+    df = MagicMock()
+    df.write = _Writer()
+    tags = {key: value for key, value in BASE_TAGS.items() if key != "provider.container"}
+
+    with pytest.raises(ValueError, match="provider.container"):
+        provider.write_to_entity(df, _entity(tags))
+
+
+def test_extra_connector_options_are_passed_through():
+    provider = _provider()
+    writer = _Writer()
+    df = MagicMock()
+    df.write = writer
+
+    provider.write_to_entity(
+        df,
+        _entity({**BASE_TAGS, "provider.option.spark.cosmos.write.bulk.enabled": "false"}),
+    )
+
+    assert writer.options["spark.cosmos.write.bulk.enabled"] == "false"
+
+
+def test_read_entity_scans_container_with_inferred_schema():
+    provider = _provider()
+    reader = _Reader()
+
+    with _patched_spark_read(reader):
+        df = provider.read_entity(_entity(BASE_TAGS))
+
+    assert df is reader.loaded_df
+    assert reader.format_name == "cosmos.oltp"
+    assert reader.options["spark.cosmos.container"] == "Orders"
+    assert reader.options["spark.cosmos.read.inferSchema.enabled"] == "true"
+    assert reader.options["spark.cosmos.auth.type"] == "ServicePrincipal"
+    # Write-only options must not leak into reads
+    assert "spark.cosmos.write.strategy" not in reader.options
+
+
+def test_read_entity_uses_custom_query():
+    provider = _provider()
+    reader = _Reader()
+
+    with _patched_spark_read(reader):
+        provider.read_entity(
+            _entity({**BASE_TAGS, "provider.query": "SELECT c.id FROM c WHERE c.amount > 15"})
+        )
+
+    assert reader.options["spark.cosmos.read.customQuery"] == (
+        "SELECT c.id FROM c WHERE c.amount > 15"
+    )
+
+
+def test_read_infer_schema_can_be_disabled():
+    provider = _provider()
+    reader = _Reader()
+
+    with _patched_spark_read(reader):
+        provider.read_entity(_entity({**BASE_TAGS, "provider.infer_schema": "false"}))
+
+    assert reader.options["spark.cosmos.read.inferSchema.enabled"] == "false"
+
+
+def test_stream_append_starts_query_with_cosmos_sink_options():
+    provider = _provider()
+    writer = _StreamWriter()
+    df = MagicMock()
+    df.writeStream = writer
+
+    query = provider.append_as_stream(
+        df, _entity({**BASE_TAGS, "provider.query_name": "orders_to_cosmos"}), "/chk/orders"
+    )
+
+    assert query is writer.query
+    assert writer.format_name == "cosmos.oltp"
+    assert writer.output_mode == "append"
+    assert writer.query_name == "orders_to_cosmos"
+    assert writer.options["checkpointLocation"] == "/chk/orders"
+    assert writer.options["spark.cosmos.container"] == "Orders"
+    assert writer.options["spark.cosmos.write.strategy"] == "ItemOverwrite"
+    assert writer.started is True
+
+
+def test_check_entity_exists_defaults_to_true():
+    assert _provider().check_entity_exists(_entity(BASE_TAGS)) is True
+
+
+def test_unsupported_auth_mode_raises():
+    provider = _provider()
+    df = MagicMock()
+    df.write = _Writer()
+
+    with pytest.raises(ValueError, match="Unsupported Cosmos auth mode"):
+        provider.write_to_entity(df, _entity({**BASE_TAGS, "provider.auth": "magic"}))


### PR DESCRIPTION
## What

New `kindling_cosmos` extension: an entity provider for Azure Cosmos DB (NoSQL API) via the Cosmos Spark connector (`azure-cosmos-spark_3-5_2-12:4.37.2`), mirroring the `kindling_adx` extension structure. Includes unit tests and a live round-trip system test.

## Capabilities

- **Batch read** — whole container scan or `provider.query` Cosmos SQL (`spark.cosmos.read.customQuery`); schema inference on by default, `provider.infer_schema` to disable.
- **Upsert writes** — connector `ItemOverwrite` strategy: documents upsert by `(id, partition key)`, making writes **idempotent under retry** (merge-like semantics when the entity key maps to the document `id`). `provider.write_strategy` overrides (`ItemAppend`, `ItemDelete`, …).
- **Streaming writes** — `StreamWritableEntityProvider.append_as_stream` via the connector sink.
- **Auth** — service principal (requires `subscription_id`/`resource_group`; the connector resolves account metadata through ARM, and needs a Cosmos **data-plane** RBAC role, e.g. Built-in Data Contributor) or master key. `provider.option.*` passthrough for any connector option.

## Verification

- 13 unit tests (mocked reader/writer/stream-writer, option and auth-validation coverage); full unit suite green (1692).
- **Live system test passed against `sep-cosmos-dataint-dev`** (~21s): upserts uniquely marked documents into `kindling/documents`, reads them back via Cosmos SQL query, verifies upsert-by-id updates rather than duplicates, then deletes test documents via `ItemDelete`. Env-driven (`COSMOS_TEST_*`, ambient `AZURE_*` service principal); skips when unconfigured. Run with `poe test-extension --extension cosmos`.

Two live-found fixes are baked in: Cosmos data-plane RBAC is required and documented (control-plane roles are not sufficient), and `subscriptionId`/`resourceGroupName` are validated up front for ServicePrincipal auth instead of the connector's opaque `None.get` crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)