### PR TITLE
feat(execution): skip_dependents error strategy (Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ All notable changes to spark-kindling are documented here.
 
 ### Added
 
+- `skip_dependents` error strategy for DAG execution: on pipe failure, only
+  its transitive consumers are skipped (reported with
+  `reason: upstream_failed`) while independent branches keep running —
+  notebook-DAG (`runMultiple`) dependent-skipping semantics. Select via
+  `kindling.execution.error_strategy: skip_dependents` or
+  `ErrorStrategy.SKIP_DEPENDENTS`.
 - Per-pipe retry for DAG execution: `kindling.execution.retry.attempts` /
   `interval_seconds` (run-level) and `kindling.execution.pipes.<pipeid>.retry.*`
   (per-pipe), with `retry_attempts`/`retry_interval_seconds` as just-in-time

--- a/docs/contributing/execution_strategy_quick_reference.md
+++ b/docs/contributing/execution_strategy_quick_reference.md
@@ -389,7 +389,7 @@ the built-in default. Passing a parameter overrides config just-in-time
 | `strategy` | `ExecutionStrategy` | — | `None` (batch) | Strategy override |
 | `parallel` | `bool` | `parallel` | `False` | Run independent pipes *within* a generation concurrently (generations themselves are always sequential) |
 | `max_workers` | `int` | `max_workers` | `4` | Thread pool size when parallel |
-| `error_strategy` | `ErrorStrategy` | `error_strategy` (`fail_fast` \| `continue`) | `FAIL_FAST` | Error handling mode |
+| `error_strategy` | `ErrorStrategy` | `error_strategy` (`fail_fast` \| `continue` \| `skip_dependents`) | `FAIL_FAST` | Error handling mode |
 | `pipe_timeout` | `float` | `pipe_timeout` | `None` | Per-pipe timeout in seconds |
 | `streaming_options` | `dict` | — | `None` | Passed to GenerationExecutor |
 | `auto_cache` | `bool` | `auto_cache` | `False` | Enable automatic cache |
@@ -411,6 +411,13 @@ kindling:
       "ingest.orders":       # quote ids containing dots — the map is indexed
         retry: { attempts: 1 }   # by the literal id, not dotted traversal
 ```
+
+**Error strategies**: `fail_fast` stops after the first failed generation;
+`continue` runs everything and reports failures at the end;
+`skip_dependents` skips only the transitive consumers of a failed pipe
+(reported as skipped with `reason: upstream_failed`) while independent
+branches keep running — matching notebook-DAG (`runMultiple`)
+dependent-skipping semantics.
 
 **Retry semantics**: only exceptions raised inside an attempt are retried —
 timeouts surfaced by the parallel wrapper are never retried (the first

--- a/docs/guide/migrating_from_runmultiple.md
+++ b/docs/guide/migrating_from_runmultiple.md
@@ -190,7 +190,7 @@ environment without code changes.
 |---|---|
 | `"concurrency": 4` | `parallel: true`, `max_workers: 4` |
 | `"timeoutPerCellInSeconds": 900` | `pipe_timeout: 900` (per pipe, not per cell) |
-| Activity fails → dependents skipped | `error_strategy: fail_fast` (default): a failed generation stops the run, so downstream generations never start |
+| Activity fails → dependents skipped | `error_strategy: skip_dependents` — exact same semantics: only transitive consumers skip, independent branches keep running |
 | Run everything, report failures at the end | `error_strategy: continue` |
 
 ```yaml
@@ -340,11 +340,12 @@ those (the DAG orchestrator will re-derive the correct sub-order).
 equivalent; `pipe_timeout` applies per pipe. If you need a global budget,
 enforce it in the caller (e.g., the platform job's timeout setting).
 
-**Failure semantics.** With the default `FAIL_FAST`, a pipe failure stops
-its generation and no later generation starts — close to `runMultiple`
-skipping dependents, but coarser: independent pipes in *later* generations
-that don't depend on the failure are also not run. Use
-`ErrorStrategy.CONTINUE` if you want maximum forward progress.
+**Failure semantics.** `error_strategy: skip_dependents` reproduces
+`runMultiple`'s behavior exactly: a failed pipe's transitive consumers are
+skipped (reported with `reason: upstream_failed`) while independent branches
+keep running. The default `FAIL_FAST` is stricter — a failed generation
+stops the whole run — and `CONTINUE` is looser, running everything and
+reporting failures at the end.
 
 **Skipped pipes.** A pipe is skipped (not failed) when its first input
 entity returns no data. This replaces the common notebook pattern of exiting

--- a/docs/proposals/config_driven_execution_options.md
+++ b/docs/proposals/config_driven_execution_options.md
@@ -1,6 +1,6 @@
 # Proposal: Config-Driven Execution Options
 
-**Status:** Phase 1 shipped (#169); Phase 2 (retry) implemented; Phase 3 open
+**Status:** Phase 1 shipped (#169); Phase 2 (retry) shipped (#173); Phase 3 (skip_dependents) implemented
 **Author:** derived from migration-gap analysis (see
 [Migrating from runMultiple](../guide/migrating_from_runmultiple.md))
 
@@ -105,7 +105,7 @@ previously required code changes.
 - Future hardening: `persist_id`-based idempotent persist to make retry
   safe by default on non-merge paths.
 
-## Phase 3 — `skip_dependents` error strategy
+## Phase 3 — `skip_dependents` error strategy (IMPLEMENTED)
 
 - New `ErrorStrategy.SKIP_DEPENDENTS`: on pipe failure, mark transitive
   consumers (via `PipeGraph.entity_consumers`) as skipped, keep independent

--- a/packages/kindling/generation_executor.py
+++ b/packages/kindling/generation_executor.py
@@ -58,6 +58,9 @@ class ErrorStrategy(Enum):
 
     FAIL_FAST = "fail_fast"  # Stop immediately on first error
     CONTINUE = "continue"  # Run all pipes, collect errors
+    # Skip transitive dependents of a failed pipe; independent branches
+    # keep running (matches notebook-DAG dependent-skipping semantics).
+    SKIP_DEPENDENTS = "skip_dependents"
 
 
 #: Built-in defaults, used when neither a parameter nor config provides a
@@ -345,6 +348,7 @@ class GenerationExecutor(SignalEmitter):
                 component="generation_executor",
                 operation=f"execute_{mode}",
             ):
+                blocked: Dict[str, str] = {}  # pipe_id -> upstream pipe that failed
                 for generation in plan.generations:
                     gen_result = self._execute_generation(
                         generation=generation,
@@ -356,6 +360,7 @@ class GenerationExecutor(SignalEmitter):
                         pipe_timeout=pipe_timeout,
                         streaming_options=streaming_options,
                         no_watermark=no_watermark,
+                        blocked=blocked,
                     )
                     result.generation_results.append(gen_result)
 
@@ -366,6 +371,14 @@ class GenerationExecutor(SignalEmitter):
                             f"({gen_result.failed_pipes}), stopping execution"
                         )
                         break
+
+                    # Skip-dependents: poison the transitive consumers of
+                    # failures so later generations skip them while
+                    # independent branches keep running.
+                    if error_strategy == ErrorStrategy.SKIP_DEPENDENTS:
+                        for failed_pipe in gen_result.failed_pipes:
+                            for dependent in self._transitive_dependents(plan.graph, failed_pipe):
+                                blocked.setdefault(dependent, failed_pipe)
 
             result.duration_seconds = time.time() - start_time
 
@@ -637,6 +650,22 @@ class GenerationExecutor(SignalEmitter):
                     f"persists may double-write (at-least-once semantics)"
                 )
 
+    def _transitive_dependents(self, graph: Any, pipe_id: str) -> List[str]:
+        """BFS over graph.get_dependents to find all downstream pipes."""
+        seen: List[str] = []
+        frontier = [pipe_id]
+        while frontier:
+            current = frontier.pop()
+            try:
+                dependents = graph.get_dependents(current) or []
+            except Exception:
+                dependents = []
+            for dependent in dependents:
+                if dependent not in seen and dependent != pipe_id:
+                    seen.append(dependent)
+                    frontier.append(dependent)
+        return seen
+
     def _is_streaming_plan(self, plan: ExecutionPlan) -> bool:
         """Determine if plan should use streaming execution."""
         strategy = plan.strategy.lower()
@@ -750,9 +779,15 @@ class GenerationExecutor(SignalEmitter):
         pipe_timeout: Optional[float],
         streaming_options: Optional[Dict[str, Any]],
         no_watermark: bool = False,
+        blocked: Optional[Dict[str, str]] = None,
     ) -> GenerationResult:
-        """Execute all pipes in a generation."""
+        """Execute all pipes in a generation.
+
+        Pipes present in `blocked` (skip_dependents poisoning: pipe_id ->
+        failed upstream pipe) are skipped without executing.
+        """
         gen_start = time.time()
+        blocked = blocked or {}
 
         self.logger.info(
             f"Starting generation {generation.number}: "
@@ -769,14 +804,46 @@ class GenerationExecutor(SignalEmitter):
 
         gen_result = GenerationResult(generation_number=generation.number)
 
-        if parallel and not is_streaming and len(generation.pipe_ids) > 1:
+        skipped_results = []
+        runnable_ids = []
+        for pipe_id in generation.pipe_ids:
+            if pipe_id in blocked:
+                upstream = blocked[pipe_id]
+                self.logger.warning(f"Skipping pipe '{pipe_id}': upstream pipe '{upstream}' failed")
+                self.emit(
+                    "orchestrator.pipe_skipped",
+                    run_id=run_id,
+                    pipe_id=pipe_id,
+                    duration_seconds=0.0,
+                    reason="upstream_failed",
+                    upstream_pipe=upstream,
+                )
+                skipped_results.append(
+                    PipeResult(
+                        pipe_id=pipe_id,
+                        status="skipped",
+                        error=f"upstream pipe '{upstream}' failed",
+                        error_type="UpstreamFailure",
+                    )
+                )
+            else:
+                runnable_ids.append(pipe_id)
+        gen_result.pipe_results.extend(skipped_results)
+
+        if parallel and not is_streaming and len(runnable_ids) > 1:
             # Parallel batch execution
-            gen_result = self._execute_generation_parallel(
-                generation, run_id, max_workers, error_strategy, pipe_timeout, no_watermark
+            runnable_generation = Generation(
+                number=generation.number,
+                pipe_ids=runnable_ids,
+                dependencies=generation.dependencies,
             )
+            parallel_result = self._execute_generation_parallel(
+                runnable_generation, run_id, max_workers, error_strategy, pipe_timeout, no_watermark
+            )
+            gen_result.pipe_results.extend(parallel_result.pipe_results)
         else:
             # Sequential execution (batch or streaming)
-            for pipe_id in generation.pipe_ids:
+            for pipe_id in runnable_ids:
                 pipe_result = self._execute_pipe(
                     pipe_id=pipe_id,
                     run_id=run_id,

--- a/packages/kindling/generation_executor.py
+++ b/packages/kindling/generation_executor.py
@@ -376,7 +376,9 @@ class GenerationExecutor(SignalEmitter):
                     # failures so later generations skip them while
                     # independent branches keep running.
                     if error_strategy == ErrorStrategy.SKIP_DEPENDENTS:
-                        for failed_pipe in gen_result.failed_pipes:
+                        # Sorted for deterministic upstream attribution:
+                        # parallel results arrive in as_completed order.
+                        for failed_pipe in sorted(gen_result.failed_pipes):
                             for dependent in self._transitive_dependents(plan.graph, failed_pipe):
                                 blocked.setdefault(dependent, failed_pipe)
 
@@ -651,20 +653,22 @@ class GenerationExecutor(SignalEmitter):
                 )
 
     def _transitive_dependents(self, graph: Any, pipe_id: str) -> List[str]:
-        """BFS over graph.get_dependents to find all downstream pipes."""
+        """BFS over graph.get_dependents to find all downstream pipes.
+
+        Errors from the graph lookup propagate: silently treating a failed
+        lookup as "no dependents" would execute pipes that skip_dependents
+        promised to skip. Returned sorted for deterministic poisoning order.
+        """
         seen: List[str] = []
         frontier = [pipe_id]
         while frontier:
             current = frontier.pop()
-            try:
-                dependents = graph.get_dependents(current) or []
-            except Exception:
-                dependents = []
+            dependents = graph.get_dependents(current) or []
             for dependent in dependents:
                 if dependent not in seen and dependent != pipe_id:
                     seen.append(dependent)
                     frontier.append(dependent)
-        return seen
+        return sorted(seen)
 
     def _is_streaming_plan(self, plan: ExecutionPlan) -> bool:
         """Determine if plan should use streaming execution."""

--- a/tests/unit/test_generation_executor.py
+++ b/tests/unit/test_generation_executor.py
@@ -27,7 +27,7 @@ from kindling.generation_executor import (
     PipeResult,
     RetryPolicy,
 )
-from kindling.pipe_graph import PipeGraph, PipeNode
+from kindling.pipe_graph import PipeEdge, PipeGraph, PipeNode
 from kindling.pipe_streaming import SimplePipeStreamStarter
 
 # ---- Fixtures ----
@@ -1735,3 +1735,128 @@ class TestRetry:
 
         assert result.success_count == 1
         assert result.generation_results[0].pipe_results[0].attempts == 2
+
+
+# ---- Skip-Dependents Tests (Phase 3) ----
+
+
+def make_chain_graph():
+    """a -> b -> c chain plus independent pipe x."""
+    graph = PipeGraph()
+    graph.add_node(PipeNode("a", [], "entity.a"))
+    graph.add_node(PipeNode("b", ["entity.a"], "entity.b"))
+    graph.add_node(PipeNode("c", ["entity.b"], "entity.c"))
+    graph.add_node(PipeNode("x", [], "entity.x"))
+    graph.add_edge(PipeEdge(from_pipe="a", to_pipe="b", entity="entity.a"))
+    graph.add_edge(PipeEdge(from_pipe="b", to_pipe="c", entity="entity.b"))
+    return graph
+
+
+class TestSkipDependents:
+    """ErrorStrategy.SKIP_DEPENDENTS skips downstream pipes, runs independent ones."""
+
+    def _setup(self, pipes_registry, entity_registry, persist_strategy, failing_ids):
+        def get_pipe(pid):
+            inputs = {"a": [], "b": ["entity.a"], "c": ["entity.b"], "x": []}[pid]
+            pipe = make_pipe(pid, inputs=inputs, output=f"entity.{pid}")
+            if pid in failing_ids:
+                pipe.execute = Mock(side_effect=RuntimeError(f"{pid} boom"))
+            return pipe
+
+        pipes_registry.get_pipe_definition.side_effect = get_pipe
+        entity_registry.get_entity_definition.return_value = Mock()
+        persist_strategy.create_pipe_entity_reader.return_value = Mock(return_value=Mock())
+        persist_strategy.create_pipe_persist_activator.return_value = Mock()
+
+        graph = make_chain_graph()
+        generations = [
+            Generation(number=0, pipe_ids=["a", "x"], dependencies=[]),
+            Generation(number=1, pipe_ids=["b"], dependencies=["a"]),
+            Generation(number=2, pipe_ids=["c"], dependencies=["b"]),
+        ]
+        return ExecutionPlan(
+            pipe_ids=["a", "x", "b", "c"],
+            generations=generations,
+            graph=graph,
+            strategy="batch",
+            metadata={},
+        )
+
+    def test_dependents_skipped_independent_branch_runs(
+        self, executor, pipes_registry, entity_registry, persist_strategy
+    ):
+        plan = self._setup(pipes_registry, entity_registry, persist_strategy, failing_ids={"a"})
+
+        with patch.object(executor, "emit", wraps=executor.emit) as emit_spy:
+            result = executor.execute(plan, error_strategy=ErrorStrategy.SKIP_DEPENDENTS)
+
+        statuses = {r.pipe_id: r.status for g in result.generation_results for r in g.pipe_results}
+        assert statuses == {"a": "failed", "x": "success", "b": "skipped", "c": "skipped"}
+
+        upstream_skips = [
+            c
+            for c in emit_spy.call_args_list
+            if c.args[0] == "orchestrator.pipe_skipped"
+            and c.kwargs.get("reason") == "upstream_failed"
+        ]
+        assert {c.kwargs["pipe_id"] for c in upstream_skips} == {"b", "c"}
+        assert all(c.kwargs["upstream_pipe"] == "a" for c in upstream_skips)
+
+    def test_mid_chain_failure_skips_only_downstream(
+        self, executor, pipes_registry, entity_registry, persist_strategy
+    ):
+        plan = self._setup(pipes_registry, entity_registry, persist_strategy, failing_ids={"b"})
+
+        result = executor.execute(plan, error_strategy=ErrorStrategy.SKIP_DEPENDENTS)
+
+        statuses = {r.pipe_id: r.status for g in result.generation_results for r in g.pipe_results}
+        assert statuses == {"a": "success", "x": "success", "b": "failed", "c": "skipped"}
+
+    def test_skipped_result_carries_upstream_error(
+        self, executor, pipes_registry, entity_registry, persist_strategy
+    ):
+        plan = self._setup(pipes_registry, entity_registry, persist_strategy, failing_ids={"a"})
+
+        result = executor.execute(plan, error_strategy=ErrorStrategy.SKIP_DEPENDENTS)
+
+        skipped = [
+            r for g in result.generation_results for r in g.pipe_results if r.status == "skipped"
+        ]
+        assert all(r.error_type == "UpstreamFailure" for r in skipped)
+        assert all("'a' failed" in r.error for r in skipped)
+
+    def test_fail_fast_behavior_unchanged(
+        self, executor, pipes_registry, entity_registry, persist_strategy
+    ):
+        plan = self._setup(pipes_registry, entity_registry, persist_strategy, failing_ids={"a"})
+
+        result = executor.execute(plan, error_strategy=ErrorStrategy.FAIL_FAST)
+
+        # fail_fast stops after generation 0 — b and c never appear at all
+        assert len(result.generation_results) == 1
+
+    def test_config_selects_skip_dependents(
+        self, executor, pipes_registry, entity_registry, persist_strategy
+    ):
+        executor.config_service = make_config(
+            {"kindling.execution.error_strategy": "skip_dependents"}
+        )
+        plan = self._setup(pipes_registry, entity_registry, persist_strategy, failing_ids={"a"})
+
+        result = executor.execute(plan)
+
+        statuses = {r.pipe_id: r.status for g in result.generation_results for r in g.pipe_results}
+        assert statuses["b"] == "skipped"
+        assert statuses["x"] == "success"
+
+    def test_parallel_mode_skips_dependents(
+        self, executor, pipes_registry, entity_registry, persist_strategy
+    ):
+        plan = self._setup(pipes_registry, entity_registry, persist_strategy, failing_ids={"a"})
+
+        result = executor.execute(
+            plan, error_strategy=ErrorStrategy.SKIP_DEPENDENTS, parallel=True, max_workers=2
+        )
+
+        statuses = {r.pipe_id: r.status for g in result.generation_results for r in g.pipe_results}
+        assert statuses == {"a": "failed", "x": "success", "b": "skipped", "c": "skipped"}


### PR DESCRIPTION
## What

`ErrorStrategy.SKIP_DEPENDENTS` — the final phase of `docs/proposals/config_driven_execution_options.md`. When a pipe fails, only its **transitive consumers** are skipped; independent branches keep running through later generations. This reproduces notebook-DAG (`runMultiple`) dependent-skipping semantics exactly, closing the last behavioral gap documented in the migration guide.

## Design

- Failed pipes poison their transitive dependents via BFS over the plan graph's `get_dependents` adjacency; poisoned pipes are skipped up front in each generation (sequential and parallel paths) without executing.
- Skipped-for-upstream results are distinguishable: `status: skipped`, `error_type: UpstreamFailure`, error naming the failed upstream pipe, and the `orchestrator.pipe_skipped` signal carries `reason: upstream_failed` + `upstream_pipe`.
- Selectable config-first (`kindling.execution.error_strategy: skip_dependents`) or per call — the existing strategy resolution handles the new enum value with no extra plumbing.
- `fail_fast` (default) and `continue` are unchanged.

## Verification

6 new unit tests over a real `PipeGraph` (chain + independent branch): source failure skips the chain while the independent pipe succeeds, mid-chain failure skips only downstream, skipped results carry upstream attribution, `fail_fast` unchanged, config-driven selection, and the parallel path. Full unit suite: 1716 passed.

Migration guide updated — `skip_dependents` is now listed as the exact `runMultiple` failure-semantics equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)