### PR TITLE
feat(temporal): validated conditions ingestion with per-row quarantine

### DIFF
--- a/packages/extensions/kindling_ext_temporal/README.md
+++ b/packages/extensions/kindling_ext_temporal/README.md
@@ -44,6 +44,14 @@ complete temporal-processing system described in the white paper and proposal.
   re-emit into an in-place revision; a batch with no new events and no
   evaluation time emits nothing for reconstructed episodes so persisted state
   never regresses;
+- validated conditions ingestion: `ingest_conditions` validates rule rows per
+  row (Spark SQL expression parsing, event-type graph cycle rejection),
+  quarantines rejects (returned, and appended to
+  `kindling.temporal.conditions.quarantine_entity_id` when configured), and
+  upserts the well-formed rows — including disabled ones — through the
+  conditions entity's SCD2 merge; `validated_conditions_transform` gates a
+  `FileIngestion` file-drop entry with the same validation, rejecting a file
+  whole on any invalid row;
 - unit, integration, and system coverage for the first executable slice.
 
 ## Configuration
@@ -56,6 +64,10 @@ complete temporal-processing system described in the white paper and proposal.
 - `kindling.temporal.revise_persisted` — set to `false` to disable the prior
   episode-state read entirely; episode pipes then compute a pure batch view.
   Defaults to enabled.
+- `kindling.temporal.conditions.quarantine_entity_id` — optional entity id for
+  rejected condition rows; when set, `ingest_conditions` appends quarantined
+  rows (condition id, errors, raw row, timestamp) there. Unset: rejects are
+  only returned in the ingestion result.
 
 ## Revision semantics
 
@@ -113,4 +125,5 @@ mistaken for a full implementation:
 - aggregation, correlation, and inference-derived event paths;
 - cloud platform persistence/orchestration coverage beyond the local system
   test path;
+- a `kindling conditions set/remove` CLI on top of `ingest_conditions`;
 - production examples and operator documentation.

--- a/packages/extensions/kindling_ext_temporal/README.md
+++ b/packages/extensions/kindling_ext_temporal/README.md
@@ -45,8 +45,9 @@ complete temporal-processing system described in the white paper and proposal.
   evaluation time emits nothing for reconstructed episodes so persisted state
   never regresses;
 - validated conditions ingestion: `ingest_conditions` validates rule rows per
-  row (Spark SQL expression parsing, event-type graph cycle rejection),
-  quarantines rejects (returned, and appended to
+  row (Spark SQL expression parsing, event-type graph cycle rejection,
+  duplicate `condition_id`s within a batch), quarantines rejects (returned,
+  and appended to
   `kindling.temporal.conditions.quarantine_entity_id` when configured), and
   upserts the well-formed rows — including disabled ones — through the
   conditions entity's SCD2 merge; `validated_conditions_transform` gates a

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/__init__.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/__init__.py
@@ -1,9 +1,16 @@
 """Temporal event, condition, and episode primitives for Kindling."""
 
+from .conditions import (
+    QUARANTINE_ENTITY_CONFIG_KEY,
+    ConditionsIngestionResult,
+    ingest_conditions,
+    validated_conditions_transform,
+)
 from .engine import ConditionEngineRunner, EpisodeRunner
 from .entities import (
     SimpleTemporalEntityResolver,
     TemporalEntityResolver,
+    condition_quarantine_schema,
     conditions_schema,
     episodes_schema,
     events_schema,
@@ -37,6 +44,8 @@ __all__ = [
     "ConditionRule",
     "ConditionValidationError",
     "ConditionValidationReport",
+    "ConditionsIngestionResult",
+    "QUARANTINE_ENTITY_CONFIG_KEY",
     "DataEpisodes",
     "DataEvents",
     "EpisodeMetadata",
@@ -50,9 +59,12 @@ __all__ = [
     "TemporalEventRegistry",
     "TemporalEventRegistryManager",
     "TemporalPipeTranslator",
+    "condition_quarantine_schema",
     "conditions_schema",
     "episodes_schema",
     "events_schema",
+    "ingest_conditions",
+    "validated_conditions_transform",
 ]
 
 __version__ = "0.1.0"
@@ -61,7 +73,6 @@ __version__ = "0.1.0"
 def _register_services():
     """Register extension services with Kindling's DI container."""
     from injector import singleton
-
     from kindling.injection import GlobalInjector
 
     injector = GlobalInjector.get_injector()

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/conditions.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/conditions.py
@@ -1,0 +1,172 @@
+"""Validated ingestion for `silver.conditions` (proposal MVP items 1 and 2).
+
+Conditions are rules-as-data: adding, modifying, or removing one is an
+ordinary SCD2 upsert through whichever path feeds the table (file drop, CLI,
+notebook, another pipeline). What this module adds is the required
+validation pass in front of that upsert — a bad `enter_when` must not pass
+silently into the table where a bad Python expression would never survive
+code review.
+
+`ingest_conditions` validates per row and quarantines rejects: well-formed
+rows (including disabled ones — `enabled` is row state the engine filters at
+read time) merge into the conditions entity, malformed rows are returned and,
+when `kindling.temporal.conditions.quarantine_entity_id` is configured,
+appended to the quarantine entity. Event-type graph cycles are set-level
+inconsistencies — no subset ingest is well-defined — so they raise instead.
+
+`validated_conditions_transform` is the file-drop hook: attach it as the
+transform of a `FileIngestion` entry targeting the conditions entity and a
+file containing any invalid row is rejected whole (the file path has no
+per-row quarantine channel; use `ingest_conditions` for that).
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+from .entities import condition_quarantine_schema
+from .validation import (
+    ConditionValidationError,
+    InvalidCondition,
+    TemporalConditionValidator,
+)
+
+QUARANTINE_ENTITY_CONFIG_KEY = "kindling.temporal.conditions.quarantine_entity_id"
+
+
+@dataclass(frozen=True)
+class ConditionsIngestionResult:
+    ingested_count: int
+    quarantined: List[InvalidCondition] = field(default_factory=list)
+    quarantine_entity_id: Optional[str] = None
+
+    @property
+    def is_clean(self) -> bool:
+        return not self.quarantined
+
+
+def _resolve_quarantine_entity_id() -> Optional[str]:
+    try:
+        from kindling.injection import GlobalInjector
+        from kindling.spark_config import ConfigService
+
+        value = GlobalInjector.get(ConfigService).get(QUARANTINE_ENTITY_CONFIG_KEY, None)
+        return str(value).strip() or None if value is not None else None
+    except Exception:
+        return None
+
+
+def _conditions_entity(resolver=None):
+    if resolver is None:
+        from kindling.injection import GlobalInjector
+
+        from .entities import TemporalEntityResolver
+
+        resolver = GlobalInjector.get(TemporalEntityResolver)
+    return resolver.get_conditions_entity()
+
+
+def _provider_for(entity):
+    from kindling.entity_provider_registry import EntityProviderRegistry
+    from kindling.injection import GlobalInjector
+
+    return GlobalInjector.get(EntityProviderRegistry).get_provider_for_entity(entity)
+
+
+def _write_quarantine(spark, invalids, quarantine_entity_id, provider_factory):
+    from kindling.data_entities import EntityMetadata
+    from pyspark.sql import functions as F
+
+    entity = EntityMetadata(
+        entityid=quarantine_entity_id,
+        name=quarantine_entity_id.split(".")[-1],
+        merge_columns=[],
+        tags={"provider_type": "delta", "temporal.kind": "conditions_quarantine"},
+        schema=condition_quarantine_schema(),
+        partition_columns=[],
+    )
+    rows = [
+        (
+            invalid.condition_id or None,
+            list(invalid.errors),
+            None if invalid.row is None else repr(invalid.row.asDict(recursive=True)),
+        )
+        for invalid in invalids
+    ]
+    df = spark.createDataFrame(rows, condition_quarantine_schema()).withColumn(
+        "quarantined_at", F.current_timestamp()
+    )
+    provider_factory(entity).append_to_entity(df, entity)
+
+
+def ingest_conditions(
+    conditions_df,
+    *,
+    validator: Optional[TemporalConditionValidator] = None,
+    resolver=None,
+    provider_factory=None,
+    quarantine_entity_id: Optional[str] = None,
+) -> ConditionsIngestionResult:
+    """Validate condition rows per row, quarantine rejects, upsert the rest.
+
+    The conditions set is small by design (tens to low hundreds — the same
+    assumption the condition engine's driver-side loop makes), so rows are
+    collected and validated on the driver. Graph cycles raise
+    ConditionValidationError: a cyclic set has no ingestible subset.
+
+    Keyword arguments are JIT overrides for tests and manual runs; defaults
+    resolve through the injector (TemporalEntityResolver, the provider
+    registry) and the `kindling.temporal.conditions.quarantine_entity_id`
+    config key.
+    """
+    from .validation import ActiveSparkSqlExpressionParser
+
+    rows = conditions_df.collect()
+    validator = validator or TemporalConditionValidator(
+        expression_parser=ActiveSparkSqlExpressionParser(conditions_df.sparkSession)
+    )
+    report = validator.validate(rows)
+
+    set_level = [invalid for invalid in report.invalid_conditions if invalid.row is None]
+    if set_level:
+        raise ConditionValidationError(
+            "Conditions set is not ingestible:\n"
+            + "\n".join("; ".join(invalid.errors) for invalid in set_level)
+        )
+
+    invalid_row_ids = {id(invalid.row) for invalid in report.invalid_conditions}
+    valid_rows = [row for row in rows if id(row) not in invalid_row_ids]
+
+    provider_factory = provider_factory or _provider_for
+    if valid_rows:
+        entity = _conditions_entity(resolver)
+        valid_df = conditions_df.sparkSession.createDataFrame(valid_rows, conditions_df.schema)
+        provider_factory(entity).merge_to_entity(valid_df, entity)
+
+    quarantined = list(report.invalid_conditions)
+    quarantine_entity_id = quarantine_entity_id or _resolve_quarantine_entity_id()
+    if quarantined and quarantine_entity_id:
+        _write_quarantine(
+            conditions_df.sparkSession, quarantined, quarantine_entity_id, provider_factory
+        )
+
+    return ConditionsIngestionResult(
+        ingested_count=len(valid_rows),
+        quarantined=quarantined,
+        quarantine_entity_id=quarantine_entity_id if quarantined else None,
+    )
+
+
+def validated_conditions_transform(df: Any) -> Any:
+    """File-ingestion transform: reject the whole file on any invalid row.
+
+    Attach to a FileIngestion entry whose dest entity is the conditions
+    entity; the standard file path then persists only files that validate
+    clean. Per-row quarantine needs `ingest_conditions` instead.
+    """
+    from .validation import ActiveSparkSqlExpressionParser
+
+    validator = TemporalConditionValidator(
+        expression_parser=ActiveSparkSqlExpressionParser(df.sparkSession)
+    )
+    validator.validate_or_raise(df.collect())
+    return df

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/conditions.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/conditions.py
@@ -20,8 +20,13 @@ file containing any invalid row is rejected whole (the file path has no
 per-row quarantine channel; use `ingest_conditions` for that).
 """
 
+import json
+import logging
+from collections import Counter
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
+
+from kindling.sentinels import UNSET
 
 from .entities import condition_quarantine_schema
 from .validation import (
@@ -31,6 +36,8 @@ from .validation import (
 )
 
 QUARANTINE_ENTITY_CONFIG_KEY = "kindling.temporal.conditions.quarantine_entity_id"
+
+_logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -88,7 +95,11 @@ def _write_quarantine(spark, invalids, quarantine_entity_id, provider_factory):
         (
             invalid.condition_id or None,
             list(invalid.errors),
-            None if invalid.row is None else repr(invalid.row.asDict(recursive=True)),
+            (
+                None
+                if invalid.row is None
+                else json.dumps(invalid.row.asDict(recursive=True), default=str)
+            ),
         )
         for invalid in invalids
     ]
@@ -104,27 +115,49 @@ def ingest_conditions(
     validator: Optional[TemporalConditionValidator] = None,
     resolver=None,
     provider_factory=None,
-    quarantine_entity_id: Optional[str] = None,
+    quarantine_entity_id: Any = UNSET,
 ) -> ConditionsIngestionResult:
     """Validate condition rows per row, quarantine rejects, upsert the rest.
 
     The conditions set is small by design (tens to low hundreds — the same
     assumption the condition engine's driver-side loop makes), so rows are
     collected and validated on the driver. Graph cycles raise
-    ConditionValidationError: a cyclic set has no ingestible subset.
+    ConditionValidationError: a cyclic set has no ingestible subset. Rows
+    sharing a condition_id within one batch are all quarantined — the entity
+    declares no scd.sequence_by, so which duplicate should win is undefined
+    and the SCD2 merge would reject the batch far less legibly.
 
     Keyword arguments are JIT overrides for tests and manual runs; defaults
     resolve through the injector (TemporalEntityResolver, the provider
     registry) and the `kindling.temporal.conditions.quarantine_entity_id`
-    config key.
+    config key. Pass ``quarantine_entity_id=None`` to disable the quarantine
+    write even when config names an entity.
     """
     from .validation import ActiveSparkSqlExpressionParser
 
     rows = conditions_df.collect()
+
+    id_counts = Counter(getattr(row, "condition_id", None) for row in rows)
+    duplicates = [
+        InvalidCondition(
+            condition_id=row.condition_id,
+            errors=[
+                f"condition_id '{row.condition_id}' appears "
+                f"{id_counts[row.condition_id]} times in this batch — which "
+                "version wins is undefined (the entity has no scd.sequence_by)"
+            ],
+            row=row,
+        )
+        for row in rows
+        if getattr(row, "condition_id", None) is not None and id_counts[row.condition_id] > 1
+    ]
+    duplicate_row_ids = {id(invalid.row) for invalid in duplicates}
+    candidate_rows = [row for row in rows if id(row) not in duplicate_row_ids]
+
     validator = validator or TemporalConditionValidator(
         expression_parser=ActiveSparkSqlExpressionParser(conditions_df.sparkSession)
     )
-    report = validator.validate(rows)
+    report = validator.validate(candidate_rows)
 
     set_level = [invalid for invalid in report.invalid_conditions if invalid.row is None]
     if set_level:
@@ -134,7 +167,7 @@ def ingest_conditions(
         )
 
     invalid_row_ids = {id(invalid.row) for invalid in report.invalid_conditions}
-    valid_rows = [row for row in rows if id(row) not in invalid_row_ids]
+    valid_rows = [row for row in candidate_rows if id(row) not in invalid_row_ids]
 
     provider_factory = provider_factory or _provider_for
     if valid_rows:
@@ -142,12 +175,22 @@ def ingest_conditions(
         valid_df = conditions_df.sparkSession.createDataFrame(valid_rows, conditions_df.schema)
         provider_factory(entity).merge_to_entity(valid_df, entity)
 
-    quarantined = list(report.invalid_conditions)
-    quarantine_entity_id = quarantine_entity_id or _resolve_quarantine_entity_id()
+    quarantined = duplicates + list(report.invalid_conditions)
+    if quarantine_entity_id is UNSET:
+        quarantine_entity_id = _resolve_quarantine_entity_id()
     if quarantined and quarantine_entity_id:
-        _write_quarantine(
-            conditions_df.sparkSession, quarantined, quarantine_entity_id, provider_factory
-        )
+        try:
+            _write_quarantine(
+                conditions_df.sparkSession, quarantined, quarantine_entity_id, provider_factory
+            )
+        except Exception:
+            _logger.warning(
+                "Quarantine write to '%s' failed after a successful conditions "
+                "merge; rejected rows are only in the returned result",
+                quarantine_entity_id,
+                exc_info=True,
+            )
+            quarantine_entity_id = None
 
     return ConditionsIngestionResult(
         ingested_count=len(valid_rows),

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/entities.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/entities.py
@@ -54,6 +54,17 @@ def conditions_schema() -> StructType:
     )
 
 
+def condition_quarantine_schema() -> StructType:
+    """Schema for rejected condition rows (validation quarantine)."""
+    return StructType(
+        [
+            StructField("condition_id", StringType(), True),
+            StructField("errors", ArrayType(StringType(), False), False),
+            StructField("raw_row", StringType(), True),
+        ]
+    )
+
+
 def episodes_schema() -> StructType:
     """Return the canonical episode schema."""
     return StructType(

--- a/tests/integration/test_temporal_extension_integration.py
+++ b/tests/integration/test_temporal_extension_integration.py
@@ -864,3 +864,191 @@ def test_episode_runner_deduplicates_replayed_start_against_persisted_episode(sp
     assert len(replayed) == 1
     assert replayed[0].episode_id == persisted_row.episode_id
     assert replayed[0].status == "open"
+
+
+class _RecordingProvider:
+    def __init__(self):
+        self.merged = []
+        self.appended = []
+
+    def merge_to_entity(self, df, entity):
+        self.merged.append((df, entity))
+
+    def append_to_entity(self, df, entity):
+        self.appended.append((df, entity))
+
+
+def _conditions_rows_df(spark, rows):
+    from kindling_ext_temporal import conditions_schema
+
+    return spark.createDataFrame(rows, conditions_schema())
+
+
+@pytest.mark.requires_spark
+def test_ingest_conditions_upserts_valid_rows_and_quarantines_invalid(spark):
+    from kindling_ext_temporal import SimpleTemporalEntityResolver, ingest_conditions
+
+    observed_at = datetime(2026, 7, 14, 12, 0, 0)
+    rows = [
+        (
+            "condition.temperature_high",
+            ["telemetry.observed"],
+            "machine",
+            {
+                "enter_when": "cast(payload['temperature'] as double) > 90",
+                "exit_when": "cast(payload['temperature'] as double) <= 90",
+            },
+            True,
+            observed_at,
+            None,
+        ),
+        (
+            "condition.pressure_high",
+            ["telemetry.observed"],
+            "machine",
+            {
+                "enter_when": "cast(payload['pressure'] as double) > 5",
+                "exit_when": "cast(payload['pressure'] as double) <= 5",
+            },
+            False,
+            observed_at,
+            None,
+        ),
+        (
+            "condition.broken",
+            ["telemetry.observed"],
+            "machine",
+            {"enter_when": "this is ((( not sql", "exit_when": "false"},
+            True,
+            observed_at,
+            None,
+        ),
+    ]
+    provider = _RecordingProvider()
+
+    result = ingest_conditions(
+        _conditions_rows_df(spark, rows),
+        resolver=SimpleTemporalEntityResolver(),
+        provider_factory=lambda entity: provider,
+        quarantine_entity_id="silver.conditions_quarantine",
+    )
+
+    assert result.ingested_count == 2
+    assert result.is_clean is False
+    assert [invalid.condition_id for invalid in result.quarantined] == ["condition.broken"]
+    assert result.quarantine_entity_id == "silver.conditions_quarantine"
+
+    merged_df, merged_entity = provider.merged[0]
+    assert merged_entity.entityid == "silver.conditions"
+    merged_ids = sorted(row.condition_id for row in merged_df.collect())
+    assert merged_ids == ["condition.pressure_high", "condition.temperature_high"]
+
+    quarantine_df, quarantine_entity = provider.appended[0]
+    assert quarantine_entity.entityid == "silver.conditions_quarantine"
+    quarantine_rows = quarantine_df.collect()
+    assert len(quarantine_rows) == 1
+    assert quarantine_rows[0].condition_id == "condition.broken"
+    assert quarantine_rows[0].errors
+    assert quarantine_rows[0].raw_row
+    assert quarantine_rows[0].quarantined_at is not None
+
+
+@pytest.mark.requires_spark
+def test_ingest_conditions_without_quarantine_entity_only_returns_rejects(spark):
+    from kindling_ext_temporal import SimpleTemporalEntityResolver, ingest_conditions
+
+    observed_at = datetime(2026, 7, 14, 12, 0, 0)
+    rows = [
+        (
+            "condition.broken",
+            ["telemetry.observed"],
+            "machine",
+            {"enter_when": "((( nope", "exit_when": "false"},
+            True,
+            observed_at,
+            None,
+        ),
+    ]
+    provider = _RecordingProvider()
+
+    result = ingest_conditions(
+        _conditions_rows_df(spark, rows),
+        resolver=SimpleTemporalEntityResolver(),
+        provider_factory=lambda entity: provider,
+        quarantine_entity_id=None,
+    )
+
+    assert result.ingested_count == 0
+    assert len(result.quarantined) == 1
+    assert result.quarantine_entity_id is None
+    assert provider.merged == []
+    assert provider.appended == []
+
+
+@pytest.mark.requires_spark
+def test_ingest_conditions_raises_on_event_type_graph_cycle(spark):
+    from kindling_ext_temporal import (
+        ConditionValidationError,
+        SimpleTemporalEntityResolver,
+        ingest_conditions,
+    )
+
+    observed_at = datetime(2026, 7, 14, 12, 0, 0)
+    rows = [
+        (
+            "condition.a",
+            ["condition.b.entered"],
+            "machine",
+            {"enter_when": "true", "exit_when": "false"},
+            True,
+            observed_at,
+            None,
+        ),
+        (
+            "condition.b",
+            ["condition.a.entered"],
+            "machine",
+            {"enter_when": "true", "exit_when": "false"},
+            True,
+            observed_at,
+            None,
+        ),
+    ]
+    provider = _RecordingProvider()
+
+    with pytest.raises(ConditionValidationError, match="not ingestible"):
+        ingest_conditions(
+            _conditions_rows_df(spark, rows),
+            resolver=SimpleTemporalEntityResolver(),
+            provider_factory=lambda entity: provider,
+        )
+    assert provider.merged == []
+
+
+@pytest.mark.requires_spark
+def test_validated_conditions_transform_gates_file_drop(spark):
+    from kindling_ext_temporal import (
+        ConditionValidationError,
+        validated_conditions_transform,
+    )
+
+    valid_df = _conditions_df(spark)
+    assert validated_conditions_transform(valid_df) is valid_df
+
+    observed_at = datetime(2026, 7, 14, 12, 0, 0)
+    invalid_df = _conditions_rows_df(
+        spark,
+        [
+            (
+                "condition.broken",
+                ["telemetry.observed"],
+                "machine",
+                {"enter_when": "((( nope", "exit_when": "false"},
+                True,
+                observed_at,
+                None,
+            )
+        ],
+    )
+    with pytest.raises(ConditionValidationError):
+        validated_conditions_transform(invalid_df)

--- a/tests/integration/test_temporal_extension_integration.py
+++ b/tests/integration/test_temporal_extension_integration.py
@@ -1052,3 +1052,78 @@ def test_validated_conditions_transform_gates_file_drop(spark):
     )
     with pytest.raises(ConditionValidationError):
         validated_conditions_transform(invalid_df)
+
+
+@pytest.mark.requires_spark
+def test_ingest_conditions_quarantines_duplicate_condition_ids(spark):
+    from kindling_ext_temporal import SimpleTemporalEntityResolver, ingest_conditions
+
+    observed_at = datetime(2026, 7, 14, 12, 0, 0)
+    good = {
+        "enter_when": "cast(payload['temperature'] as double) > 90",
+        "exit_when": "cast(payload['temperature'] as double) <= 90",
+    }
+    rows = [
+        ("condition.dup", ["telemetry.observed"], "machine", good, True, observed_at, None),
+        ("condition.dup", ["telemetry.observed"], "machine", good, False, observed_at, None),
+        ("condition.unique", ["telemetry.observed"], "machine", good, True, observed_at, None),
+    ]
+    provider = _RecordingProvider()
+
+    result = ingest_conditions(
+        _conditions_rows_df(spark, rows),
+        resolver=SimpleTemporalEntityResolver(),
+        provider_factory=lambda entity: provider,
+        quarantine_entity_id=None,
+    )
+
+    assert result.ingested_count == 1
+    assert sorted(invalid.condition_id for invalid in result.quarantined) == [
+        "condition.dup",
+        "condition.dup",
+    ]
+    assert all("appears 2 times" in invalid.errors[0] for invalid in result.quarantined)
+    merged_ids = [row.condition_id for row in provider.merged[0][0].collect()]
+    assert merged_ids == ["condition.unique"]
+
+
+@pytest.mark.requires_spark
+def test_ingest_conditions_explicit_none_disables_configured_quarantine(spark, monkeypatch):
+    from kindling_ext_temporal import SimpleTemporalEntityResolver
+    from kindling_ext_temporal import conditions as conditions_module
+    from kindling_ext_temporal import ingest_conditions
+
+    monkeypatch.setattr(
+        conditions_module, "_resolve_quarantine_entity_id", lambda: "silver.conditions_quarantine"
+    )
+    observed_at = datetime(2026, 7, 14, 12, 0, 0)
+    rows = [
+        (
+            "condition.broken",
+            ["telemetry.observed"],
+            "machine",
+            {"enter_when": "((( nope", "exit_when": "false"},
+            True,
+            observed_at,
+            None,
+        ),
+    ]
+
+    default_provider = _RecordingProvider()
+    defaulted = ingest_conditions(
+        _conditions_rows_df(spark, rows),
+        resolver=SimpleTemporalEntityResolver(),
+        provider_factory=lambda entity: default_provider,
+    )
+    assert defaulted.quarantine_entity_id == "silver.conditions_quarantine"
+    assert len(default_provider.appended) == 1
+
+    disabled_provider = _RecordingProvider()
+    disabled = ingest_conditions(
+        _conditions_rows_df(spark, rows),
+        resolver=SimpleTemporalEntityResolver(),
+        provider_factory=lambda entity: disabled_provider,
+        quarantine_entity_id=None,
+    )
+    assert disabled.quarantine_entity_id is None
+    assert disabled_provider.appended == []

--- a/tests/unit/test_temporal_extension.py
+++ b/tests/unit/test_temporal_extension.py
@@ -727,3 +727,14 @@ def test_condition_validator_rejects_event_type_cycles():
 
     assert report.is_valid is False
     assert "Cycle detected in pipe dependencies" in report.invalid_conditions[0].errors[0]
+
+
+def test_conditions_ingestion_result_and_config_key():
+    from kindling_ext_temporal import (
+        QUARANTINE_ENTITY_CONFIG_KEY,
+        ConditionsIngestionResult,
+    )
+
+    assert QUARANTINE_ENTITY_CONFIG_KEY == "kindling.temporal.conditions.quarantine_entity_id"
+    assert ConditionsIngestionResult(ingested_count=3).is_clean is True
+    assert ConditionsIngestionResult(ingested_count=0, quarantined=[object()]).is_clean is False


### PR DESCRIPTION
## Summary

Implements the conditions ingestion path — proposal MVP item 1 plus the ingestion-time half of item 2 (the **required** validation pass). Stacked on #177; merge that first.

Conditions are rules-as-data: adding, modifying, or removing one is an ordinary SCD2 upsert through whichever path feeds the table. What was missing is the gate in front of that upsert — a bad `enter_when` must not pass silently into the table where a bad Python expression would never survive code review.

- `ingest_conditions(conditions_df, ...)` validates rule rows **per row** (Spark SQL expression parsing via the existing `TemporalConditionValidator`, event-type graph cycle detection) and upserts well-formed rows through the conditions entity's SCD2 merge — including *disabled* rows, which are legitimate row state the engine filters at read time
- rejects are **quarantined**: always returned in the `ConditionsIngestionResult`, and appended (condition id, errors, raw row, timestamp) to the entity named by `kindling.temporal.conditions.quarantine_entity_id` when configured
- event-type graph **cycles raise** instead of quarantining: a cyclic set has no well-defined ingestible subset
- `validated_conditions_transform` gates the existing `FileIngestion` file-drop path with the same validation, rejecting a file whole on any invalid row (the file path has no per-row quarantine channel)
- keyword arguments are JIT overrides (validator, resolver, provider factory, quarantine target); defaults resolve through the injector and config, matching the extension's config-first pattern
- a `kindling conditions set/remove` CLI on top of `ingest_conditions` stays deferred (README not-yet list)

## Coverage

- unit: result semantics and config key
- integration (Spark): valid + disabled + malformed rows → 2 upserted, 1 quarantined with errors and raw row; no-quarantine-config path returns rejects only; graph cycle raises with no writes; file-drop transform passes clean files through and raises on invalid ones

## Validation

- `poe test-unit` (1742 passed, 1 skipped — matplotlib not installed locally)
- `poe test-integration --path tests/integration/test_temporal_extension_integration.py` (113 passed, 1 skipped)
- `poe test-extension --extension temporal` (1 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
