### PR TITLE
feat(temporal): stateful late real-end revision of persisted episodes

### DIFF
--- a/packages/extensions/kindling_ext_temporal/README.md
+++ b/packages/extensions/kindling_ext_temporal/README.md
@@ -65,7 +65,19 @@ emitted alongside them with its own deterministic `event_id`.
 
 A pipe reading its own output entity (the episode pipes read `silver.episodes`
 while writing it) is prior-state feedback, not a scheduling dependency;
-`PipeGraphBuilder` skips such self-edges instead of reporting a cycle.
+`PipeGraphBuilder` skips such self-edges instead of reporting a cycle, and
+both executers pass `None` for a self-referential input whose table does not
+exist yet, so the pipe's first run proceeds with no prior state instead of
+failing on the read.
+
+Known limitations:
+
+- episode rows persisted before this package recorded `start_generation` in
+  episode attributes are reconstructed with generation 1; determination
+  events for that legacy cohort can understate generation, and revision
+  writes the fallback back to the row;
+- revision re-emits refresh `created_at` (the upsert updates all columns), so
+  a revised episode does not retain its original creation timestamp.
 
 ## Lifecycle identity
 

--- a/packages/extensions/kindling_ext_temporal/README.md
+++ b/packages/extensions/kindling_ext_temporal/README.md
@@ -35,14 +35,15 @@ complete temporal-processing system described in the white paper and proposal.
   with `correlation_id = episode_id` and incremented generation numbers,
   including expiration events for expired episodes and invalidation events for
   invalidated episodes;
-- stateful late real-end revision of persisted episodes: episode pipes read
-  the episodes entity as reference data (`revise_persisted`, on by default),
-  reconstruct start boundaries for persisted open, expired, and
-  synthetically-invalidated episodes, and re-emit them with the same
-  `episode_id` when a late real end event arrives — the entity's
-  `merge_columns=["episode_id"]` upsert turns the re-emit into an in-place
-  revision; a batch with no new events and no evaluation time emits nothing
-  for reconstructed episodes so persisted state never regresses;
+- stateful late real-end revision of persisted episodes: the episode engine
+  resolves its own prior state at execution time (on by default, disabled via
+  `kindling.temporal.revise_persisted`), reconstructs start boundaries for
+  persisted open, expired, and synthetically-invalidated episodes, and
+  re-emits them with the same `episode_id` when a late real end event
+  arrives — the entity's `merge_columns=["episode_id"]` upsert turns the
+  re-emit into an in-place revision; a batch with no new events and no
+  evaluation time emits nothing for reconstructed episodes so persisted state
+  never regresses;
 - unit, integration, and system coverage for the first executable slice.
 
 ## Configuration
@@ -52,6 +53,9 @@ complete temporal-processing system described in the white paper and proposal.
   batch views. A per-execution `temporal_evaluation_time` keyword argument to
   a temporal pipe's `execute` overrides it. When neither is set, the bounded
   input horizon (the batch's maximum `event_ts`) is used.
+- `kindling.temporal.revise_persisted` — set to `false` to disable the prior
+  episode-state read entirely; episode pipes then compute a pure batch view.
+  Defaults to enabled.
 
 ## Revision semantics
 
@@ -63,19 +67,26 @@ determination events (for example an expiration event later superseded by a
 real close) remain in `silver.events` as history; the corrective event is
 emitted alongside them with its own deterministic `event_id`.
 
-A pipe reading its own output entity (the episode pipes read `silver.episodes`
-while writing it) is prior-state feedback, not a scheduling dependency;
-`PipeGraphBuilder` skips such self-edges instead of reporting a cycle, and
-both executers pass `None` for a self-referential input whose table does not
-exist yet, so the pipe's first run proceeds with no prior state instead of
-failing on the read.
+Prior state is an execution-strategy concern this extension owns, not a
+declared dataflow dependency: episode pipes declare only the events entity as
+input, and the engine resolves persisted episode state itself at execution
+time — a keyword argument named after the episodes entity (tests, manual
+runs) wins, the `kindling.temporal.revise_persisted` config key can disable
+the read, and otherwise the episodes entity is read through its provider when
+it exists. A first run therefore proceeds with no prior state instead of
+failing on a read of the table it is about to create. The pipes carry a
+`temporal.reads_prior_state` tag so lineage tooling can see the feedback
+loop the pipe graph deliberately does not schedule around. (A pipe that does
+declare its own output as an input — the determination pipe writes and reads
+`silver.events` — is prior-state feedback too; `PipeGraphBuilder` skips such
+self-edges instead of reporting a cycle.)
 
 Known limitations:
 
-- episode rows persisted before this package recorded `start_generation` in
-  episode attributes are reconstructed with generation 1; determination
-  events for that legacy cohort can understate generation, and revision
-  writes the fallback back to the row;
+- episode rows persisted before the schema carried `start_generation` are
+  reconstructed at generation 1; determination events for that legacy cohort
+  can understate generation, and revision writes the fallback back to the
+  row;
 - revision re-emits refresh `created_at` (the upsert updates all columns), so
   a revised episode does not retain its original creation timestamp.
 

--- a/packages/extensions/kindling_ext_temporal/README.md
+++ b/packages/extensions/kindling_ext_temporal/README.md
@@ -35,6 +35,14 @@ complete temporal-processing system described in the white paper and proposal.
   with `correlation_id = episode_id` and incremented generation numbers,
   including expiration events for expired episodes and invalidation events for
   invalidated episodes;
+- stateful late real-end revision of persisted episodes: episode pipes read
+  the episodes entity as reference data (`revise_persisted`, on by default),
+  reconstruct start boundaries for persisted open, expired, and
+  synthetically-invalidated episodes, and re-emit them with the same
+  `episode_id` when a late real end event arrives — the entity's
+  `merge_columns=["episode_id"]` upsert turns the re-emit into an in-place
+  revision; a batch with no new events and no evaluation time emits nothing
+  for reconstructed episodes so persisted state never regresses;
 - unit, integration, and system coverage for the first executable slice.
 
 ## Configuration
@@ -44,6 +52,20 @@ complete temporal-processing system described in the white paper and proposal.
   batch views. A per-execution `temporal_evaluation_time` keyword argument to
   a temporal pipe's `execute` overrides it. When neither is set, the bounded
   input horizon (the batch's maximum `event_ts`) is used.
+
+## Revision semantics
+
+Episodes ended by a real end event are terminal: revision reconsiders only
+persisted episodes whose end is synthetic (expired, invalidated past max
+duration) or absent (open). A late-arriving end event that is earlier than an
+already-accepted real end does not reopen or re-pair a closed episode. Prior
+determination events (for example an expiration event later superseded by a
+real close) remain in `silver.events` as history; the corrective event is
+emitted alongside them with its own deterministic `event_id`.
+
+A pipe reading its own output entity (the episode pipes read `silver.episodes`
+while writing it) is prior-state feedback, not a scheduling dependency;
+`PipeGraphBuilder` skips such self-edges instead of reporting a cycle.
 
 ## Lifecycle identity
 
@@ -59,8 +81,8 @@ do not create a different episode identity.
 The remaining proposal work is tracked here so the current package is not
 mistaken for a full implementation:
 
-- stateful late real-end revision of already-persisted expired or invalidated
-  episodes;
+- revision of episodes closed by a real end event (a later-arriving end
+  earlier than the accepted one never re-pairs a closed episode);
 - late-event grace windows, watermarks, replay/backfill semantics, and
   stateful streaming execution;
 - multi-generation orchestration beyond one condition-engine pass;

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/engine.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/engine.py
@@ -98,10 +98,15 @@ class ConditionEngineRunner:
 class EpisodeRunner:
     """Form Episodes by pairing start Events with the earliest matching end Event."""
 
-    def execute(self, events_df, episode, evaluation_time=None):
+    def execute(self, events_df, episode, evaluation_time=None, existing_episodes_df=None):
         from pyspark.sql import functions as F
 
-        paired = self._paired_boundaries(events_df, episode, evaluation_time=evaluation_time)
+        paired = self._paired_boundaries(
+            events_df,
+            episode,
+            evaluation_time=evaluation_time,
+            existing_episodes_df=existing_episodes_df,
+        )
 
         return paired.select(
             F.col("episode_id"),
@@ -124,11 +129,16 @@ class EpisodeRunner:
             self._episode_attributes(episode).alias("attributes"),
         )
 
-    def execute_determination_events(self, events_df, episode, evaluation_time=None):
+    def execute_determination_events(
+        self, events_df, episode, evaluation_time=None, existing_episodes_df=None
+    ):
         from pyspark.sql import functions as F
 
         paired = self._paired_boundaries(
-            events_df, episode, evaluation_time=evaluation_time
+            events_df,
+            episode,
+            evaluation_time=evaluation_time,
+            existing_episodes_df=existing_episodes_df,
         ).filter(F.col("status").isin("closed", "expired", "invalidated"))
         determination_event = episode.determination_event or f"{episode.episodeid}.closed"
         expiration_event = episode.expiration_event or f"{episode.episodeid}.expired"
@@ -205,7 +215,7 @@ class EpisodeRunner:
         )
 
     @staticmethod
-    def _paired_boundaries(events_df, episode, evaluation_time=None):
+    def _paired_boundaries(events_df, episode, evaluation_time=None, existing_episodes_df=None):
         from pyspark.sql import functions as F
         from pyspark.sql.window import Window
 
@@ -214,6 +224,15 @@ class EpisodeRunner:
         if episode.subject_type:
             starts = starts.filter(F.col("subject_type") == F.lit(episode.subject_type))
             ends = ends.filter(F.col("subject_type") == F.lit(episode.subject_type))
+
+        starts = starts.withColumn("__temporal_reconstructed_start", F.lit(False))
+        if existing_episodes_df is not None:
+            reconstructed = EpisodeRunner._reconstruct_start_boundaries(
+                existing_episodes_df, episode
+            ).join(starts.select("event_id"), on="event_id", how="left_anti")
+            starts = starts.unionByName(
+                reconstructed.withColumn("__temporal_reconstructed_start", F.lit(True))
+            )
 
         starts = starts.alias("start")
         ends = ends.alias("end")
@@ -240,6 +259,16 @@ class EpisodeRunner:
                 "__temporal_evaluation_time",
                 F.lit(evaluation_time).cast("timestamp"),
             )
+        # A reconstructed start with no new end event and no evaluation time
+        # carries no new information; emitting it would recompute the
+        # persisted episode as merely "open" and regress its lifecycle state.
+        paired = paired.filter(
+            ~(
+                F.col("start.__temporal_reconstructed_start")
+                & F.col("end.event_id").isNull()
+                & F.col("__temporal_evaluation_time").isNull()
+            )
+        )
 
         expiration_time = F.lit(None).cast("timestamp")
         if episode.expires_after_seconds is not None:
@@ -351,6 +380,46 @@ class EpisodeRunner:
         )
 
     @staticmethod
+    def _reconstruct_start_boundaries(episodes_df, episode):
+        """Rebuild start-boundary event rows for persisted revisable episodes.
+
+        Revisable means the episode has no real end yet: open, expired, or
+        invalidated with a synthetic end. Episodes ended by a real event are
+        terminal and never revised. The reconstructed rows let an incremental
+        batch that only contains a late real end event pair it against a start
+        consumed by an earlier batch.
+        """
+        from pyspark.sql import functions as F
+
+        revisable = episodes_df.filter(
+            (F.col("episode_type") == F.lit(episode.episodeid))
+            & (
+                F.col("status").isin("open", "expired")
+                | ((F.col("status") == F.lit("invalidated")) & F.col("end_event_synthetic"))
+            )
+        )
+        if episode.subject_type:
+            revisable = revisable.filter(F.col("subject_type") == F.lit(episode.subject_type))
+
+        string_map = "map<string,string>"
+        return revisable.select(
+            F.col("start_event_id").alias("event_id"),
+            F.lit(episode.start_event).alias("event_type"),
+            F.coalesce(F.col("attributes").getItem("start_generation").cast("int"), F.lit(1)).alias(
+                "generation"
+            ),
+            F.lit("condition").alias("event_class"),
+            F.col("subject_type"),
+            F.col("subject_id"),
+            F.col("start_time").alias("event_ts"),
+            F.lit("kindling-ext-temporal.revision").alias("source_system"),
+            F.col("episode_id").alias("correlation_id"),
+            F.lit(None).cast(string_map).alias("payload"),
+            F.lit(None).cast(string_map).alias("attributes"),
+            F.current_timestamp().alias("ingested_at"),
+        )
+
+    @staticmethod
     def _episode_attributes(episode):
         from pyspark.sql import functions as F
 
@@ -359,6 +428,8 @@ class EpisodeRunner:
             F.lit(episode.start_event),
             F.lit("end_event_type"),
             F.lit(episode.end_event),
+            F.lit("start_generation"),
+            F.col("start.generation").cast("string"),
         )
 
     @staticmethod

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/engine.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/engine.py
@@ -227,9 +227,11 @@ class EpisodeRunner:
 
         starts = starts.withColumn("__temporal_reconstructed_start", F.lit(False))
         if existing_episodes_df is not None:
-            reconstructed = EpisodeRunner._reconstruct_start_boundaries(
-                existing_episodes_df, episode
-            ).join(starts.select("event_id"), on="event_id", how="left_anti")
+            reconstructed = (
+                EpisodeRunner._reconstruct_start_boundaries(existing_episodes_df, episode)
+                .dropDuplicates(["event_id"])
+                .join(starts.select("event_id"), on="event_id", how="left_anti")
+            )
             starts = starts.unionByName(
                 reconstructed.withColumn("__temporal_reconstructed_start", F.lit(True))
             )

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/engine.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/engine.py
@@ -116,6 +116,7 @@ class EpisodeRunner:
             F.col("start.subject_type").alias("subject_type"),
             F.col("start.subject_id").alias("subject_id"),
             F.col("start.event_id").alias("start_event_id"),
+            F.col("start.generation").cast("int").alias("start_generation"),
             F.col("end_event_id"),
             F.col("start.event_ts").alias("start_time"),
             F.col("end_time"),
@@ -403,13 +404,18 @@ class EpisodeRunner:
         if episode.subject_type:
             revisable = revisable.filter(F.col("subject_type") == F.lit(episode.subject_type))
 
+        # Rows persisted before the schema carried start_generation (or with a
+        # null value) reconstruct at generation 1.
+        if "start_generation" in episodes_df.columns:
+            start_generation = F.coalesce(F.col("start_generation").cast("int"), F.lit(1))
+        else:
+            start_generation = F.lit(1)
+
         string_map = "map<string,string>"
         return revisable.select(
             F.col("start_event_id").alias("event_id"),
             F.lit(episode.start_event).alias("event_type"),
-            F.coalesce(F.col("attributes").getItem("start_generation").cast("int"), F.lit(1)).alias(
-                "generation"
-            ),
+            start_generation.alias("generation"),
             F.lit("condition").alias("event_class"),
             F.col("subject_type"),
             F.col("subject_id"),
@@ -430,8 +436,6 @@ class EpisodeRunner:
             F.lit(episode.start_event),
             F.lit("end_event_type"),
             F.lit(episode.end_event),
-            F.lit("start_generation"),
-            F.col("start.generation").cast("string"),
         )
 
     @staticmethod

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/entities.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/entities.py
@@ -3,6 +3,8 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
+from kindling.data_entities import EntityMetadata
+from kindling.injection import GlobalInjector
 from pyspark.sql.types import (
     ArrayType,
     BooleanType,
@@ -14,9 +16,6 @@ from pyspark.sql.types import (
     StructType,
     TimestampType,
 )
-
-from kindling.data_entities import EntityMetadata
-from kindling.injection import GlobalInjector
 
 
 def events_schema() -> StructType:
@@ -66,6 +65,7 @@ def episodes_schema() -> StructType:
             StructField("subject_type", StringType(), False),
             StructField("subject_id", StringType(), False),
             StructField("start_event_id", StringType(), False),
+            StructField("start_generation", IntegerType(), True),
             StructField("end_event_id", StringType(), True),
             StructField("start_time", TimestampType(), False),
             StructField("end_time", TimestampType(), True),

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/registry.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/registry.py
@@ -67,6 +67,7 @@ class EpisodeMetadata:
     late_event_grace_seconds: Optional[int] = None
     expires_after_seconds: Optional[int] = None
     expiration_event: Optional[str] = None
+    revise_persisted: bool = True
     tags: Dict[str, str] = field(default_factory=dict)
 
 

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/registry.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/registry.py
@@ -67,7 +67,6 @@ class EpisodeMetadata:
     late_event_grace_seconds: Optional[int] = None
     expires_after_seconds: Optional[int] = None
     expiration_event: Optional[str] = None
-    revise_persisted: bool = True
     tags: Dict[str, str] = field(default_factory=dict)
 
 

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/translation.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/translation.py
@@ -1,6 +1,6 @@
 """Lower temporal declarations into ordinary Kindling pipe registrations."""
 
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from kindling.data_entities import DataEntityRegistry, EntityMetadata
 from kindling.data_pipes import DataPipesRegistry
@@ -164,12 +164,27 @@ class TemporalPipeTranslator:
                 "temporal.episode_id": metadata.episodeid,
                 "temporal.start_event": metadata.start_event,
                 "temporal.end_event": metadata.end_event,
+                "temporal.revise_persisted": str(bool(metadata.revise_persisted)).lower(),
             },
-            "input_entity_ids": [metadata.events_entity_id],
+            "input_entity_ids": cls._episode_input_entity_ids(metadata),
             "output_entity_id": metadata.output_entity_id,
             "output_type": metadata.output_type,
             "use_watermark": metadata.use_watermark,
         }
+
+    @classmethod
+    def _episode_input_entity_ids(cls, metadata: "EpisodeMetadata") -> List[str]:
+        """Inputs for episode-family pipes.
+
+        The events entity is first — the watermarked driving source. With
+        revision enabled, the episodes entity follows as reference data (read
+        in full per the driving-source convention) so late real end events can
+        revise persisted open/expired/synthetically-invalidated episodes.
+        """
+        input_ids = [metadata.events_entity_id]
+        if metadata.revise_persisted:
+            input_ids.append(metadata.output_entity_id)
+        return input_ids
 
     @classmethod
     def episode_determination_event_pipe_params(cls, metadata: "EpisodeMetadata") -> Dict[str, Any]:
@@ -186,8 +201,9 @@ class TemporalPipeTranslator:
                 "temporal.invalidation_event_type": metadata.invalidation_event,
                 "temporal.start_event": metadata.start_event,
                 "temporal.end_event": metadata.end_event,
+                "temporal.revise_persisted": str(bool(metadata.revise_persisted)).lower(),
             },
-            "input_entity_ids": [metadata.events_entity_id],
+            "input_entity_ids": cls._episode_input_entity_ids(metadata),
             "output_entity_id": metadata.events_entity_id,
             "output_type": metadata.output_type,
             "use_watermark": metadata.use_watermark,
@@ -226,10 +242,12 @@ class TemporalPipeTranslator:
 
             from .engine import EpisodeRunner
 
+            episodes_key = metadata.output_entity_id.replace(".", "_")
             return EpisodeRunner().execute(
                 events_df,
                 metadata,
                 evaluation_time=cls.resolve_evaluation_time(entity_dfs),
+                existing_episodes_df=entity_dfs.get(episodes_key),
             )
 
         return execute
@@ -270,10 +288,12 @@ class TemporalPipeTranslator:
 
             from .engine import EpisodeRunner
 
+            episodes_key = metadata.output_entity_id.replace(".", "_")
             return EpisodeRunner().execute_determination_events(
                 events_df,
                 metadata,
                 evaluation_time=cls.resolve_evaluation_time(entity_dfs),
+                existing_episodes_df=entity_dfs.get(episodes_key),
             )
 
         return execute

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/translation.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/translation.py
@@ -1,6 +1,6 @@
 """Lower temporal declarations into ordinary Kindling pipe registrations."""
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from kindling.data_entities import DataEntityRegistry, EntityMetadata
 from kindling.data_pipes import DataPipesRegistry
@@ -17,6 +17,7 @@ class TemporalPipeTranslator:
     EPISODE_PIPE_PREFIX = "temporal.episode."
     EPISODE_DETERMINATION_EVENT_PIPE_PREFIX = "temporal.episode_event."
     EVALUATION_TIME_CONFIG_KEY = "kindling.temporal.evaluation_time"
+    PRIOR_STATE_CONFIG_KEY = "kindling.temporal.revise_persisted"
 
     @classmethod
     def base_event_pipe_id(cls, eventid: str) -> str:
@@ -164,27 +165,13 @@ class TemporalPipeTranslator:
                 "temporal.episode_id": metadata.episodeid,
                 "temporal.start_event": metadata.start_event,
                 "temporal.end_event": metadata.end_event,
-                "temporal.revise_persisted": str(bool(metadata.revise_persisted)).lower(),
+                "temporal.reads_prior_state": "true",
             },
-            "input_entity_ids": cls._episode_input_entity_ids(metadata),
+            "input_entity_ids": [metadata.events_entity_id],
             "output_entity_id": metadata.output_entity_id,
             "output_type": metadata.output_type,
             "use_watermark": metadata.use_watermark,
         }
-
-    @classmethod
-    def _episode_input_entity_ids(cls, metadata: "EpisodeMetadata") -> List[str]:
-        """Inputs for episode-family pipes.
-
-        The events entity is first — the watermarked driving source. With
-        revision enabled, the episodes entity follows as reference data (read
-        in full per the driving-source convention) so late real end events can
-        revise persisted open/expired/synthetically-invalidated episodes.
-        """
-        input_ids = [metadata.events_entity_id]
-        if metadata.revise_persisted:
-            input_ids.append(metadata.output_entity_id)
-        return input_ids
 
     @classmethod
     def episode_determination_event_pipe_params(cls, metadata: "EpisodeMetadata") -> Dict[str, Any]:
@@ -201,9 +188,9 @@ class TemporalPipeTranslator:
                 "temporal.invalidation_event_type": metadata.invalidation_event,
                 "temporal.start_event": metadata.start_event,
                 "temporal.end_event": metadata.end_event,
-                "temporal.revise_persisted": str(bool(metadata.revise_persisted)).lower(),
+                "temporal.reads_prior_state": "true",
             },
-            "input_entity_ids": cls._episode_input_entity_ids(metadata),
+            "input_entity_ids": [metadata.events_entity_id],
             "output_entity_id": metadata.events_entity_id,
             "output_type": metadata.output_type,
             "use_watermark": metadata.use_watermark,
@@ -242,15 +229,56 @@ class TemporalPipeTranslator:
 
             from .engine import EpisodeRunner
 
-            episodes_key = metadata.output_entity_id.replace(".", "_")
             return EpisodeRunner().execute(
                 events_df,
                 metadata,
                 evaluation_time=cls.resolve_evaluation_time(entity_dfs),
-                existing_episodes_df=entity_dfs.get(episodes_key),
+                existing_episodes_df=cls.resolve_prior_episodes(entity_dfs, metadata),
             )
 
         return execute
+
+    @classmethod
+    def resolve_prior_episodes(cls, entity_dfs: Dict[str, Any], metadata: "EpisodeMetadata") -> Any:
+        """Resolve the persisted episode state an episode-family pipe revises.
+
+        Prior state is an execution-strategy concern owned by this extension,
+        not a declared dataflow dependency — the pipe graph never schedules a
+        pipe ahead of its own previous run. Resolution order: a JIT keyword
+        argument named after the episodes entity (tests, manual runs) wins;
+        the `kindling.temporal.revise_persisted` config key can disable the
+        read; otherwise the episodes entity is read through its provider when
+        it exists. Returns None (no prior state) when disabled, unresolvable,
+        or not yet created — the runner treats None as a pure batch view.
+        """
+        episodes_key = metadata.output_entity_id.replace(".", "_")
+        if episodes_key in entity_dfs:
+            return entity_dfs[episodes_key]
+        try:
+            from kindling.injection import GlobalInjector
+            from kindling.spark_config import ConfigService
+
+            enabled = GlobalInjector.get(ConfigService).get(cls.PRIOR_STATE_CONFIG_KEY, True)
+            if str(enabled).strip().lower() in ("false", "0", "no", "off"):
+                return None
+        except Exception:
+            pass
+        try:
+            from kindling.data_entities import DataEntityRegistry
+            from kindling.entity_provider_registry import EntityProviderRegistry
+            from kindling.injection import GlobalInjector
+
+            entity = GlobalInjector.get(DataEntityRegistry).get_entity_definition(
+                metadata.output_entity_id
+            )
+            if entity is None:
+                return None
+            provider = GlobalInjector.get(EntityProviderRegistry).get_provider_for_entity(entity)
+            if provider is None or not provider.check_entity_exists(entity):
+                return None
+            return provider.read_entity(entity)
+        except Exception:
+            return None
 
     @classmethod
     def resolve_evaluation_time(cls, entity_dfs: Dict[str, Any]) -> Any:
@@ -288,12 +316,11 @@ class TemporalPipeTranslator:
 
             from .engine import EpisodeRunner
 
-            episodes_key = metadata.output_entity_id.replace(".", "_")
             return EpisodeRunner().execute_determination_events(
                 events_df,
                 metadata,
                 evaluation_time=cls.resolve_evaluation_time(entity_dfs),
-                existing_episodes_df=entity_dfs.get(episodes_key),
+                existing_episodes_df=cls.resolve_prior_episodes(entity_dfs, metadata),
             )
 
         return execute

--- a/packages/kindling/data_pipes.py
+++ b/packages/kindling/data_pipes.py
@@ -8,13 +8,12 @@ from typing import Any, Callable, Dict, List, Optional
 
 from delta.tables import DeltaTable
 from injector import Binder, Injector, inject, singleton
-from pyspark.sql import DataFrame
-
 from kindling.injection import *
 from kindling.sentinels import UNSET
 from kindling.signaling import SignalEmitter, SignalProvider
 from kindling.spark_log_provider import *
 from kindling.spark_trace import *
+from pyspark.sql import DataFrame
 
 from .data_entities import *
 from .data_entities import _raise_if_not_initialized
@@ -268,6 +267,42 @@ class DataPipesExecution(ABC):
         pass
 
 
+def self_input_without_state(pipe, entity_id, entity, provider_registry, logger) -> bool:
+    """Return True when a pipe's self-referential input has no persisted state yet.
+
+    A non-driving input naming the pipe's own output entity consumes the
+    previous run's state (see PipeGraphBuilder's self-edge exemption). Before
+    the pipe's first successful persist that state does not exist, and reading
+    it would fail the very pipe that is supposed to create it. Executers
+    substitute None for such an input — pipe execute functions treat a missing
+    self-input as "no prior state".
+
+    Only a positive "entity does not exist" answer skips the read. When the
+    check cannot be made (no provider registry, unknown entity, provider
+    without an existence check, or the check itself fails), the read proceeds
+    and any real read error surfaces as usual.
+    """
+    if entity_id != pipe.output_entity_id or provider_registry is None or entity is None:
+        return False
+    try:
+        provider = provider_registry.get_provider_for_entity(entity)
+        if provider is None or not hasattr(provider, "check_entity_exists"):
+            return False
+        if provider.check_entity_exists(entity):
+            return False
+    except Exception as exc:
+        logger.debug(
+            f"Self-input existence check failed for '{entity_id}' "
+            f"({type(exc).__name__}: {exc}) — attempting the read"
+        )
+        return False
+    logger.info(
+        f"Pipe '{pipe.pipeid}' reads its own output entity '{entity_id}', which does "
+        f"not exist yet — passing no prior state (None) for this input"
+    )
+    return True
+
+
 @GlobalInjector.singleton_autobind()
 class DataPipesManager(DataPipesRegistry):
     @inject
@@ -515,9 +550,13 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
             # WatermarkAspect (kindling.watermarking) for the write side.
             is_first = i == 0
             key = entity_id.replace(".", "_")
-            result[key] = entity_reader(
-                self.dpe.get_entity_definition(entity_id), pipe.use_watermark and is_first
-            )
+            entity = self.dpe.get_entity_definition(entity_id)
+            if not is_first and self_input_without_state(
+                pipe, entity_id, entity, getattr(self.erps, "provider_registry", None), self.logger
+            ):
+                result[key] = None
+                continue
+            result[key] = entity_reader(entity, pipe.use_watermark and is_first)
         return result
 
 

--- a/packages/kindling/data_pipes.py
+++ b/packages/kindling/data_pipes.py
@@ -267,42 +267,6 @@ class DataPipesExecution(ABC):
         pass
 
 
-def self_input_without_state(pipe, entity_id, entity, provider_registry, logger) -> bool:
-    """Return True when a pipe's self-referential input has no persisted state yet.
-
-    A non-driving input naming the pipe's own output entity consumes the
-    previous run's state (see PipeGraphBuilder's self-edge exemption). Before
-    the pipe's first successful persist that state does not exist, and reading
-    it would fail the very pipe that is supposed to create it. Executers
-    substitute None for such an input — pipe execute functions treat a missing
-    self-input as "no prior state".
-
-    Only a positive "entity does not exist" answer skips the read. When the
-    check cannot be made (no provider registry, unknown entity, provider
-    without an existence check, or the check itself fails), the read proceeds
-    and any real read error surfaces as usual.
-    """
-    if entity_id != pipe.output_entity_id or provider_registry is None or entity is None:
-        return False
-    try:
-        provider = provider_registry.get_provider_for_entity(entity)
-        if provider is None or not hasattr(provider, "check_entity_exists"):
-            return False
-        if provider.check_entity_exists(entity):
-            return False
-    except Exception as exc:
-        logger.debug(
-            f"Self-input existence check failed for '{entity_id}' "
-            f"({type(exc).__name__}: {exc}) — attempting the read"
-        )
-        return False
-    logger.info(
-        f"Pipe '{pipe.pipeid}' reads its own output entity '{entity_id}', which does "
-        f"not exist yet — passing no prior state (None) for this input"
-    )
-    return True
-
-
 @GlobalInjector.singleton_autobind()
 class DataPipesManager(DataPipesRegistry):
     @inject
@@ -550,13 +514,9 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
             # WatermarkAspect (kindling.watermarking) for the write side.
             is_first = i == 0
             key = entity_id.replace(".", "_")
-            entity = self.dpe.get_entity_definition(entity_id)
-            if not is_first and self_input_without_state(
-                pipe, entity_id, entity, getattr(self.erps, "provider_registry", None), self.logger
-            ):
-                result[key] = None
-                continue
-            result[key] = entity_reader(entity, pipe.use_watermark and is_first)
+            result[key] = entity_reader(
+                self.dpe.get_entity_definition(entity_id), pipe.use_watermark and is_first
+            )
         return result
 
 

--- a/packages/kindling/generation_executor.py
+++ b/packages/kindling/generation_executor.py
@@ -35,7 +35,6 @@ from kindling.data_pipes import (
     DataPipesRegistry,
     EntityReadPersistStrategy,
     PipeMetadata,
-    self_input_without_state,
 )
 from kindling.entity_provider_registry import EntityProviderRegistry
 from kindling.execution_strategy import (
@@ -1068,15 +1067,6 @@ class GenerationExecutor(SignalEmitter):
         for i, entity_id in enumerate(pipe.input_entity_ids):
             is_first = i == 0
             key = entity_id.replace(".", "_")
-            if not is_first and self_input_without_state(
-                pipe,
-                entity_id,
-                self.entity_registry.get_entity_definition(entity_id),
-                self.provider_registry,
-                self.logger,
-            ):
-                input_entities[key] = None
-                continue
             input_entities[key] = self._read_batch_input_entity(
                 entity_id=entity_id,
                 entity_reader=entity_reader,

--- a/packages/kindling/generation_executor.py
+++ b/packages/kindling/generation_executor.py
@@ -28,7 +28,6 @@ from threading import Lock
 from typing import Any, Callable, Dict, List, Optional
 
 from injector import inject
-
 from kindling.cache_optimizer import CacheOptimizer
 from kindling.data_entities import DataEntityRegistry
 from kindling.data_pipes import (
@@ -36,6 +35,7 @@ from kindling.data_pipes import (
     DataPipesRegistry,
     EntityReadPersistStrategy,
     PipeMetadata,
+    self_input_without_state,
 )
 from kindling.entity_provider_registry import EntityProviderRegistry
 from kindling.execution_strategy import (
@@ -1068,6 +1068,15 @@ class GenerationExecutor(SignalEmitter):
         for i, entity_id in enumerate(pipe.input_entity_ids):
             is_first = i == 0
             key = entity_id.replace(".", "_")
+            if not is_first and self_input_without_state(
+                pipe,
+                entity_id,
+                self.entity_registry.get_entity_definition(entity_id),
+                self.provider_registry,
+                self.logger,
+            ):
+                input_entities[key] = None
+                continue
             input_entities[key] = self._read_batch_input_entity(
                 entity_id=entity_id,
                 entity_reader=entity_reader,

--- a/packages/kindling/pipe_graph.py
+++ b/packages/kindling/pipe_graph.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Set, Tuple
 
 from injector import inject
-
 from kindling.data_pipes import DataPipesRegistry, PipeMetadata
 from kindling.spark_log_provider import PythonLoggerProvider
 
@@ -224,6 +223,17 @@ class PipeGraphBuilder:
             for input_entity in node.input_entities:
                 # Find which pipe produces this input entity
                 producer_id = graph.entity_producers.get(input_entity)
+                if producer_id == pipe_id:
+                    # A pipe reading its own output entity consumes the
+                    # previous run's persisted state (e.g. temporal episode
+                    # revision), not an ordering dependency — a self-edge
+                    # could never be satisfied by scheduling and would be
+                    # reported as a cycle.
+                    self.logger.debug(
+                        f"Skipping self-edge: {pipe_id} reads its own output "
+                        f"entity '{input_entity}' (prior-state feedback)"
+                    )
+                    continue
                 if producer_id and producer_id in graph.nodes:
                     # Create edge from producer to consumer
                     edge = PipeEdge(from_pipe=producer_id, to_pipe=pipe_id, entity=input_entity)

--- a/tests/integration/test_temporal_extension_integration.py
+++ b/tests/integration/test_temporal_extension_integration.py
@@ -194,6 +194,7 @@ def test_episode_runner_pairs_entered_and_exited_events(spark):
     assert row.subject_type == "machine"
     assert row.subject_id == "machine-1"
     assert row.start_event_id
+    assert row.start_generation == 1
     assert row.end_event_id
     assert row.status == "closed"
     assert row.close_reason == "end_event"
@@ -707,6 +708,18 @@ def test_episode_runner_revises_persisted_expired_episode_with_late_real_end(spa
     assert event.payload["status"] == "closed"
     assert event.payload["close_reason"] == "end_event"
     assert event.payload["end_event_id"] == row.end_event_id
+
+    legacy_state = persisted.drop("start_generation")
+    legacy_revised = runner.execute(
+        late_end_boundaries,
+        episode,
+        evaluation_time=observed_at + timedelta(minutes=15),
+        existing_episodes_df=legacy_state,
+    ).collect()
+    assert len(legacy_revised) == 1
+    assert legacy_revised[0].status == "closed"
+    assert legacy_revised[0].episode_id == persisted_row.episode_id
+    assert legacy_revised[0].start_generation == 1
 
 
 @pytest.mark.requires_spark

--- a/tests/integration/test_temporal_extension_integration.py
+++ b/tests/integration/test_temporal_extension_integration.py
@@ -95,6 +95,30 @@ def _unclosed_events_df(spark):
     )
 
 
+def _end_only_events_df(spark, cooled_at):
+    from kindling_ext_temporal import events_schema
+
+    return spark.createDataFrame(
+        [
+            (
+                "source-cool",
+                "telemetry.observed",
+                0,
+                "base",
+                "machine",
+                "machine-1",
+                cooled_at,
+                "sensor",
+                None,
+                {"temperature": "80"},
+                None,
+                cooled_at,
+            ),
+        ],
+        events_schema(),
+    )
+
+
 def _conditions_df(spark):
     from kindling_ext_temporal import conditions_schema
 
@@ -615,3 +639,215 @@ def test_episode_runner_emits_episode_determination_event(spark):
     assert event.attributes["end_event_type"] == "condition.temperature_high.exited"
     assert event.attributes["start_generation"] == "1"
     assert event.attributes["end_generation"] == "1"
+
+
+@pytest.mark.requires_spark
+def test_episode_runner_revises_persisted_expired_episode_with_late_real_end(spark):
+    from kindling_ext_temporal import (
+        ConditionEngineRunner,
+        EpisodeMetadata,
+        EpisodeRunner,
+    )
+
+    observed_at = datetime(2026, 7, 14, 12, 0, 0)
+    episode = EpisodeMetadata(
+        episodeid="episode.temperature_high_active",
+        output_entity_id="silver.episodes",
+        events_entity_id="silver.events",
+        start_event="condition.temperature_high.entered",
+        end_event="condition.temperature_high.exited",
+        condition_id="condition.temperature_high",
+        determination_event="episode.temperature_high_active.closed",
+        expiration_event="episode.temperature_high_active.expired",
+        expires_after_seconds=300,
+        subject_type="machine",
+    )
+    runner = EpisodeRunner()
+
+    first_batch_boundaries = ConditionEngineRunner().execute(
+        _unclosed_events_df(spark), _conditions_df(spark)
+    )
+    persisted = runner.execute(
+        first_batch_boundaries, episode, evaluation_time=observed_at + timedelta(minutes=10)
+    )
+    persisted_row = persisted.collect()[0]
+    assert persisted_row.status == "expired"
+
+    late_end_boundaries = ConditionEngineRunner().execute(
+        _end_only_events_df(spark, observed_at + timedelta(minutes=10)), _conditions_df(spark)
+    )
+    revised = runner.execute(
+        late_end_boundaries,
+        episode,
+        evaluation_time=observed_at + timedelta(minutes=15),
+        existing_episodes_df=persisted,
+    ).collect()
+    revision_events = runner.execute_determination_events(
+        late_end_boundaries,
+        episode,
+        evaluation_time=observed_at + timedelta(minutes=15),
+        existing_episodes_df=persisted,
+    ).collect()
+
+    assert len(revised) == 1
+    row = revised[0]
+    assert row.episode_id == persisted_row.episode_id
+    assert row.start_event_id == persisted_row.start_event_id
+    assert row.status == "closed"
+    assert row.close_reason == "end_event"
+    assert row.end_event_synthetic is False
+    assert row.end_time == observed_at + timedelta(minutes=10)
+    assert row.duration_ms == 600000
+
+    assert len(revision_events) == 1
+    event = revision_events[0]
+    assert event.event_type == "episode.temperature_high_active.closed"
+    assert event.generation == 2
+    assert event.correlation_id == persisted_row.episode_id
+    assert event.payload["status"] == "closed"
+    assert event.payload["close_reason"] == "end_event"
+    assert event.payload["end_event_id"] == row.end_event_id
+
+
+@pytest.mark.requires_spark
+def test_episode_runner_revises_persisted_invalidated_episode_with_in_bounds_real_end(spark):
+    from kindling_ext_temporal import (
+        ConditionEngineRunner,
+        EpisodeMetadata,
+        EpisodeRunner,
+    )
+
+    observed_at = datetime(2026, 7, 14, 12, 0, 0)
+    episode = EpisodeMetadata(
+        episodeid="episode.temperature_high_active",
+        output_entity_id="silver.episodes",
+        events_entity_id="silver.events",
+        start_event="condition.temperature_high.entered",
+        end_event="condition.temperature_high.exited",
+        condition_id="condition.temperature_high",
+        invalidation_event="episode.temperature_high_active.invalidated",
+        max_duration_seconds=300,
+        subject_type="machine",
+    )
+    runner = EpisodeRunner()
+
+    first_batch_boundaries = ConditionEngineRunner().execute(
+        _unclosed_events_df(spark), _conditions_df(spark)
+    )
+    persisted = runner.execute(
+        first_batch_boundaries, episode, evaluation_time=observed_at + timedelta(minutes=10)
+    )
+    persisted_row = persisted.collect()[0]
+    assert persisted_row.status == "invalidated"
+    assert persisted_row.end_event_synthetic is True
+
+    late_end_boundaries = ConditionEngineRunner().execute(
+        _end_only_events_df(spark, observed_at + timedelta(minutes=4)), _conditions_df(spark)
+    )
+    revised = runner.execute(
+        late_end_boundaries,
+        episode,
+        evaluation_time=observed_at + timedelta(minutes=15),
+        existing_episodes_df=persisted,
+    ).collect()
+
+    assert len(revised) == 1
+    row = revised[0]
+    assert row.episode_id == persisted_row.episode_id
+    assert row.status == "closed"
+    assert row.close_reason == "end_event"
+    assert row.end_event_synthetic is False
+    assert row.end_time == observed_at + timedelta(minutes=4)
+    assert row.duration_ms == 240000
+
+
+@pytest.mark.requires_spark
+def test_episode_runner_does_not_regress_persisted_state_without_new_information(spark):
+    from kindling_ext_temporal import (
+        ConditionEngineRunner,
+        EpisodeMetadata,
+        EpisodeRunner,
+        events_schema,
+    )
+
+    observed_at = datetime(2026, 7, 14, 12, 0, 0)
+    episode = EpisodeMetadata(
+        episodeid="episode.temperature_high_active",
+        output_entity_id="silver.episodes",
+        events_entity_id="silver.events",
+        start_event="condition.temperature_high.entered",
+        end_event="condition.temperature_high.exited",
+        condition_id="condition.temperature_high",
+        expiration_event="episode.temperature_high_active.expired",
+        expires_after_seconds=300,
+        subject_type="machine",
+    )
+    runner = EpisodeRunner()
+
+    first_batch_boundaries = ConditionEngineRunner().execute(
+        _unclosed_events_df(spark), _conditions_df(spark)
+    )
+    persisted = runner.execute(
+        first_batch_boundaries, episode, evaluation_time=observed_at + timedelta(minutes=10)
+    )
+    assert persisted.collect()[0].status == "expired"
+
+    empty_boundaries = spark.createDataFrame([], events_schema())
+    no_information = runner.execute(
+        empty_boundaries, episode, existing_episodes_df=persisted
+    ).collect()
+    assert no_information == []
+
+    recomputed = runner.execute(
+        empty_boundaries,
+        episode,
+        evaluation_time=observed_at + timedelta(minutes=20),
+        existing_episodes_df=persisted,
+    ).collect()
+    assert len(recomputed) == 1
+    assert recomputed[0].status == "expired"
+    assert recomputed[0].episode_id == persisted.collect()[0].episode_id
+    assert recomputed[0].end_time == observed_at + timedelta(minutes=5)
+    assert recomputed[0].duration_ms == 300000
+
+
+@pytest.mark.requires_spark
+def test_episode_runner_deduplicates_replayed_start_against_persisted_episode(spark):
+    from kindling_ext_temporal import (
+        ConditionEngineRunner,
+        EpisodeMetadata,
+        EpisodeRunner,
+    )
+
+    observed_at = datetime(2026, 7, 14, 12, 0, 0)
+    episode = EpisodeMetadata(
+        episodeid="episode.temperature_high_active",
+        output_entity_id="silver.episodes",
+        events_entity_id="silver.events",
+        start_event="condition.temperature_high.entered",
+        end_event="condition.temperature_high.exited",
+        condition_id="condition.temperature_high",
+        expires_after_seconds=300,
+        subject_type="machine",
+    )
+    runner = EpisodeRunner()
+
+    first_batch_boundaries = ConditionEngineRunner().execute(
+        _unclosed_events_df(spark), _conditions_df(spark)
+    )
+    persisted = runner.execute(
+        first_batch_boundaries, episode, evaluation_time=observed_at + timedelta(minutes=1)
+    )
+    persisted_row = persisted.collect()[0]
+    assert persisted_row.status == "open"
+
+    replayed = runner.execute(
+        first_batch_boundaries,
+        episode,
+        evaluation_time=observed_at + timedelta(minutes=1),
+        existing_episodes_df=persisted,
+    ).collect()
+
+    assert len(replayed) == 1
+    assert replayed[0].episode_id == persisted_row.episode_id
+    assert replayed[0].status == "open"

--- a/tests/system/extensions/temporal/test_temporal_extension.py
+++ b/tests/system/extensions/temporal/test_temporal_extension.py
@@ -176,6 +176,31 @@ def _closed_events_for_machine_2_df(spark):
     )
 
 
+def _late_end_events_for_machine_2_df(spark):
+    from kindling_ext_temporal import events_schema
+
+    cooled_at = datetime(2026, 7, 14, 12, 10, 0)
+    return spark.createDataFrame(
+        [
+            (
+                "source-cool-late",
+                "telemetry.observed",
+                0,
+                "base",
+                "machine",
+                "machine-2",
+                cooled_at,
+                "sensor",
+                None,
+                {"temperature": "80"},
+                None,
+                datetime(2026, 7, 14, 12, 20, 0),
+            ),
+        ],
+        events_schema(),
+    )
+
+
 def _conditions_df(spark):
     from kindling_ext_temporal import conditions_schema
 
@@ -422,3 +447,34 @@ def test_temporal_extension_registers_and_executes_condition_episode_flow(spark)
     assert closure_event_for_same_start.correlation_id == closure_for_same_start.episode_id
     assert closure_event_for_same_start.payload["status"] == "closed"
     assert closure_event_for_same_start.payload["close_reason"] == "end_event"
+
+    late_end_boundary_events = condition_pipe.execute(
+        silver_events=_late_end_events_for_machine_2_df(spark),
+        silver_conditions_current=_conditions_df(spark),
+    )
+    persisted_expired = episode_pipe.execute(
+        silver_events=open_boundary_events,
+        temporal_evaluation_time=datetime(2026, 7, 14, 12, 10, 0),
+    )
+    revised = episode_pipe.execute(
+        silver_events=late_end_boundary_events,
+        silver_episodes=persisted_expired,
+        temporal_evaluation_time=datetime(2026, 7, 14, 12, 25, 0),
+    ).collect()
+    revised_events = episode_event_pipe.execute(
+        silver_events=late_end_boundary_events,
+        silver_episodes=persisted_expired,
+        temporal_evaluation_time=datetime(2026, 7, 14, 12, 25, 0),
+    ).collect()
+
+    assert len(revised) == 1
+    assert revised[0].status == "closed"
+    assert revised[0].close_reason == "end_event"
+    assert revised[0].episode_id == open_episodes[0].episode_id
+    assert revised[0].start_event_id == open_episodes[0].start_event_id
+    assert revised[0].end_event_synthetic is False
+    assert revised[0].end_time == datetime(2026, 7, 14, 12, 10, 0)
+    assert len(revised_events) == 1
+    assert revised_events[0].event_type == "episode.temperature_high_active.closed"
+    assert revised_events[0].correlation_id == revised[0].episode_id
+    assert revised_events[0].payload["status"] == "closed"

--- a/tests/unit/test_data_pipes.py
+++ b/tests/unit/test_data_pipes.py
@@ -8,7 +8,6 @@ from typing import Callable, Dict, List
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
-
 from kindling.data_entities import KindlingNotInitializedError
 from kindling.data_pipes import (
     DataPipes,
@@ -19,6 +18,7 @@ from kindling.data_pipes import (
     EntityReadPersistStrategy,
     PipeMetadata,
     StageProcessingService,
+    self_input_without_state,
 )
 from kindling.injection import GlobalInjector
 
@@ -741,6 +741,7 @@ class TestDataPipesExecuter:
         mock_pipe = Mock(spec=PipeMetadata)
         mock_pipe.pipeid = "test_pipe"
         mock_pipe.input_entity_ids = ["entity1", "entity2"]
+        mock_pipe.output_entity_id = "entity.final"
         mock_pipe.execute = Mock(return_value=mock_result)
 
         # Mock entity reader
@@ -803,6 +804,7 @@ class TestDataPipesExecuter:
         # Mock pipe
         mock_pipe = Mock(spec=PipeMetadata)
         mock_pipe.input_entity_ids = ["entity.one", "entity.two", "entity.three"]
+        mock_pipe.output_entity_id = "entity.final"
 
         # Mock DataFrames
         mock_df1 = Mock()
@@ -1344,3 +1346,121 @@ class TestDataPipesView:
                     output_entity_id="view.orders",
                     sql="SELECT * FROM bronze_orders",
                 )
+
+
+class TestSelfInputWithoutState:
+    """Tests for the self-referential-input first-run guard."""
+
+    def _pipe(self, output_entity_id="entity.out"):
+        pipe = Mock(spec=PipeMetadata)
+        pipe.pipeid = "pipe.self"
+        pipe.output_entity_id = output_entity_id
+        return pipe
+
+    def _provider_registry(self, exists=None, provider=None, raises=None):
+        registry = Mock()
+        if raises is not None:
+            registry.get_provider_for_entity.side_effect = raises
+        else:
+            if provider is None:
+                provider = Mock()
+                provider.check_entity_exists.return_value = exists
+            registry.get_provider_for_entity.return_value = provider
+        return registry
+
+    def test_non_self_input_never_skips(self):
+        registry = self._provider_registry(exists=False)
+        assert (
+            self_input_without_state(self._pipe(), "entity.other", Mock(), registry, Mock())
+            is False
+        )
+        registry.get_provider_for_entity.assert_not_called()
+
+    def test_missing_self_input_skips_read(self):
+        logger = Mock()
+        result = self_input_without_state(
+            self._pipe(), "entity.out", Mock(), self._provider_registry(exists=False), logger
+        )
+        assert result is True
+        logger.info.assert_called_once()
+
+    def test_existing_self_input_reads_normally(self):
+        assert (
+            self_input_without_state(
+                self._pipe(), "entity.out", Mock(), self._provider_registry(exists=True), Mock()
+            )
+            is False
+        )
+
+    def test_no_provider_registry_attempts_read(self):
+        assert self_input_without_state(self._pipe(), "entity.out", Mock(), None, Mock()) is False
+
+    def test_unknown_entity_attempts_read(self):
+        registry = self._provider_registry(exists=False)
+        assert self_input_without_state(self._pipe(), "entity.out", None, registry, Mock()) is False
+
+    def test_provider_without_existence_check_attempts_read(self):
+        registry = self._provider_registry(provider=object())
+        assert (
+            self_input_without_state(self._pipe(), "entity.out", Mock(), registry, Mock()) is False
+        )
+
+    def test_failed_existence_check_attempts_read(self):
+        registry = self._provider_registry(raises=RuntimeError("no storage context"))
+        logger = Mock()
+        assert (
+            self_input_without_state(self._pipe(), "entity.out", Mock(), registry, logger) is False
+        )
+        logger.debug.assert_called_once()
+
+
+class TestPopulateSourceDictSelfInput:
+    """DataPipesExecuter passes None for a missing self-referential input."""
+
+    def _executer(self, provider_registry):
+        logger_provider = Mock()
+        logger_provider.get_logger.return_value = Mock()
+        entity_registry = Mock()
+        entity_registry.get_entity_definition.side_effect = lambda entity_id: Mock(
+            entityid=entity_id
+        )
+        erps = Mock()
+        erps.provider_registry = provider_registry
+        return DataPipesExecuter(logger_provider, entity_registry, Mock(), erps, Mock())
+
+    def _self_reading_pipe(self):
+        pipe = Mock(spec=PipeMetadata)
+        pipe.pipeid = "pipe.self"
+        pipe.input_entity_ids = ["entity.src", "entity.out"]
+        pipe.output_entity_id = "entity.out"
+        pipe.use_watermark = True
+        return pipe
+
+    def test_missing_self_input_becomes_none(self):
+        provider = Mock()
+        provider.check_entity_exists.return_value = False
+        provider_registry = Mock()
+        provider_registry.get_provider_for_entity.return_value = provider
+        executer = self._executer(provider_registry)
+        reader = Mock(return_value=Mock())
+
+        result = executer._populate_source_dict(reader, self._self_reading_pipe())
+
+        assert result["entity_out"] is None
+        assert result["entity_src"] is not None
+        assert reader.call_count == 1
+
+    def test_existing_self_input_is_read(self):
+        provider = Mock()
+        provider.check_entity_exists.return_value = True
+        provider_registry = Mock()
+        provider_registry.get_provider_for_entity.return_value = provider
+        executer = self._executer(provider_registry)
+        src_df, out_df = Mock(), Mock()
+        reader = Mock(side_effect=[src_df, out_df])
+
+        result = executer._populate_source_dict(reader, self._self_reading_pipe())
+
+        assert result["entity_src"] is src_df
+        assert result["entity_out"] is out_df
+        assert reader.call_count == 2

--- a/tests/unit/test_data_pipes.py
+++ b/tests/unit/test_data_pipes.py
@@ -18,7 +18,6 @@ from kindling.data_pipes import (
     EntityReadPersistStrategy,
     PipeMetadata,
     StageProcessingService,
-    self_input_without_state,
 )
 from kindling.injection import GlobalInjector
 
@@ -741,7 +740,6 @@ class TestDataPipesExecuter:
         mock_pipe = Mock(spec=PipeMetadata)
         mock_pipe.pipeid = "test_pipe"
         mock_pipe.input_entity_ids = ["entity1", "entity2"]
-        mock_pipe.output_entity_id = "entity.final"
         mock_pipe.execute = Mock(return_value=mock_result)
 
         # Mock entity reader
@@ -804,7 +802,6 @@ class TestDataPipesExecuter:
         # Mock pipe
         mock_pipe = Mock(spec=PipeMetadata)
         mock_pipe.input_entity_ids = ["entity.one", "entity.two", "entity.three"]
-        mock_pipe.output_entity_id = "entity.final"
 
         # Mock DataFrames
         mock_df1 = Mock()
@@ -1346,121 +1343,3 @@ class TestDataPipesView:
                     output_entity_id="view.orders",
                     sql="SELECT * FROM bronze_orders",
                 )
-
-
-class TestSelfInputWithoutState:
-    """Tests for the self-referential-input first-run guard."""
-
-    def _pipe(self, output_entity_id="entity.out"):
-        pipe = Mock(spec=PipeMetadata)
-        pipe.pipeid = "pipe.self"
-        pipe.output_entity_id = output_entity_id
-        return pipe
-
-    def _provider_registry(self, exists=None, provider=None, raises=None):
-        registry = Mock()
-        if raises is not None:
-            registry.get_provider_for_entity.side_effect = raises
-        else:
-            if provider is None:
-                provider = Mock()
-                provider.check_entity_exists.return_value = exists
-            registry.get_provider_for_entity.return_value = provider
-        return registry
-
-    def test_non_self_input_never_skips(self):
-        registry = self._provider_registry(exists=False)
-        assert (
-            self_input_without_state(self._pipe(), "entity.other", Mock(), registry, Mock())
-            is False
-        )
-        registry.get_provider_for_entity.assert_not_called()
-
-    def test_missing_self_input_skips_read(self):
-        logger = Mock()
-        result = self_input_without_state(
-            self._pipe(), "entity.out", Mock(), self._provider_registry(exists=False), logger
-        )
-        assert result is True
-        logger.info.assert_called_once()
-
-    def test_existing_self_input_reads_normally(self):
-        assert (
-            self_input_without_state(
-                self._pipe(), "entity.out", Mock(), self._provider_registry(exists=True), Mock()
-            )
-            is False
-        )
-
-    def test_no_provider_registry_attempts_read(self):
-        assert self_input_without_state(self._pipe(), "entity.out", Mock(), None, Mock()) is False
-
-    def test_unknown_entity_attempts_read(self):
-        registry = self._provider_registry(exists=False)
-        assert self_input_without_state(self._pipe(), "entity.out", None, registry, Mock()) is False
-
-    def test_provider_without_existence_check_attempts_read(self):
-        registry = self._provider_registry(provider=object())
-        assert (
-            self_input_without_state(self._pipe(), "entity.out", Mock(), registry, Mock()) is False
-        )
-
-    def test_failed_existence_check_attempts_read(self):
-        registry = self._provider_registry(raises=RuntimeError("no storage context"))
-        logger = Mock()
-        assert (
-            self_input_without_state(self._pipe(), "entity.out", Mock(), registry, logger) is False
-        )
-        logger.debug.assert_called_once()
-
-
-class TestPopulateSourceDictSelfInput:
-    """DataPipesExecuter passes None for a missing self-referential input."""
-
-    def _executer(self, provider_registry):
-        logger_provider = Mock()
-        logger_provider.get_logger.return_value = Mock()
-        entity_registry = Mock()
-        entity_registry.get_entity_definition.side_effect = lambda entity_id: Mock(
-            entityid=entity_id
-        )
-        erps = Mock()
-        erps.provider_registry = provider_registry
-        return DataPipesExecuter(logger_provider, entity_registry, Mock(), erps, Mock())
-
-    def _self_reading_pipe(self):
-        pipe = Mock(spec=PipeMetadata)
-        pipe.pipeid = "pipe.self"
-        pipe.input_entity_ids = ["entity.src", "entity.out"]
-        pipe.output_entity_id = "entity.out"
-        pipe.use_watermark = True
-        return pipe
-
-    def test_missing_self_input_becomes_none(self):
-        provider = Mock()
-        provider.check_entity_exists.return_value = False
-        provider_registry = Mock()
-        provider_registry.get_provider_for_entity.return_value = provider
-        executer = self._executer(provider_registry)
-        reader = Mock(return_value=Mock())
-
-        result = executer._populate_source_dict(reader, self._self_reading_pipe())
-
-        assert result["entity_out"] is None
-        assert result["entity_src"] is not None
-        assert reader.call_count == 1
-
-    def test_existing_self_input_is_read(self):
-        provider = Mock()
-        provider.check_entity_exists.return_value = True
-        provider_registry = Mock()
-        provider_registry.get_provider_for_entity.return_value = provider
-        executer = self._executer(provider_registry)
-        src_df, out_df = Mock(), Mock()
-        reader = Mock(side_effect=[src_df, out_df])
-
-        result = executer._populate_source_dict(reader, self._self_reading_pipe())
-
-        assert result["entity_src"] is src_df
-        assert result["entity_out"] is out_df
-        assert reader.call_count == 2

--- a/tests/unit/test_pipe_graph.py
+++ b/tests/unit/test_pipe_graph.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from unittest.mock import MagicMock, Mock
 
 import pytest
-
 from kindling.data_pipes import PipeMetadata
 from kindling.pipe_graph import (
     GraphCycleError,
@@ -283,17 +282,26 @@ class TestPipeGraphBuilder:
         assert "pipe1" in str(exc_info.value)
         assert "pipe2" in str(exc_info.value)
 
-    def test_detect_self_cycle(self, builder, mock_registry):
-        """Test detecting a self-referencing cycle."""
-        # pipe1 -> pipe1 (self-loop via entity)
+    def test_self_read_is_prior_state_not_a_cycle(self, builder, mock_registry):
+        """A pipe reading its own output entity builds without a cycle.
+
+        Reading your own output consumes the previous run's persisted state
+        (e.g. temporal episode revision) — it cannot be satisfied by
+        scheduling, so no self-edge is created and ordering edges to other
+        pipes are preserved.
+        """
         mock_registry.pipe_defs = {
-            "pipe1": self.create_pipe_metadata("pipe1", ["entity.a"], "entity.a"),
+            "pipe0": self.create_pipe_metadata("pipe0", [], "entity.src"),
+            "pipe1": self.create_pipe_metadata("pipe1", ["entity.src", "entity.a"], "entity.a"),
+            "pipe2": self.create_pipe_metadata("pipe2", ["entity.a"], "entity.b"),
         }
 
-        with pytest.raises(GraphCycleError) as exc_info:
-            builder.build_graph(["pipe1"])
+        graph = builder.build_graph(["pipe0", "pipe1", "pipe2"])
 
-        assert "pipe1" in str(exc_info.value)
+        assert len(graph.edges) == 2
+        assert all(edge.from_pipe != edge.to_pipe for edge in graph.edges)
+        assert graph.get_root_nodes() == ["pipe0"]
+        assert graph.get_leaf_nodes() == ["pipe2"]
 
     def test_detect_complex_cycle(self, builder, mock_registry):
         """Test detecting a cycle in a complex graph."""

--- a/tests/unit/test_temporal_extension.py
+++ b/tests/unit/test_temporal_extension.py
@@ -304,17 +304,18 @@ def test_episode_registration_uses_canonical_entities():
     assert entity_registry.get_entity_definition("silver.episodes") is not None
 
     pipe = pipe_registry.get_pipe_definition("temporal.episode.episode.machine_cycle")
-    assert pipe.input_entity_ids == ["silver.events"]
+    assert pipe.input_entity_ids == ["silver.events", "silver.episodes"]
     assert pipe.output_entity_id == "silver.episodes"
     assert pipe.output_type == "delta"
     assert pipe.use_watermark is True
     assert pipe.tags["pipe_type"] == "temporal.episode"
     assert pipe.tags["temporal.start_event"] == "condition.machine_running.entered"
     assert pipe.tags["temporal.end_event"] == "condition.machine_running.exited"
+    assert pipe.tags["temporal.revise_persisted"] == "true"
     assert callable(pipe.execute)
 
     event_pipe = pipe_registry.get_pipe_definition("temporal.episode_event.episode.machine_cycle")
-    assert event_pipe.input_entity_ids == ["silver.events"]
+    assert event_pipe.input_entity_ids == ["silver.events", "silver.episodes"]
     assert event_pipe.output_entity_id == "silver.events"
     assert event_pipe.output_type == "delta"
     assert event_pipe.use_watermark is True
@@ -367,6 +368,42 @@ def test_episode_registration_accepts_explicit_determination_event_and_pipe_id()
     assert event_pipe.tags["temporal.event_type"] == "episode.machine_cycle.completed"
     assert event_pipe.tags["temporal.expiration_event_type"] == "episode.machine_cycle.timed_out"
     assert event_pipe.tags["temporal.invalidation_event_type"] == "episode.machine_cycle.rejected"
+
+
+def test_episode_registration_can_opt_out_of_persisted_revision():
+    from kindling.data_entities import DataEntityManager
+    from kindling.data_pipes import DataPipesManager
+    from kindling_ext_temporal import DataEpisodes, TemporalEpisodeRegistryManager
+
+    DataEpisodes.reset()
+    registry = TemporalEpisodeRegistryManager(_logger_provider())
+    entity_registry = DataEntityManager()
+    pipe_registry = DataPipesManager(_logger_provider())
+
+    with patch(
+        "kindling.injection.GlobalInjector.get",
+        side_effect=_temporal_service_get(
+            episode_registry=registry,
+            entity_registry=entity_registry,
+            pipe_registry=pipe_registry,
+        ),
+    ):
+        DataEpisodes.episode(
+            episodeid="episode.machine_cycle",
+            start_event="condition.machine_running.entered",
+            end_event="condition.machine_running.exited",
+            revise_persisted=False,
+        )
+
+    metadata = registry.get_episode_definition("episode.machine_cycle")
+    assert metadata.revise_persisted is False
+
+    pipe = pipe_registry.get_pipe_definition("temporal.episode.episode.machine_cycle")
+    assert pipe.input_entity_ids == ["silver.events"]
+    assert pipe.tags["temporal.revise_persisted"] == "false"
+
+    event_pipe = pipe_registry.get_pipe_definition("temporal.episode_event.episode.machine_cycle")
+    assert event_pipe.input_entity_ids == ["silver.events"]
 
 
 def test_translator_evaluation_time_prefers_execution_parameter():

--- a/tests/unit/test_temporal_extension.py
+++ b/tests/unit/test_temporal_extension.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -304,18 +304,19 @@ def test_episode_registration_uses_canonical_entities():
     assert entity_registry.get_entity_definition("silver.episodes") is not None
 
     pipe = pipe_registry.get_pipe_definition("temporal.episode.episode.machine_cycle")
-    assert pipe.input_entity_ids == ["silver.events", "silver.episodes"]
+    assert pipe.input_entity_ids == ["silver.events"]
     assert pipe.output_entity_id == "silver.episodes"
     assert pipe.output_type == "delta"
     assert pipe.use_watermark is True
     assert pipe.tags["pipe_type"] == "temporal.episode"
     assert pipe.tags["temporal.start_event"] == "condition.machine_running.entered"
     assert pipe.tags["temporal.end_event"] == "condition.machine_running.exited"
-    assert pipe.tags["temporal.revise_persisted"] == "true"
+    assert pipe.tags["temporal.reads_prior_state"] == "true"
     assert callable(pipe.execute)
 
     event_pipe = pipe_registry.get_pipe_definition("temporal.episode_event.episode.machine_cycle")
-    assert event_pipe.input_entity_ids == ["silver.events", "silver.episodes"]
+    assert event_pipe.input_entity_ids == ["silver.events"]
+    assert event_pipe.tags["temporal.reads_prior_state"] == "true"
     assert event_pipe.output_entity_id == "silver.events"
     assert event_pipe.output_type == "delta"
     assert event_pipe.use_watermark is True
@@ -370,40 +371,131 @@ def test_episode_registration_accepts_explicit_determination_event_and_pipe_id()
     assert event_pipe.tags["temporal.invalidation_event_type"] == "episode.machine_cycle.rejected"
 
 
-def test_episode_registration_can_opt_out_of_persisted_revision():
-    from kindling.data_entities import DataEntityManager
-    from kindling.data_pipes import DataPipesManager
-    from kindling_ext_temporal import DataEpisodes, TemporalEpisodeRegistryManager
+def _episode_metadata_for_resolution():
+    from kindling_ext_temporal import EpisodeMetadata
 
-    DataEpisodes.reset()
-    registry = TemporalEpisodeRegistryManager(_logger_provider())
-    entity_registry = DataEntityManager()
-    pipe_registry = DataPipesManager(_logger_provider())
+    return EpisodeMetadata(
+        episodeid="episode.machine_cycle",
+        output_entity_id="silver.episodes",
+        events_entity_id="silver.events",
+        start_event="condition.machine_running.entered",
+        end_event="condition.machine_running.exited",
+    )
+
+
+def test_translator_prior_episodes_prefers_execution_parameter():
+    from kindling_ext_temporal import TemporalPipeTranslator
+
+    state_df = object()
+    with patch("kindling.injection.GlobalInjector.get") as injector_get:
+        resolved = TemporalPipeTranslator.resolve_prior_episodes(
+            {"silver_events": None, "silver_episodes": state_df},
+            _episode_metadata_for_resolution(),
+        )
+
+    assert resolved is state_df
+    injector_get.assert_not_called()
+
+
+def test_translator_prior_episodes_reads_existing_entity_through_provider():
+    from kindling.data_entities import DataEntityRegistry
+    from kindling.entity_provider_registry import EntityProviderRegistry
+    from kindling.spark_config import ConfigService
+    from kindling_ext_temporal import TemporalPipeTranslator
+
+    state_df = object()
+    entity = Mock(entityid="silver.episodes")
+    entity_registry = Mock()
+    entity_registry.get_entity_definition.return_value = entity
+    provider = Mock()
+    provider.check_entity_exists.return_value = True
+    provider.read_entity.return_value = state_df
+    provider_registry = Mock()
+    provider_registry.get_provider_for_entity.return_value = provider
+    config_service = Mock()
+    config_service.get.return_value = True
+
+    def _get(dep):
+        if dep is ConfigService:
+            return config_service
+        if dep is DataEntityRegistry:
+            return entity_registry
+        if dep is EntityProviderRegistry:
+            return provider_registry
+        raise AssertionError(f"Unexpected service request: {dep}")
+
+    with patch("kindling.injection.GlobalInjector.get", side_effect=_get):
+        resolved = TemporalPipeTranslator.resolve_prior_episodes(
+            {"silver_events": None}, _episode_metadata_for_resolution()
+        )
+
+    assert resolved is state_df
+    config_service.get.assert_called_once_with("kindling.temporal.revise_persisted", True)
+    provider.read_entity.assert_called_once_with(entity)
+
+
+def test_translator_prior_episodes_none_when_entity_missing_or_disabled():
+    from kindling.data_entities import DataEntityRegistry
+    from kindling.entity_provider_registry import EntityProviderRegistry
+    from kindling.spark_config import ConfigService
+    from kindling_ext_temporal import TemporalPipeTranslator
+
+    entity_registry = Mock()
+    entity_registry.get_entity_definition.return_value = Mock(entityid="silver.episodes")
+    provider = Mock()
+    provider.check_entity_exists.return_value = False
+    provider_registry = Mock()
+    provider_registry.get_provider_for_entity.return_value = provider
+
+    def _get_enabled(dep):
+        if dep is ConfigService:
+            service = Mock()
+            service.get.return_value = True
+            return service
+        if dep is DataEntityRegistry:
+            return entity_registry
+        if dep is EntityProviderRegistry:
+            return provider_registry
+        raise AssertionError(f"Unexpected service request: {dep}")
+
+    with patch("kindling.injection.GlobalInjector.get", side_effect=_get_enabled):
+        assert (
+            TemporalPipeTranslator.resolve_prior_episodes(
+                {"silver_events": None}, _episode_metadata_for_resolution()
+            )
+            is None
+        )
+    provider.read_entity.assert_not_called()
+
+    def _get_disabled(dep):
+        if dep is ConfigService:
+            service = Mock()
+            service.get.return_value = "false"
+            return service
+        raise AssertionError(f"Unexpected service request: {dep}")
+
+    with patch("kindling.injection.GlobalInjector.get", side_effect=_get_disabled):
+        assert (
+            TemporalPipeTranslator.resolve_prior_episodes(
+                {"silver_events": None}, _episode_metadata_for_resolution()
+            )
+            is None
+        )
+
+
+def test_translator_prior_episodes_none_without_bound_services():
+    from kindling_ext_temporal import TemporalPipeTranslator
 
     with patch(
         "kindling.injection.GlobalInjector.get",
-        side_effect=_temporal_service_get(
-            episode_registry=registry,
-            entity_registry=entity_registry,
-            pipe_registry=pipe_registry,
-        ),
+        side_effect=RuntimeError("no bindings"),
     ):
-        DataEpisodes.episode(
-            episodeid="episode.machine_cycle",
-            start_event="condition.machine_running.entered",
-            end_event="condition.machine_running.exited",
-            revise_persisted=False,
+        assert (
+            TemporalPipeTranslator.resolve_prior_episodes(
+                {"silver_events": None}, _episode_metadata_for_resolution()
+            )
+            is None
         )
-
-    metadata = registry.get_episode_definition("episode.machine_cycle")
-    assert metadata.revise_persisted is False
-
-    pipe = pipe_registry.get_pipe_definition("temporal.episode.episode.machine_cycle")
-    assert pipe.input_entity_ids == ["silver.events"]
-    assert pipe.tags["temporal.revise_persisted"] == "false"
-
-    event_pipe = pipe_registry.get_pipe_definition("temporal.episode_event.episode.machine_cycle")
-    assert event_pipe.input_entity_ids == ["silver.events"]
 
 
 def test_translator_evaluation_time_prefers_execution_parameter():


### PR DESCRIPTION
## Summary

Implements stateful late real-end revision of persisted episodes — the top item on the temporal extension's not-yet-implemented list, and MVP item 9's incremental semantics.

An incremental (watermarked) batch that contains only a late real end event previously could not revise an episode whose start was consumed by an earlier batch: pairing needs the start boundary, and the persisted expired/invalidated row was final. Now:

- the episode engine resolves its **own prior state at execution time** — prior state is an execution-strategy concern the extension owns, not a declared dataflow dependency. Resolution order: JIT keyword argument named after the episodes entity (tests/manual runs) → `kindling.temporal.revise_persisted` config switch (default on) → provider read guarded by `check_entity_exists`. A first run proceeds with no prior state by construction; pipes declare only `silver.events` as input and carry a `temporal.reads_prior_state` lineage tag
- `EpisodeRunner` reconstructs start-boundary events for persisted **open, expired, and synthetically-invalidated** episodes (deduplicated, and deduplicated against batch starts by `event_id`), so a late real end pairs, wins over the synthetic end, and re-emits the episode with the same `episode_id`
- the entity's `merge_columns=["episode_id"]` upsert turns the re-emit into an in-place revision; corrective determination events (e.g. `.closed` after an earlier `.expired`) are emitted alongside the historical ones
- episodes ended by a **real** end event are terminal and never revised
- a batch with no new events and no evaluation time emits nothing for reconstructed episodes — persisted lifecycle state never regresses
- `start_generation` is a real column on the episodes schema (additive), so determination-event generation arithmetic survives across batches; legacy tables without the column reconstruct at generation 1

Core change: `PipeGraphBuilder` no longer reports a pipe reading its own output entity as a one-node cycle — that read is prior-state feedback and cannot be satisfied by scheduling. Cross-pipe cycles are still detected. (This unblocks the determination-event pipe from #164, which reads and writes `silver.events`.)

This shape keeps the one genuinely engine-constrained piece of temporal — episode lifecycle revision (keyed merge/upsert) — contained in the extension, per `kindling_core_runner_split.md` and `declarative_pipelines_engine.md`, instead of leaking flags and self-referential inputs into declarations and executers.

## Coverage

- unit: pipe input/tag wiring, prior-state resolution order (JIT param, config off-switch, provider read, unbound-services fallback), self-read graph construction (roots/leaves/edge count)
- integration: late real end revises expired episode (same `episode_id`, corrective `.closed` event, generation 2); in-bounds late end revises a max-duration-invalidated episode; no-regression on empty batches; replayed-start dedup; legacy-schema (no `start_generation` column) revision
- system: registered pipes revise a persisted expired episode via the `silver_episodes` JIT input through condition → episode → episode-event flow

## Validation

- `poe test-unit` (1741 passed, 1 skipped — matplotlib not installed locally)
- `poe test-integration --path tests/integration/test_temporal_extension_integration.py` (109 passed, 1 skipped)
- `poe test-extension --extension temporal` (1 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
