### PR TITLE
feat(execution): config-driven per-pipe retry (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ All notable changes to spark-kindling are documented here.
 
 ### Added
 
+- Per-pipe retry for DAG execution: `kindling.execution.retry.attempts` /
+  `interval_seconds` (run-level) and `kindling.execution.pipes.<pipeid>.retry.*`
+  (per-pipe), with `retry_attempts`/`retry_interval_seconds` as just-in-time
+  parameter overrides. Emits `orchestrator.pipe_retrying`; records `attempts`
+  on pipe results; warns when retry targets a non-merge-capable provider
+  (retried appends are at-least-once).
 - New guide: [Migrating from notebook-based execution (`runMultiple`)](docs/guide/migrating_from_runmultiple.md)
   for Synapse/Fabric users moving notebook DAGs to Kindling pipes.
 - Added `kindling env update` to refresh Kindling wheels and the local

--- a/docs/contributing/execution_strategy_quick_reference.md
+++ b/docs/contributing/execution_strategy_quick_reference.md
@@ -405,9 +405,11 @@ kindling:
     retry:
       attempts: 0            # retries per failed pipe attempt (0 = off)
       interval_seconds: 30
-    pipes:                   # per-pipe overrides, keyed by pipeid
+    pipes:                   # per-pipe overrides, keyed by LITERAL pipeid
       silver_orders:
         retry: { attempts: 2, interval_seconds: 10 }
+      "ingest.orders":       # quote ids containing dots — the map is indexed
+        retry: { attempts: 1 }   # by the literal id, not dotted traversal
 ```
 
 **Retry semantics**: only exceptions raised inside an attempt are retried —

--- a/docs/contributing/execution_strategy_quick_reference.md
+++ b/docs/contributing/execution_strategy_quick_reference.md
@@ -402,7 +402,21 @@ kindling:
     parallel: true
     max_workers: 8
     error_strategy: continue
+    retry:
+      attempts: 0            # retries per failed pipe attempt (0 = off)
+      interval_seconds: 30
+    pipes:                   # per-pipe overrides, keyed by pipeid
+      silver_orders:
+        retry: { attempts: 2, interval_seconds: 10 }
 ```
+
+**Retry semantics**: only exceptions raised inside an attempt are retried —
+timeouts surfaced by the parallel wrapper are never retried (the first
+attempt's thread may still be running). Retried persists are only idempotent
+on merge-capable output providers (Delta, Cosmos); a warning is logged at
+execution start for retry-enabled pipes whose provider lacks
+`merge_to_entity`. The executor emits `orchestrator.pipe_retrying` per retry
+and records total `attempts` on each `PipeResult`.
 
 Streaming plans ignore `parallel` regardless of source — stream startup
 order matters, so streaming pipes always start sequentially.

--- a/docs/proposals/config_driven_execution_options.md
+++ b/docs/proposals/config_driven_execution_options.md
@@ -1,6 +1,6 @@
 # Proposal: Config-Driven Execution Options
 
-**Status:** Phase 1 in progress
+**Status:** Phase 1 shipped (#169); Phase 2 (retry) implemented; Phase 3 open
 **Author:** derived from migration-gap analysis (see
 [Migrating from runMultiple](../guide/migrating_from_runmultiple.md))
 
@@ -84,7 +84,7 @@ Backward compatibility: all existing call sites keep working. The only
 behavior change is intentional — config can now enable options that
 previously required code changes.
 
-## Phase 2 — Per-pipe retry
+## Phase 2 — Per-pipe retry (IMPLEMENTED)
 
 - `kindling.execution.retry.attempts` / `interval_seconds` as run-level
   defaults; `kindling.execution.pipes.<pipeid>.retry.*` per pipe.

--- a/packages/kindling/data_pipes.py
+++ b/packages/kindling/data_pipes.py
@@ -447,6 +447,8 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
         streaming_options: Optional[Dict[str, Any]] = None,
         auto_cache: Any = UNSET,  # bool | UNSET
         no_watermark: bool = False,
+        retry_attempts: Any = UNSET,  # int | UNSET
+        retry_interval_seconds: Any = UNSET,  # float | UNSET
     ):
         """Execute pipes via DAG planning/generation execution facade.
 
@@ -467,6 +469,8 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
             streaming_options=streaming_options,
             auto_cache=auto_cache,
             no_watermark=no_watermark,
+            retry_attempts=retry_attempts,
+            retry_interval_seconds=retry_interval_seconds,
         )
 
     def _execute_datapipe(

--- a/packages/kindling/execution_orchestrator.py
+++ b/packages/kindling/execution_orchestrator.py
@@ -55,6 +55,8 @@ class ExecutionOrchestrator(SignalEmitter):
         streaming_options: Optional[dict[str, Any]] = None,
         auto_cache: Any = UNSET,  # bool | UNSET
         no_watermark: bool = False,
+        retry_attempts: Any = UNSET,  # int | UNSET
+        retry_interval_seconds: Any = UNSET,  # float | UNSET
     ) -> ExecutionResult:
         """Generate an execution plan and run it through GenerationExecutor.
 
@@ -87,6 +89,8 @@ class ExecutionOrchestrator(SignalEmitter):
             streaming_options=streaming_options,
             auto_cache=auto_cache,
             no_watermark=no_watermark,
+            retry_attempts=retry_attempts,
+            retry_interval_seconds=retry_interval_seconds,
         )
 
     def execute_batch(

--- a/packages/kindling/generation_executor.py
+++ b/packages/kindling/generation_executor.py
@@ -36,6 +36,7 @@ from kindling.data_pipes import (
     EntityReadPersistStrategy,
     PipeMetadata,
 )
+from kindling.entity_provider_registry import EntityProviderRegistry
 from kindling.execution_strategy import (
     ExecutionPlan,
     ExecutionPlanGenerator,
@@ -66,7 +67,17 @@ EXECUTION_CONFIG_DEFAULTS: Dict[str, Any] = {
     "error_strategy": ErrorStrategy.FAIL_FAST,
     "pipe_timeout": None,
     "auto_cache": False,
+    "retry.attempts": 0,
+    "retry.interval_seconds": 30.0,
 }
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """Resolved retry policy for one pipe."""
+
+    attempts: int = 0  # retries after the first attempt (0 = no retry)
+    interval_seconds: float = 30.0
 
 
 @dataclass
@@ -79,6 +90,7 @@ class PipeResult:
     error: Optional[str] = None
     error_type: Optional[str] = None
     streaming_query: Optional[Any] = None  # For streaming mode
+    attempts: int = 1  # total attempts made (1 = no retry was needed)
 
 
 @dataclass
@@ -185,6 +197,7 @@ class GenerationExecutor(SignalEmitter):
         - orchestrator.pipe_started
         - orchestrator.pipe_completed
         - orchestrator.pipe_failed
+        - orchestrator.pipe_retrying
         - orchestrator.pipe_skipped
         - orchestrator.cache_recommended
         - orchestrator.cache_hit
@@ -200,6 +213,7 @@ class GenerationExecutor(SignalEmitter):
         "orchestrator.pipe_started",
         "orchestrator.pipe_completed",
         "orchestrator.pipe_failed",
+        "orchestrator.pipe_retrying",
         "orchestrator.pipe_skipped",
         "orchestrator.cache_recommended",
         "orchestrator.cache_hit",
@@ -217,6 +231,7 @@ class GenerationExecutor(SignalEmitter):
         trace_provider: SparkTraceProvider,
         logger_provider: PythonLoggerProvider,
         signal_provider: SignalProvider = None,
+        provider_registry: EntityProviderRegistry = None,
     ):
         self.pipes_registry = pipes_registry
         self.entity_registry = entity_registry
@@ -226,8 +241,12 @@ class GenerationExecutor(SignalEmitter):
         self.tp = trace_provider
         self.logger = logger_provider.get_logger("generation_executor")
         self._init_signal_emitter(signal_provider)
+        # Optional: used only for the retry-safety warning (merge-capable
+        # output providers make retried persists idempotent).
+        self.provider_registry = provider_registry
         self._cache_optimizer = CacheOptimizer()
         self._cache_lock = Lock()
+        self._retry_defaults = RetryPolicy()
         self._reset_cache_state()
 
     def execute(
@@ -240,6 +259,8 @@ class GenerationExecutor(SignalEmitter):
         streaming_options: Optional[Dict[str, Any]] = None,
         auto_cache: Any = UNSET,  # bool | UNSET
         no_watermark: bool = False,
+        retry_attempts: Any = UNSET,  # int | UNSET
+        retry_interval_seconds: Any = UNSET,  # float | UNSET
     ) -> ExecutionResult:
         """Execute an ExecutionPlan generation by generation.
 
@@ -251,8 +272,10 @@ class GenerationExecutor(SignalEmitter):
 
         Execution options left UNSET resolve from hierarchical config under
         `kindling.execution.*` (parallel, max_workers, error_strategy,
-        pipe_timeout, auto_cache), falling back to built-in defaults.
-        Passing a value overrides config just-in-time.
+        pipe_timeout, auto_cache, retry.attempts, retry.interval_seconds),
+        falling back to built-in defaults. Passing a value overrides config
+        just-in-time. Retry policy additionally supports per-pipe config under
+        `kindling.execution.pipes.<pipeid>.retry.*`.
 
         Args:
             plan: The execution plan to execute
@@ -266,6 +289,10 @@ class GenerationExecutor(SignalEmitter):
             auto_cache: If True, call `persist()/cache()` on recommended shared
                 entities when first read in batch mode.
             no_watermark: If True, disable watermark reads/writes for this run.
+            retry_attempts: Run-level retries per failed pipe attempt
+                (0 = off). Retried persists are only idempotent on
+                merge-capable providers — a warning is logged otherwise.
+            retry_interval_seconds: Delay between retry attempts.
 
         Returns:
             ExecutionResult with per-pipe and per-generation results
@@ -275,6 +302,13 @@ class GenerationExecutor(SignalEmitter):
         error_strategy = self._resolve_error_strategy_option(error_strategy)
         pipe_timeout = self._resolve_float_option(pipe_timeout, "pipe_timeout", minimum=0.0)
         auto_cache = self._resolve_bool_option(auto_cache, "auto_cache")
+        self._retry_defaults = RetryPolicy(
+            attempts=self._resolve_int_option(retry_attempts, "retry.attempts", minimum=0),
+            interval_seconds=self._resolve_float_option(
+                retry_interval_seconds, "retry.interval_seconds", minimum=0.0
+            )
+            or 0.0,
+        )
 
         run_id = str(uuid.uuid4())
         start_time = time.time()
@@ -302,6 +336,8 @@ class GenerationExecutor(SignalEmitter):
         result = ExecutionResult(plan=plan, run_id=run_id)
         self._initialize_cache_state(plan=plan, is_streaming=is_streaming, auto_cache=auto_cache)
         self._emit_cache_recommendations(plan=plan, run_id=run_id)
+        if not is_streaming:
+            self._warn_retry_without_merge(plan)
 
         try:
             with self.tp.span(
@@ -514,6 +550,67 @@ class GenerationExecutor(SignalEmitter):
             f"{value!r} — using default {default!r}"
         )
         return default
+
+    # ---- Retry policy (config-first, per-pipe overrides) ----
+
+    def _resolve_pipe_retry_policy(self, pipe_id: str) -> RetryPolicy:
+        """Per-pipe retry policy: pipes.<pipeid>.retry.* config over run defaults."""
+        defaults = self._retry_defaults
+
+        def pipe_config(option: str, fallback: Any) -> Any:
+            key = f"kindling.execution.pipes.{pipe_id}.retry.{option}"
+            try:
+                return self.config_service.get(key, fallback)
+            except Exception:
+                return fallback
+
+        attempts = pipe_config("attempts", defaults.attempts)
+        interval = pipe_config("interval_seconds", defaults.interval_seconds)
+
+        try:
+            attempts = max(0, int(attempts))
+        except (TypeError, ValueError):
+            self.logger.warning(
+                f"Invalid retry.attempts for pipe '{pipe_id}': {attempts!r} — "
+                f"using {defaults.attempts}"
+            )
+            attempts = defaults.attempts
+        try:
+            interval = max(0.0, float(interval))
+        except (TypeError, ValueError):
+            self.logger.warning(
+                f"Invalid retry.interval_seconds for pipe '{pipe_id}': {interval!r} — "
+                f"using {defaults.interval_seconds}"
+            )
+            interval = defaults.interval_seconds
+
+        return RetryPolicy(attempts=attempts, interval_seconds=interval)
+
+    def _warn_retry_without_merge(self, plan: ExecutionPlan) -> None:
+        """Warn when retry is enabled for pipes whose output provider lacks merge.
+
+        Without merge_to_entity, the persist path appends — a retried persist
+        can double-write (at-least-once). Best-effort: skipped when the
+        provider registry or definitions are unavailable.
+        """
+        if self.provider_registry is None:
+            return
+
+        for pipe_id in plan.pipe_ids:
+            if self._resolve_pipe_retry_policy(pipe_id).attempts <= 0:
+                continue
+            try:
+                pipe = self.pipes_registry.get_pipe_definition(pipe_id)
+                entity = self.entity_registry.get_entity_definition(pipe.output_entity_id)
+                provider = self.provider_registry.get_provider_for_entity(entity)
+            except Exception:
+                continue
+            if provider is not None and not hasattr(provider, "merge_to_entity"):
+                self.logger.warning(
+                    f"Retry is enabled for pipe '{pipe_id}' but its output provider "
+                    f"({type(provider).__name__}) does not support merge — retried "
+                    f"persists may double-write (at-least-once semantics)"
+                )
 
     def _is_streaming_plan(self, plan: ExecutionPlan) -> bool:
         """Determine if plan should use streaming execution."""
@@ -755,8 +852,16 @@ class GenerationExecutor(SignalEmitter):
         streaming_options: Optional[Dict[str, Any]],
         no_watermark: bool = False,
     ) -> PipeResult:
-        """Execute a single pipe (batch or streaming)."""
+        """Execute a single pipe (batch or streaming), with retry per policy.
+
+        Only exceptions raised inside an attempt are retried. Timeouts
+        surfaced by the parallel wrapper (`future.result`) are never retried
+        here — the first attempt's thread may still be running and could
+        commit its write later (zombie double-write).
+        """
+        policy = self._resolve_pipe_retry_policy(pipe_id)
         pipe_start = time.time()
+        attempt = 1
 
         self.logger.debug(f"Executing pipe: {pipe_id} (streaming={is_streaming})")
 
@@ -767,65 +872,95 @@ class GenerationExecutor(SignalEmitter):
             is_streaming=is_streaming,
         )
 
-        try:
-            pipe = self.pipes_registry.get_pipe_definition(pipe_id)
-            if pipe is None:
-                raise ValueError(f"Pipe '{pipe_id}' not found in registry")
-            if no_watermark and pipe.use_watermark:
-                pipe = replace(pipe, use_watermark=False)
+        while True:
+            try:
+                pipe = self.pipes_registry.get_pipe_definition(pipe_id)
+                if pipe is None:
+                    raise ValueError(f"Pipe '{pipe_id}' not found in registry")
+                if no_watermark and pipe.use_watermark:
+                    pipe = replace(pipe, use_watermark=False)
 
-            if is_streaming:
-                result = self._execute_pipe_streaming(pipe, streaming_options)
-            else:
-                result = self._execute_pipe_batch(pipe, run_id)
+                if is_streaming:
+                    result = self._execute_pipe_streaming(pipe, streaming_options)
+                else:
+                    result = self._execute_pipe_batch(pipe, run_id)
 
-            duration = time.time() - pipe_start
-            result.duration_seconds = duration
+                duration = time.time() - pipe_start
+                result.duration_seconds = duration
+                result.attempts = attempt
 
-            if result.status == "skipped":
-                self.logger.debug(f"Pipe '{pipe_id}' skipped (no data)")
+                if result.status == "skipped":
+                    self.logger.debug(f"Pipe '{pipe_id}' skipped (no data)")
+                    self.emit(
+                        "orchestrator.pipe_skipped",
+                        run_id=run_id,
+                        pipe_id=pipe_id,
+                        duration_seconds=duration,
+                    )
+                else:
+                    self.logger.info(
+                        f"Pipe '{pipe_id}' completed in {duration:.2f}s"
+                        + (f" (attempt {attempt})" if attempt > 1 else "")
+                    )
+                    self.emit(
+                        "orchestrator.pipe_completed",
+                        run_id=run_id,
+                        pipe_id=pipe_id,
+                        duration_seconds=duration,
+                        is_streaming=is_streaming,
+                        attempts=attempt,
+                    )
+
+                return result
+
+            except Exception as e:
+                if attempt <= policy.attempts:
+                    self.logger.warning(
+                        f"Pipe '{pipe_id}' failed on attempt {attempt}/"
+                        f"{policy.attempts + 1} ({type(e).__name__}: {e}) — "
+                        f"retrying in {policy.interval_seconds}s"
+                    )
+                    self.emit(
+                        "orchestrator.pipe_retrying",
+                        run_id=run_id,
+                        pipe_id=pipe_id,
+                        attempt=attempt,
+                        max_attempts=policy.attempts + 1,
+                        error=str(e),
+                        error_type=type(e).__name__,
+                        interval_seconds=policy.interval_seconds,
+                    )
+                    if policy.interval_seconds > 0:
+                        time.sleep(policy.interval_seconds)
+                    attempt += 1
+                    continue
+
+                duration = time.time() - pipe_start
+
+                self.logger.error(
+                    f"Pipe '{pipe_id}' failed after {duration:.2f}s "
+                    f"({attempt} attempt{'s' if attempt > 1 else ''}): {e}",
+                    include_traceback=True,
+                )
+
                 self.emit(
-                    "orchestrator.pipe_skipped",
+                    "orchestrator.pipe_failed",
                     run_id=run_id,
                     pipe_id=pipe_id,
+                    error=str(e),
+                    error_type=type(e).__name__,
                     duration_seconds=duration,
+                    attempts=attempt,
                 )
-            else:
-                self.logger.info(f"Pipe '{pipe_id}' completed in {duration:.2f}s")
-                self.emit(
-                    "orchestrator.pipe_completed",
-                    run_id=run_id,
+
+                return PipeResult(
                     pipe_id=pipe_id,
+                    status="failed",
                     duration_seconds=duration,
-                    is_streaming=is_streaming,
+                    error=str(e),
+                    error_type=type(e).__name__,
+                    attempts=attempt,
                 )
-
-            return result
-
-        except Exception as e:
-            duration = time.time() - pipe_start
-
-            self.logger.error(
-                f"Pipe '{pipe_id}' failed after {duration:.2f}s: {e}",
-                include_traceback=True,
-            )
-
-            self.emit(
-                "orchestrator.pipe_failed",
-                run_id=run_id,
-                pipe_id=pipe_id,
-                error=str(e),
-                error_type=type(e).__name__,
-                duration_seconds=duration,
-            )
-
-            return PipeResult(
-                pipe_id=pipe_id,
-                status="failed",
-                duration_seconds=duration,
-                error=str(e),
-                error_type=type(e).__name__,
-            )
 
     def _execute_pipe_batch(self, pipe: PipeMetadata, run_id: str) -> PipeResult:
         """Execute a pipe in batch mode (read → transform → persist)."""

--- a/packages/kindling/generation_executor.py
+++ b/packages/kindling/generation_executor.py
@@ -20,6 +20,7 @@ Part of: Capability #15 - Unified DAG Orchestrator
 
 import time
 import uuid
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field, replace
 from enum import Enum
@@ -553,11 +554,35 @@ class GenerationExecutor(SignalEmitter):
 
     # ---- Retry policy (config-first, per-pipe overrides) ----
 
+    def _pipe_retry_overrides(self, pipe_id: str) -> Dict[str, Any]:
+        """Read `kindling.execution.pipes` as a mapping keyed by literal pipe id.
+
+        Pipe ids routinely contain dots (e.g. ``ingest.orders``), which a
+        dotted config-key lookup would mis-traverse — so the mapping is
+        indexed by the literal id.
+        """
+        try:
+            pipes_map = self.config_service.get("kindling.execution.pipes", None)
+        except Exception:
+            return {}
+        if not isinstance(pipes_map, Mapping):
+            return {}
+        entry = pipes_map.get(pipe_id)
+        if not isinstance(entry, Mapping):
+            return {}
+        retry = entry.get("retry")
+        return dict(retry) if isinstance(retry, Mapping) else {}
+
     def _resolve_pipe_retry_policy(self, pipe_id: str) -> RetryPolicy:
         """Per-pipe retry policy: pipes.<pipeid>.retry.* config over run defaults."""
         defaults = self._retry_defaults
+        overrides = self._pipe_retry_overrides(pipe_id)
 
         def pipe_config(option: str, fallback: Any) -> Any:
+            if option in overrides:
+                return overrides[option]
+            # Dotted fallback for pipe ids without dots (and flat env-var
+            # style config like CONFIG__kindling__execution__pipes__...).
             key = f"kindling.execution.pipes.{pipe_id}.retry.{option}"
             try:
                 return self.config_service.get(key, fallback)

--- a/tests/unit/test_execution_orchestrator.py
+++ b/tests/unit/test_execution_orchestrator.py
@@ -59,6 +59,8 @@ def test_execute_generates_plan_emits_signal_and_delegates():
         streaming_options={"pipe_a": {"checkpoint": "/tmp/checkpoints"}},
         auto_cache=True,
         no_watermark=False,
+        retry_attempts=UNSET,
+        retry_interval_seconds=UNSET,
     )
 
     signal.send.assert_called_once()

--- a/tests/unit/test_generation_executor.py
+++ b/tests/unit/test_generation_executor.py
@@ -1708,3 +1708,30 @@ class TestRetry:
 
         warnings = [str(c) for c in executor.logger.warning.call_args_list]
         assert not any("does not support merge" in w for w in warnings)
+
+    def test_dotted_pipe_id_resolves_via_literal_mapping(
+        self, executor, pipes_registry, entity_registry, persist_strategy
+    ):
+        """Pipe ids containing dots index the pipes map literally, not by dotted traversal."""
+        executor.config_service = make_config(
+            {
+                "kindling.execution.pipes": {
+                    "ingest.orders": {"retry": {"attempts": 1, "interval_seconds": 0}}
+                }
+            }
+        )
+        pipe = make_pipe("ingest.orders", inputs=["entity.a"])
+        pipe.execute = Mock(side_effect=[RuntimeError("transient"), Mock()])
+        pipes_registry.get_pipe_definition.return_value = pipe
+        entity_registry.get_entity_definition.return_value = Mock()
+        persist_strategy.create_pipe_entity_reader.return_value = Mock(return_value=Mock())
+        persist_strategy.create_pipe_persist_activator.return_value = Mock()
+        plan = make_plan(
+            ["ingest.orders"],
+            [Generation(number=0, pipe_ids=["ingest.orders"], dependencies=[])],
+        )
+
+        result = executor.execute(plan)
+
+        assert result.success_count == 1
+        assert result.generation_results[0].pipe_results[0].attempts == 2

--- a/tests/unit/test_generation_executor.py
+++ b/tests/unit/test_generation_executor.py
@@ -25,6 +25,7 @@ from kindling.generation_executor import (
     GenerationExecutor,
     GenerationResult,
     PipeResult,
+    RetryPolicy,
 )
 from kindling.pipe_graph import PipeGraph, PipeNode
 from kindling.pipe_streaming import SimplePipeStreamStarter
@@ -1522,3 +1523,188 @@ class TestConfigDrivenOptions:
         executor.config_service = make_config({"kindling.execution.pipe_timeout": 900})
         assert executor._resolve_float_option(None, "pipe_timeout", minimum=0.0) is None
         assert executor._resolve_float_option(UNSET, "pipe_timeout", minimum=0.0) == 900.0
+
+
+# ---- Retry Tests (Phase 2: per-pipe retry) ----
+
+
+class TestRetry:
+    """Config-driven per-pipe retry in _execute_pipe."""
+
+    def _single_pipe_plan(self, pipes_registry, entity_registry, persist_strategy, execute_fn):
+        pipe = make_pipe("pipe1", inputs=["entity.a"])
+        pipe.execute = execute_fn
+        pipes_registry.get_pipe_definition.return_value = pipe
+        entity_registry.get_entity_definition.return_value = Mock()
+        persist_strategy.create_pipe_entity_reader.return_value = Mock(return_value=Mock())
+        persist_strategy.create_pipe_persist_activator.return_value = Mock()
+        return make_plan(["pipe1"], [Generation(number=0, pipe_ids=["pipe1"], dependencies=[])])
+
+    def test_no_retry_by_default(self, executor, pipes_registry, entity_registry, persist_strategy):
+        plan = self._single_pipe_plan(
+            pipes_registry,
+            entity_registry,
+            persist_strategy,
+            Mock(side_effect=RuntimeError("boom")),
+        )
+
+        with patch.object(executor, "emit", wraps=executor.emit) as emit_spy:
+            result = executor.execute(plan, error_strategy=ErrorStrategy.CONTINUE)
+
+        assert result.failed_count == 1
+        assert result.generation_results[0].pipe_results[0].attempts == 1
+        assert not any(c.args[0] == "orchestrator.pipe_retrying" for c in emit_spy.call_args_list)
+
+    def test_retry_recovers_after_transient_failure(
+        self, executor, pipes_registry, entity_registry, persist_strategy
+    ):
+        executor.config_service = make_config({"kindling.execution.retry.attempts": 2})
+        plan = self._single_pipe_plan(
+            pipes_registry,
+            entity_registry,
+            persist_strategy,
+            Mock(side_effect=[RuntimeError("transient"), Mock()]),
+        )
+
+        with (
+            patch("kindling.generation_executor.time.sleep") as sleep_spy,
+            patch.object(executor, "emit", wraps=executor.emit) as emit_spy,
+        ):
+            result = executor.execute(plan)
+
+        assert result.success_count == 1
+        assert result.generation_results[0].pipe_results[0].attempts == 2
+        retrying = [c for c in emit_spy.call_args_list if c.args[0] == "orchestrator.pipe_retrying"]
+        failed = [c for c in emit_spy.call_args_list if c.args[0] == "orchestrator.pipe_failed"]
+        assert len(retrying) == 1
+        assert retrying[0].kwargs["attempt"] == 1
+        assert retrying[0].kwargs["max_attempts"] == 3
+        assert failed == []
+        sleep_spy.assert_called_once_with(30.0)  # default interval
+
+    def test_retry_exhaustion_reports_attempts(
+        self, executor, pipes_registry, entity_registry, persist_strategy
+    ):
+        executor.config_service = make_config(
+            {
+                "kindling.execution.retry.attempts": 1,
+                "kindling.execution.retry.interval_seconds": 0,
+            }
+        )
+        plan = self._single_pipe_plan(
+            pipes_registry,
+            entity_registry,
+            persist_strategy,
+            Mock(side_effect=RuntimeError("boom")),
+        )
+
+        with patch.object(executor, "emit", wraps=executor.emit) as emit_spy:
+            result = executor.execute(plan, error_strategy=ErrorStrategy.CONTINUE)
+
+        pipe_result = result.generation_results[0].pipe_results[0]
+        assert pipe_result.status == "failed"
+        assert pipe_result.attempts == 2
+        failed = [c for c in emit_spy.call_args_list if c.args[0] == "orchestrator.pipe_failed"]
+        assert len(failed) == 1
+        assert failed[0].kwargs["attempts"] == 2
+
+    def test_per_pipe_config_overrides_run_default(
+        self, executor, pipes_registry, entity_registry, persist_strategy
+    ):
+        executor.config_service = make_config(
+            {
+                "kindling.execution.retry.attempts": 0,
+                "kindling.execution.pipes.pipe1.retry.attempts": 1,
+                "kindling.execution.pipes.pipe1.retry.interval_seconds": 0,
+            }
+        )
+        plan = self._single_pipe_plan(
+            pipes_registry,
+            entity_registry,
+            persist_strategy,
+            Mock(side_effect=[RuntimeError("transient"), Mock()]),
+        )
+
+        result = executor.execute(plan)
+
+        assert result.success_count == 1
+        assert result.generation_results[0].pipe_results[0].attempts == 2
+
+    def test_param_overrides_config_retry(
+        self, executor, pipes_registry, entity_registry, persist_strategy
+    ):
+        executor.config_service = make_config({"kindling.execution.retry.attempts": 5})
+        plan = self._single_pipe_plan(
+            pipes_registry,
+            entity_registry,
+            persist_strategy,
+            Mock(side_effect=RuntimeError("boom")),
+        )
+
+        result = executor.execute(plan, error_strategy=ErrorStrategy.CONTINUE, retry_attempts=0)
+
+        assert result.generation_results[0].pipe_results[0].attempts == 1
+
+    def test_custom_interval_is_used(
+        self, executor, pipes_registry, entity_registry, persist_strategy
+    ):
+        executor.config_service = make_config(
+            {
+                "kindling.execution.retry.attempts": 1,
+                "kindling.execution.retry.interval_seconds": 5,
+            }
+        )
+        plan = self._single_pipe_plan(
+            pipes_registry,
+            entity_registry,
+            persist_strategy,
+            Mock(side_effect=[RuntimeError("transient"), Mock()]),
+        )
+
+        with patch("kindling.generation_executor.time.sleep") as sleep_spy:
+            executor.execute(plan)
+
+        sleep_spy.assert_called_once_with(5.0)
+
+    def test_invalid_per_pipe_value_falls_back(self, executor):
+        executor.config_service = make_config(
+            {"kindling.execution.pipes.pipe1.retry.attempts": "many"}
+        )
+        executor._retry_defaults = RetryPolicy(attempts=0)
+
+        policy = executor._resolve_pipe_retry_policy("pipe1")
+
+        assert policy.attempts == 0
+        executor.logger.warning.assert_called()
+
+    def test_warns_when_retry_pipe_provider_lacks_merge(
+        self, executor, pipes_registry, entity_registry, persist_strategy
+    ):
+        executor.config_service = make_config({"kindling.execution.retry.attempts": 1})
+        plan = self._single_pipe_plan(
+            pipes_registry, entity_registry, persist_strategy, Mock(return_value=Mock())
+        )
+        provider = Mock(spec=[])  # no merge_to_entity attribute
+        executor.provider_registry = Mock()
+        executor.provider_registry.get_provider_for_entity.return_value = provider
+
+        executor.execute(plan)
+
+        warnings = [str(c) for c in executor.logger.warning.call_args_list]
+        assert any("does not support merge" in w for w in warnings)
+
+    def test_no_warning_for_merge_capable_provider(
+        self, executor, pipes_registry, entity_registry, persist_strategy
+    ):
+        executor.config_service = make_config({"kindling.execution.retry.attempts": 1})
+        plan = self._single_pipe_plan(
+            pipes_registry, entity_registry, persist_strategy, Mock(return_value=Mock())
+        )
+        provider = Mock(spec=["merge_to_entity"])
+        executor.provider_registry = Mock()
+        executor.provider_registry.get_provider_for_entity.return_value = provider
+
+        executor.execute(plan)
+
+        warnings = [str(c) for c in executor.logger.warning.call_args_list]
+        assert not any("does not support merge" in w for w in warnings)


### PR DESCRIPTION
## What

Per-pipe retry for DAG execution — Phase 2 of `docs/proposals/config_driven_execution_options.md`, building on the config-first layer from #169.

## Design

- **Config-first**: `kindling.execution.retry.attempts` / `retry.interval_seconds` set the run-level policy; `kindling.execution.pipes.<pipeid>.retry.*` overrides per pipe; `retry_attempts` / `retry_interval_seconds` parameters remain as just-in-time overrides for spot-testing. No decorator fields — retry policy is ops-tunable per environment, and `@DataPipes.pipe()` stays purely structural.
- **Placement**: the retry loop lives in `GenerationExecutor._execute_pipe`, the single choke point for both sequential and parallel paths — parallel mode gets retry for free.
- **Guardrails from the re-runnability analysis**:
  - Only exceptions raised *inside* an attempt are retried. A `TimeoutError` from the parallel wrapper's `future.result()` is never retried — the first attempt's thread may still be running and could commit its write later (zombie double-write).
  - At execution start, a warning is logged for every retry-enabled pipe whose output provider lacks `merge_to_entity`: without merge, the persist path appends, and a retried persist is at-least-once. (Merge-capable providers — Delta, Cosmos — make retries idempotent.)
- **Observability**: new `orchestrator.pipe_retrying` signal (attempt, max_attempts, error, interval); `pipe_completed`/`pipe_failed` now carry `attempts`; `PipeResult` gains an `attempts` field.

## Verification

9 new unit tests: transient-failure recovery, exhaustion reporting, per-pipe config precedence, param-over-config override, custom interval, invalid-value fallback, default-off behavior, and both sides of the merge-capability warning. Full unit suite: 1709 passed.

Phase 3 (`skip_dependents` error strategy) follows as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)