### PR TITLE
test(synapse): right-size system test job containers for parallel execution

### DIFF
--- a/tests/system/test_helpers.py
+++ b/tests/system/test_helpers.py
@@ -504,12 +504,20 @@ def apply_env_config_overrides(job_config: Dict[str, Any], platform_name: str) -
     if platform_name == "synapse" and "configure_diagnostic_emitters" not in merged_config:
         merged_config["configure_diagnostic_emitters"] = False
 
-    # Default Synapse jobs to 1 executor (driver + 1 node = 2 nodes/job).
-    # The platform default is 2 executors (3 nodes/job), which means a 6-node pool
-    # can only run 2 concurrent jobs — queuing the 3rd worker.  1 executor lets all
-    # 3 CI workers run simultaneously within the 6-node pool.
+    # Right-size Synapse test jobs. The platform defaults (2 executors,
+    # 4 cores / 28g per container) node-size every container on Small pools,
+    # making each job occupy 3 full nodes for seconds of actual test work —
+    # and serializing the whole suite on a 3-node pool. 1 executor at
+    # 2 cores / 8g packs driver + executor onto ~1 node, so a 3-node pool
+    # runs 3 concurrent workers and session allocation is faster.
     if platform_name == "synapse" and "spark_config" not in merged_config:
-        merged_config["spark_config"] = {"executor_instances": 1}
+        merged_config["spark_config"] = {
+            "executor_instances": 1,
+            "executor_cores": 2,
+            "executor_memory": "8g",
+            "driver_cores": 2,
+            "driver_memory": "8g",
+        }
 
     return merged_config
 


### PR DESCRIPTION
## What

Shrinks Synapse system-test job containers from the platform defaults (4 cores / 28g — which node-sizes every container on Small pools) to 2 cores / 8g, so driver + executor pack onto ~1 node instead of 2.

## Why / Measured impact

On the 3-node local pool (`sprkpoolkndtst`), 2-node jobs serialize the whole suite. Measured on `sep-syws-dataanalytics-dev` with the full 21-test suite:

| Run | Config | Wall time | Results |
|---|---|---|---|
| Baseline | defaults, serial (local default) | ~4.5 min/test → ~95 min projected (cancelled at 17/21, 1h16m) | 15 passed, 1 skipped, 1 failed |
| Right-sized | 2c/8g + 3 xdist workers | **41m18s** | 19 passed, 1 skipped, 1 failed (same) |

Identical outcomes — every serial pass also passed in parallel; the one failure (`test_eventhub_provider_batch_and_stream_read`, a Synapse `TokenLibraryInternal` AzureManagement-token issue unrelated to recent changes) reproduces identically in both runs, so the sizing change alters no behavior.

CI already runs 3 workers on Synapse (its 6-node pool fits 3 × 2-node jobs exactly); with 1-node jobs, that worker count can be raised later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)