### PR TITLE
feat(providers): parquet entity provider (core, all five interfaces)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ All notable changes to spark-kindling are documented here.
 
 ### Added
 
+- Parquet entity provider (`provider_type: "parquet"`, core): batch and
+  streaming read/write of plain-parquet datasets via native Spark, with
+  partitioned writes and destination ensuring. For interchange at solution
+  boundaries — no transaction log, so no merge and no safe retry; Delta
+  remains the provider for internal pipeline storage.
 - `skip_dependents` error strategy for DAG execution: on pipe failure, only
   its transitive consumers are skipped (reported with
   `reason: upstream_failed`) while independent branches keep running —

--- a/docs/contributing/entity_providers.md
+++ b/docs/contributing/entity_providers.md
@@ -18,6 +18,12 @@ The framework uses **interface composition** rather than a single monolithic abs
 
 This means a read-only CSV provider only implements `BaseEntityProvider`, while a full-featured Delta provider implements all five.
 
+Built-in providers: `delta` (all five + merge), `parquet` (all five, no
+merge — plain-parquet interchange at solution boundaries; see
+`entity_provider_parquet.py` for the no-transaction-log caveats), `csv`,
+`memory`, `eventhub`, `sql` (views), and `current_view`. Extensions add
+`adx` and `cosmos`.
+
 Capability helpers are provided for runtime checks:
 
 ```python

--- a/docs/proposals/entity_provider_roadmap.md
+++ b/docs/proposals/entity_provider_roadmap.md
@@ -1,6 +1,6 @@
 # Entity Provider Roadmap — ADX, Cosmos DB, Parquet
 
-**Status:** ADX and Cosmos DB shipped (July 2026); Parquet is the open item.
+**Status:** All three shipped (July 2026) — ADX (#170), Cosmos DB (#171), Parquet.
 **Scope:** Tracks provider coverage against the framework's capability model.
 Originally an evaluation of three candidates; two have since landed and this
 doc records what shipped, what was learned live, and what remains.
@@ -94,16 +94,19 @@ out of the box, arguably safer than the Delta append path.
 
 ---
 
-## Parquet — OPEN (next up; core provider)
+## Parquet — SHIPPED (core provider)
 
-Plain-parquet handling today is limited to file-ingestion *patterns*. Delta
-covers internal storage — a Parquet provider is for the **boundaries**:
-consuming parquet produced by external systems, publishing extracts for
-consumers that can't read Delta.
+`packages/kindling/entity_provider_parquet.py`, auto-registered as
+`provider_type: "parquet"` — native Spark, zero new dependencies. All five
+interfaces implemented (streaming reads require the entity `schema`, per
+Spark's file-source rule; partitioned writes honor `partition_columns`).
+Round-trip verified by real-Spark integration tests
+(`tests/integration/test_entity_provider_parquet_roundtrip.py`) including a
+streaming file-source → file-sink hop — no cloud resources needed.
 
-**Decision: lives in core** (`entity_provider_parquet.py` beside the CSV
-provider, auto-registered as `provider_type: "parquet"`), not an extension —
-native Spark, zero new dependencies.
+Positioning: Delta covers internal storage — the Parquet provider is for the
+**boundaries**: consuming parquet produced by external systems, publishing
+extracts for consumers that can't read Delta.
 
 | Interface | Fit |
 |---|---|

--- a/packages/kindling/entity_provider_parquet.py
+++ b/packages/kindling/entity_provider_parquet.py
@@ -1,0 +1,237 @@
+"""Parquet entity provider for Kindling.
+
+Plain-parquet datasets as entities — for the **boundaries** of a solution:
+consuming parquet produced by external systems and publishing extracts for
+consumers that can't read Delta. Delta remains the right provider for
+internal pipeline storage.
+
+Caveats (no transaction log):
+- A failed overwrite can leave a partially-written directory visible.
+- A retried append duplicates files (at-least-once). Parquet entities should
+  not opt into execution retry, and there is no merge support.
+"""
+
+from typing import Optional
+
+from injector import inject
+from pyspark.sql import DataFrame
+from pyspark.sql.streaming import StreamingQuery
+
+from .data_entities import EntityMetadata
+from .entity_provider import (
+    BaseEntityProvider,
+    DestinationEnsuringProvider,
+    StreamableEntityProvider,
+    StreamWritableEntityProvider,
+    WritableEntityProvider,
+)
+from .injection import GlobalInjector
+from .spark_log_provider import PythonLoggerProvider
+from .spark_session import get_or_create_spark_session
+
+
+@GlobalInjector.singleton_autobind()
+class ParquetEntityProvider(
+    BaseEntityProvider,
+    WritableEntityProvider,
+    StreamableEntityProvider,
+    StreamWritableEntityProvider,
+    DestinationEnsuringProvider,
+):
+    """Read/write plain parquet datasets via native Spark.
+
+    Configuration (entity tags):
+        provider_type: "parquet"
+        provider.path: dataset directory (required)
+        provider.merge_schema: enable mergeSchema on reads (default false)
+        provider.save_mode: mode for write_to_entity (default "overwrite")
+        provider.option.<name>: passed through to the Spark reader/writer
+
+    Streaming reads require an explicit schema (Spark file-source rule);
+    the entity's `schema` supplies it. Partitioned writes honor the entity's
+    `partition_columns`.
+    """
+
+    @inject
+    def __init__(self, logger_provider: PythonLoggerProvider):
+        self.logger = logger_provider.get_logger("ParquetEntityProvider")
+
+    # ---- BaseEntityProvider ----
+
+    def read_entity(self, entity_metadata: EntityMetadata) -> DataFrame:
+        """Read the parquet dataset as a batch DataFrame."""
+        config = self._get_provider_config(entity_metadata)
+        path = self._require_path(entity_metadata, config)
+
+        self.logger.info(f"Reading parquet entity '{entity_metadata.entityid}' from path: {path}")
+
+        spark = get_or_create_spark_session()
+        reader = spark.read.format("parquet")
+        if config.get("merge_schema", False):
+            reader = reader.option("mergeSchema", "true")
+        for key, value in self._extra_options(config).items():
+            reader = reader.option(key, value)
+        return reader.load(path)
+
+    def check_entity_exists(self, entity_metadata: EntityMetadata) -> bool:
+        """True when the path holds a readable parquet dataset."""
+        config = self._get_provider_config(entity_metadata)
+        path = config.get("path")
+        if not path:
+            self.logger.warning(
+                f"Cannot check existence for entity '{entity_metadata.entityid}': "
+                "no path in tags (provider.path)"
+            )
+            return False
+
+        try:
+            spark = get_or_create_spark_session()
+            spark.read.format("parquet").load(path).schema
+            return True
+        except Exception as e:  # noqa: BLE001
+            self.logger.debug(
+                f"Parquet entity '{entity_metadata.entityid}' not found at {path}: {e}"
+            )
+            return False
+
+    # ---- WritableEntityProvider ----
+
+    def write_to_entity(self, df: DataFrame, entity_metadata: EntityMetadata) -> None:
+        """Write the dataset (default mode overwrite; provider.save_mode overrides)."""
+        config = self._get_provider_config(entity_metadata)
+        mode = str(config.get("save_mode", "overwrite"))
+        self._write(df, entity_metadata, config, mode)
+
+    def append_to_entity(self, df: DataFrame, entity_metadata: EntityMetadata) -> None:
+        """Append rows to the dataset.
+
+        Not idempotent: a retried append duplicates files (no transaction
+        log). Keep execution retry off for parquet-targeted pipes.
+        """
+        config = self._get_provider_config(entity_metadata)
+        self._write(df, entity_metadata, config, "append")
+
+    def _write(
+        self,
+        df: DataFrame,
+        entity_metadata: EntityMetadata,
+        config: dict,
+        mode: str,
+    ) -> None:
+        path = self._require_path(entity_metadata, config)
+
+        self.logger.info(
+            f"Writing parquet entity '{entity_metadata.entityid}' to {path} (mode={mode})"
+        )
+
+        writer = df.write.format("parquet").mode(mode)
+        partition_columns = list(entity_metadata.partition_columns or [])
+        if partition_columns:
+            writer = writer.partitionBy(*partition_columns)
+        for key, value in self._extra_options(config).items():
+            writer = writer.option(key, value)
+        writer.save(path)
+
+    # ---- StreamableEntityProvider ----
+
+    def read_entity_as_stream(
+        self,
+        entity_metadata: EntityMetadata,
+        format: Optional[str] = None,
+        options: Optional[dict] = None,
+    ) -> DataFrame:
+        """Read the dataset as a file-source stream.
+
+        Spark's file source requires an explicit schema — the entity's
+        `schema` supplies it.
+        """
+        config = self._get_provider_config(entity_metadata)
+        if options:
+            config = {**config, **options}
+        path = self._require_path(entity_metadata, config)
+
+        schema = entity_metadata.schema
+        if schema is None:
+            raise ValueError(
+                f"Streaming read of parquet entity '{entity_metadata.entityid}' "
+                "requires an explicit schema on the entity definition "
+                "(Spark file-source streams cannot infer schemas)"
+            )
+
+        self.logger.info(
+            f"Starting streaming read of parquet entity '{entity_metadata.entityid}' "
+            f"from {path}"
+        )
+
+        spark = get_or_create_spark_session()
+        reader = spark.readStream.format(format or "parquet").schema(schema)
+        for key, value in self._extra_options(config).items():
+            reader = reader.option(key, value)
+        return reader.load(path)
+
+    # ---- StreamWritableEntityProvider ----
+
+    def append_as_stream(
+        self,
+        df: DataFrame,
+        entity_metadata: EntityMetadata,
+        checkpoint_location: str,
+        format: Optional[str] = None,
+        options: Optional[dict] = None,
+    ) -> StreamingQuery:
+        """Append a streaming DataFrame via the parquet file sink."""
+        config = self._get_provider_config(entity_metadata)
+        if options:
+            config = {**config, **options}
+        path = self._require_path(entity_metadata, config)
+
+        self.logger.info(
+            f"Starting streaming write of parquet entity '{entity_metadata.entityid}' " f"to {path}"
+        )
+
+        writer = (
+            df.writeStream.format(format or "parquet")
+            .outputMode("append")  # file sinks support append only
+            .option("checkpointLocation", checkpoint_location)
+            .option("path", path)
+        )
+        partition_columns = list(entity_metadata.partition_columns or [])
+        if partition_columns:
+            writer = writer.partitionBy(*partition_columns)
+        for key, value in self._extra_options(config).items():
+            writer = writer.option(key, value)
+        return writer.start()
+
+    # ---- DestinationEnsuringProvider ----
+
+    def ensure_destination(self, entity_metadata: EntityMetadata) -> None:
+        """Create the dataset directory if it does not exist."""
+        config = self._get_provider_config(entity_metadata)
+        path = self._require_path(entity_metadata, config)
+
+        spark = get_or_create_spark_session()
+        jvm = spark._jvm
+        hadoop_path = jvm.org.apache.hadoop.fs.Path(path)
+        fs = hadoop_path.getFileSystem(spark._jsc.hadoopConfiguration())
+        if not fs.exists(hadoop_path):
+            self.logger.info(f"Creating parquet destination directory: {path}")
+            fs.mkdirs(hadoop_path)
+
+    # ---- Helpers ----
+
+    def _require_path(self, entity_metadata: EntityMetadata, config: dict) -> str:
+        path = config.get("path")
+        if not path:
+            raise ValueError(
+                f"Parquet provider requires 'path' in tags (provider.path) for entity "
+                f"'{entity_metadata.entityid}'"
+            )
+        return str(path)
+
+    def _extra_options(self, config: dict) -> dict:
+        prefix = "option."
+        return {
+            key[len(prefix) :]: value
+            for key, value in config.items()
+            if key.startswith(prefix) and value is not None
+        }

--- a/packages/kindling/entity_provider_parquet.py
+++ b/packages/kindling/entity_provider_parquet.py
@@ -143,11 +143,10 @@ class ParquetEntityProvider(
         """Read the dataset as a file-source stream.
 
         Spark's file source requires an explicit schema — the entity's
-        `schema` supplies it.
+        `schema` supplies it. `options` are applied directly as Spark
+        reader options (e.g. maxFilesPerTrigger).
         """
         config = self._get_provider_config(entity_metadata)
-        if options:
-            config = {**config, **options}
         path = self._require_path(entity_metadata, config)
 
         schema = entity_metadata.schema
@@ -167,6 +166,8 @@ class ParquetEntityProvider(
         reader = spark.readStream.format(format or "parquet").schema(schema)
         for key, value in self._extra_options(config).items():
             reader = reader.option(key, value)
+        for key, value in (options or {}).items():
+            reader = reader.option(key, value)
         return reader.load(path)
 
     # ---- StreamWritableEntityProvider ----
@@ -179,10 +180,12 @@ class ParquetEntityProvider(
         format: Optional[str] = None,
         options: Optional[dict] = None,
     ) -> StreamingQuery:
-        """Append a streaming DataFrame via the parquet file sink."""
+        """Append a streaming DataFrame via the parquet file sink.
+
+        `options` are applied directly as Spark writer options (e.g.
+        maxRecordsPerFile).
+        """
         config = self._get_provider_config(entity_metadata)
-        if options:
-            config = {**config, **options}
         path = self._require_path(entity_metadata, config)
 
         self.logger.info(
@@ -199,6 +202,8 @@ class ParquetEntityProvider(
         if partition_columns:
             writer = writer.partitionBy(*partition_columns)
         for key, value in self._extra_options(config).items():
+            writer = writer.option(key, value)
+        for key, value in (options or {}).items():
             writer = writer.option(key, value)
         return writer.start()
 

--- a/packages/kindling/entity_provider_registry.py
+++ b/packages/kindling/entity_provider_registry.py
@@ -185,6 +185,13 @@ class EntityProviderRegistry:
             self.logger.debug("EventHub provider not available")
 
         try:
+            from .entity_provider_parquet import ParquetEntityProvider
+
+            self.register_provider("parquet", ParquetEntityProvider)
+        except ImportError:
+            self.logger.debug("Parquet provider not available")
+
+        try:
             from .entity_provider_memory import MemoryEntityProvider
 
             self.register_provider("memory", MemoryEntityProvider)

--- a/tests/integration/test_csv_entity_provider.py
+++ b/tests/integration/test_csv_entity_provider.py
@@ -54,6 +54,11 @@ class TestCSVEntityProviderIntegration:
         __main__.spark = spark
 
         yield spark
+
+        # Clear the global before stopping: a stale __main__.spark pointing
+        # at a stopped session poisons any later test that calls
+        # get_or_create_spark_session().
+        __main__.spark = None
         spark.stop()
 
     @pytest.fixture

--- a/tests/integration/test_entity_provider_parquet_roundtrip.py
+++ b/tests/integration/test_entity_provider_parquet_roundtrip.py
@@ -26,7 +26,18 @@ def spark():
         .config("spark.sql.shuffle.partitions", "2")
         .getOrCreate()
     )
+
+    # get_or_create_spark_session() prefers __main__.spark (notebook
+    # convention) — point it at this session so the provider uses it, and
+    # clear it afterward so no stale/stopped session leaks to later tests.
+    import __main__
+
+    previous = getattr(__main__, "spark", None)
+    __main__.spark = session
+
     yield session
+
+    __main__.spark = previous
     session.stop()
 
 

--- a/tests/integration/test_entity_provider_parquet_roundtrip.py
+++ b/tests/integration/test_entity_provider_parquet_roundtrip.py
@@ -1,0 +1,123 @@
+"""Round-trip integration tests for ParquetEntityProvider with real local Spark.
+
+No cloud resources needed: create → write → append → read against a temp
+directory, partitioned writes, and a streaming file-source → file-sink hop.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from kindling.data_entities import EntityMetadata
+from kindling.entity_provider_parquet import ParquetEntityProvider
+
+
+@pytest.fixture(scope="module")
+def spark():
+    try:
+        from pyspark.sql import SparkSession
+    except ImportError:
+        pytest.skip("pyspark not available")
+
+    session = (
+        SparkSession.builder.appName("kindling-parquet-roundtrip")
+        .master("local[2]")
+        .config("spark.sql.shuffle.partitions", "2")
+        .getOrCreate()
+    )
+    yield session
+    session.stop()
+
+
+@pytest.fixture
+def provider():
+    logger_provider = MagicMock()
+    logger_provider.get_logger.return_value = logging.getLogger("parquet-test")
+    return ParquetEntityProvider(logger_provider)
+
+
+def _entity(path, partition_columns=None, schema=None, extra_tags=None):
+    return EntityMetadata(
+        entityid="test.exports",
+        name="exports",
+        partition_columns=partition_columns or [],
+        merge_columns=[],
+        tags={"provider_type": "parquet", "provider.path": str(path), **(extra_tags or {})},
+        schema=schema,
+    )
+
+
+def test_write_append_read_roundtrip(spark, provider, tmp_path):
+    path = tmp_path / "exports"
+    entity = _entity(path)
+
+    assert provider.check_entity_exists(entity) is False
+
+    df = spark.createDataFrame([(1, "alpha"), (2, "bravo")], ["id", "name"])
+    provider.write_to_entity(df, entity)
+
+    assert provider.check_entity_exists(entity) is True
+    assert provider.read_entity(entity).count() == 2
+
+    provider.append_to_entity(spark.createDataFrame([(3, "charlie")], ["id", "name"]), entity)
+    result = provider.read_entity(entity)
+    assert result.count() == 3
+    assert {row["name"] for row in result.collect()} == {"alpha", "bravo", "charlie"}
+
+
+def test_overwrite_replaces_dataset(spark, provider, tmp_path):
+    path = tmp_path / "exports"
+    entity = _entity(path)
+
+    provider.write_to_entity(spark.createDataFrame([(1, "old")], ["id", "name"]), entity)
+    provider.write_to_entity(spark.createDataFrame([(2, "new")], ["id", "name"]), entity)
+
+    rows = provider.read_entity(entity).collect()
+    assert len(rows) == 1
+    assert rows[0]["name"] == "new"
+
+
+def test_partitioned_write_creates_partition_directories(spark, provider, tmp_path):
+    path = tmp_path / "partitioned"
+    entity = _entity(path, partition_columns=["region"])
+
+    df = spark.createDataFrame([(1, "us"), (2, "eu"), (3, "us")], ["id", "region"])
+    provider.write_to_entity(df, entity)
+
+    partition_dirs = {p.name for p in path.iterdir() if p.is_dir()}
+    assert {"region=us", "region=eu"} <= partition_dirs
+    assert provider.read_entity(entity).count() == 3
+
+
+def test_ensure_destination_creates_directory(spark, provider, tmp_path):
+    path = tmp_path / "ensured"
+    entity = _entity(path)
+
+    provider.ensure_destination(entity)
+
+    assert path.is_dir()
+
+
+def test_streaming_file_source_to_file_sink(spark, provider, tmp_path):
+    source_path = tmp_path / "stream-source"
+    sink_path = tmp_path / "stream-sink"
+    checkpoint = tmp_path / "checkpoint"
+
+    source_entity = _entity(source_path)
+    df = spark.createDataFrame([(1, "alpha"), (2, "bravo")], ["id", "name"])
+    provider.write_to_entity(df, source_entity)
+
+    # Stream read requires the entity schema (file-source rule).
+    streaming_source = _entity(source_path, schema=df.schema)
+    stream_df = provider.read_entity_as_stream(streaming_source)
+    assert stream_df.isStreaming
+
+    sink_entity = _entity(sink_path)
+    query = provider.append_as_stream(stream_df, sink_entity, str(checkpoint))
+    try:
+        query.processAllAvailable()
+    finally:
+        query.stop()
+
+    assert provider.read_entity(sink_entity).count() == 2

--- a/tests/unit/test_entity_provider_parquet.py
+++ b/tests/unit/test_entity_provider_parquet.py
@@ -225,3 +225,32 @@ def test_registry_registers_parquet_provider():
         registry = EntityProviderRegistry(logger_provider)
 
     assert "parquet" in registry.list_registered_providers()
+
+
+def test_stream_read_applies_direct_options():
+    provider = _provider()
+    patcher, spark = _patched_spark()
+    reader = spark.readStream.format.return_value
+    reader.schema.return_value = reader
+    reader.option.return_value = reader
+
+    with patcher:
+        provider.read_entity_as_stream(
+            _entity(BASE_TAGS, schema=MagicMock()), options={"maxFilesPerTrigger": "10"}
+        )
+
+    reader.option.assert_any_call("maxFilesPerTrigger", "10")
+
+
+def test_stream_append_applies_direct_options():
+    provider = _provider()
+    df = MagicMock()
+    writer = df.writeStream.format.return_value
+    writer.outputMode.return_value = writer
+    writer.option.return_value = writer
+
+    provider.append_as_stream(
+        df, _entity(BASE_TAGS), "/chk/exports", options={"maxRecordsPerFile": "1000"}
+    )
+
+    writer.option.assert_any_call("maxRecordsPerFile", "1000")

--- a/tests/unit/test_entity_provider_parquet.py
+++ b/tests/unit/test_entity_provider_parquet.py
@@ -1,0 +1,227 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kindling.data_entities import EntityMetadata
+from kindling.entity_provider import (
+    can_ensure_destination,
+    is_stream_writable,
+    is_streamable,
+    is_writable,
+)
+from kindling.entity_provider_parquet import ParquetEntityProvider
+
+
+def _entity(tags, partition_columns=None, schema=None):
+    return EntityMetadata(
+        entityid="boundary.exports",
+        name="exports",
+        partition_columns=partition_columns or [],
+        merge_columns=[],
+        tags={"provider_type": "parquet", **tags},
+        schema=schema,
+    )
+
+
+BASE_TAGS = {"provider.path": "/data/exports"}
+
+
+def _provider():
+    logger_provider = MagicMock()
+    logger_provider.get_logger.return_value = MagicMock()
+    return ParquetEntityProvider(logger_provider)
+
+
+def _patched_spark():
+    spark = MagicMock()
+    return (
+        patch(
+            "kindling.entity_provider_parquet.get_or_create_spark_session",
+            return_value=spark,
+        ),
+        spark,
+    )
+
+
+def test_implements_all_capability_interfaces():
+    provider = _provider()
+    assert is_writable(provider)
+    assert is_streamable(provider)
+    assert is_stream_writable(provider)
+    assert can_ensure_destination(provider)
+
+
+def test_read_entity_loads_path():
+    provider = _provider()
+    patcher, spark = _patched_spark()
+
+    with patcher:
+        df = provider.read_entity(_entity(BASE_TAGS))
+
+    spark.read.format.assert_called_once_with("parquet")
+    reader = spark.read.format.return_value
+    reader.load.assert_called_once_with("/data/exports")
+    assert df is reader.load.return_value
+
+
+def test_read_entity_requires_path():
+    provider = _provider()
+
+    with pytest.raises(ValueError, match="provider.path"):
+        provider.read_entity(_entity({}))
+
+
+def test_read_merge_schema_option():
+    provider = _provider()
+    patcher, spark = _patched_spark()
+    reader = spark.read.format.return_value
+    reader.option.return_value = reader
+
+    with patcher:
+        provider.read_entity(_entity({**BASE_TAGS, "provider.merge_schema": "true"}))
+
+    reader.option.assert_any_call("mergeSchema", "true")
+
+
+def test_write_defaults_to_overwrite_with_partitioning():
+    provider = _provider()
+    df = MagicMock()
+    writer = df.write.format.return_value
+    writer.mode.return_value = writer
+    writer.partitionBy.return_value = writer
+    writer.option.return_value = writer
+
+    provider.write_to_entity(df, _entity(BASE_TAGS, partition_columns=["region", "date"]))
+
+    df.write.format.assert_called_once_with("parquet")
+    writer.mode.assert_called_once_with("overwrite")
+    writer.partitionBy.assert_called_once_with("region", "date")
+    writer.save.assert_called_once_with("/data/exports")
+
+
+def test_append_uses_append_mode():
+    provider = _provider()
+    df = MagicMock()
+    writer = df.write.format.return_value
+    writer.mode.return_value = writer
+    writer.option.return_value = writer
+
+    provider.append_to_entity(df, _entity(BASE_TAGS))
+
+    writer.mode.assert_called_once_with("append")
+    writer.save.assert_called_once_with("/data/exports")
+
+
+def test_extra_options_pass_through():
+    provider = _provider()
+    df = MagicMock()
+    writer = df.write.format.return_value
+    writer.mode.return_value = writer
+    writer.option.return_value = writer
+
+    provider.append_to_entity(df, _entity({**BASE_TAGS, "provider.option.compression": "zstd"}))
+
+    writer.option.assert_any_call("compression", "zstd")
+
+
+def test_stream_read_requires_schema():
+    provider = _provider()
+
+    with pytest.raises(ValueError, match="requires an explicit schema"):
+        provider.read_entity_as_stream(_entity(BASE_TAGS, schema=None))
+
+
+def test_stream_read_applies_schema_and_path():
+    provider = _provider()
+    patcher, spark = _patched_spark()
+    schema = MagicMock(name="schema")
+    reader = spark.readStream.format.return_value
+    reader.schema.return_value = reader
+    reader.option.return_value = reader
+
+    with patcher:
+        provider.read_entity_as_stream(_entity(BASE_TAGS, schema=schema))
+
+    spark.readStream.format.assert_called_once_with("parquet")
+    reader.schema.assert_called_once_with(schema)
+    reader.load.assert_called_once_with("/data/exports")
+
+
+def test_stream_append_configures_file_sink():
+    provider = _provider()
+    df = MagicMock()
+    writer = df.writeStream.format.return_value
+    writer.outputMode.return_value = writer
+    writer.option.return_value = writer
+    writer.partitionBy.return_value = writer
+
+    query = provider.append_as_stream(
+        df, _entity(BASE_TAGS, partition_columns=["region"]), "/chk/exports"
+    )
+
+    df.writeStream.format.assert_called_once_with("parquet")
+    writer.outputMode.assert_called_once_with("append")
+    writer.option.assert_any_call("checkpointLocation", "/chk/exports")
+    writer.option.assert_any_call("path", "/data/exports")
+    writer.partitionBy.assert_called_once_with("region")
+    assert query is writer.start.return_value
+
+
+def test_check_entity_exists_true_when_readable():
+    provider = _provider()
+    patcher, spark = _patched_spark()
+
+    with patcher:
+        assert provider.check_entity_exists(_entity(BASE_TAGS)) is True
+
+
+def test_check_entity_exists_false_on_error():
+    provider = _provider()
+    patcher, spark = _patched_spark()
+    spark.read.format.return_value.load.side_effect = Exception("no such path")
+
+    with patcher:
+        assert provider.check_entity_exists(_entity(BASE_TAGS)) is False
+
+
+def test_check_entity_exists_false_without_path():
+    assert _provider().check_entity_exists(_entity({})) is False
+
+
+def test_ensure_destination_creates_missing_directory():
+    provider = _provider()
+    patcher, spark = _patched_spark()
+    fs = MagicMock()
+    hadoop_path = spark._jvm.org.apache.hadoop.fs.Path.return_value
+    hadoop_path.getFileSystem.return_value = fs
+    fs.exists.return_value = False
+
+    with patcher:
+        provider.ensure_destination(_entity(BASE_TAGS))
+
+    fs.mkdirs.assert_called_once_with(hadoop_path)
+
+
+def test_ensure_destination_noop_when_exists():
+    provider = _provider()
+    patcher, spark = _patched_spark()
+    fs = MagicMock()
+    hadoop_path = spark._jvm.org.apache.hadoop.fs.Path.return_value
+    hadoop_path.getFileSystem.return_value = fs
+    fs.exists.return_value = True
+
+    with patcher:
+        provider.ensure_destination(_entity(BASE_TAGS))
+
+    fs.mkdirs.assert_not_called()
+
+
+def test_registry_registers_parquet_provider():
+    from kindling.entity_provider_registry import EntityProviderRegistry
+
+    with patch("kindling.entity_provider_registry.GlobalInjector"):
+        logger_provider = MagicMock()
+        logger_provider.get_logger.return_value = MagicMock()
+        registry = EntityProviderRegistry(logger_provider)
+
+    assert "parquet" in registry.list_registered_providers()


### PR DESCRIPTION
## What

`ParquetEntityProvider` (`provider_type: "parquet"`) in core, closing the final item of `docs/proposals/entity_provider_roadmap.md`. Native Spark, zero new dependencies — auto-registered beside the other built-in providers.

## Capabilities

All five interfaces:
- **Batch read** (`provider.path`, optional `provider.merge_schema`), **write** (default overwrite, `provider.save_mode` override) and **append**, with partitioned writes honoring the entity's `partition_columns`.
- **Streaming read** — file-source stream; requires the entity `schema` (Spark's file-source rule) with a clear error otherwise.
- **Streaming write** — parquet file sink with checkpoint (append-only, per Spark).
- **Destination ensuring** — directory creation via Hadoop FS (works for local and abfss paths).
- `provider.option.*` passthrough to the Spark reader/writer.

## Positioning (documented in module + provider docs)

Interchange at solution boundaries: consuming parquet from external systems, publishing extracts for consumers that can't read Delta. No transaction log means a failed overwrite can leave partial data visible and retried appends duplicate — so no merge support, and parquet-targeted pipes shouldn't opt into execution retry. Delta remains the provider for internal pipeline storage.

## Verification

- 16 unit tests (capability interfaces, option plumbing, schema requirement, existence checks, registry registration).
- 5 real-Spark integration round-trip tests (`tests/integration/test_entity_provider_parquet_roundtrip.py`): write/append/read, overwrite semantics, partition-directory layout, `ensure_destination`, and a streaming file-source → file-sink hop — 16s total, no cloud resources.
- Full unit suite: 1732 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)