### PR TITLE
docs(temporal): execution contract and telemetry-to-gold walkthrough

### DIFF
--- a/docs/guide/temporal_end_to_end.md
+++ b/docs/guide/temporal_end_to_end.md
@@ -1,0 +1,155 @@
+# Temporal End-to-End: Telemetry to Gold
+
+One worked example through the temporal extension: raw telemetry becomes
+canonical events, a rules-as-data condition segments them, an episode pairs
+the boundaries, determination events feed back for higher-order conditions,
+and an ordinary gold pipe curates the business mart. Every block uses the
+shipped API; the execution semantics are specified in
+[temporal_streaming_contract.md](temporal_streaming_contract.md).
+
+The scenario: machines report temperature; we want one gold row per
+*thermal excursion* — a contiguous period a machine ran hot — with its
+duration and disposition.
+
+## 1. Normalize telemetry into canonical events
+
+Base events lower raw rows into the canonical `silver.events` envelope. The
+output entity is always the resolver's events entity; the declaration lowers
+to a normal Kindling pipe (`temporal.event.telemetry.base`).
+
+```python
+from kindling_ext_temporal import DataEvents
+
+@DataEvents.base_event(
+    eventid="telemetry.base",
+    input_entity_id="bronze.telemetry",
+    subject_type="machine",
+    subject_keys=["machine_id"],
+    time_column="reading_ts",
+    event_type="telemetry.observed",
+    payload_columns=["temperature"],
+    use_watermark=True,
+)
+def normalize(df):
+    return df  # already one reading per row
+```
+
+## 2. Author the condition as data and ingest it validated
+
+Conditions are rows, not code. `enter_when`/`exit_when` are Spark SQL
+expressions over the event envelope — bounded by Catalyst's grammar, not
+`eval()`. Ingestion validates per row and quarantines rejects; well-formed
+rows (including disabled ones) upsert through the entity's SCD2 merge.
+
+```python
+from kindling_ext_temporal import ingest_conditions
+
+result = ingest_conditions(conditions_df)  # schema: conditions_schema()
+# result.ingested_count, result.quarantined, result.quarantine_entity_id
+```
+
+A condition row for the running example:
+
+```text
+condition_id:        condition.temperature_high
+consumes_event_type: [telemetry.observed]
+subject_type:        machine
+parameters:          enter_when = cast(payload['temperature'] as double) > 90
+                     exit_when  = cast(payload['temperature'] as double) <= 90
+enabled:             true
+```
+
+Set `kindling.temporal.conditions.quarantine_entity_id` to persist rejects;
+duplicate `condition_id`s within a batch are quarantined too. For file-drop
+ingestion, gate the `FileIngestion` entry with
+`validated_conditions_transform` (whole-file rejection).
+
+Register the generic engine once — it reads all current rules from the
+conditions current view and emits `condition.temperature_high.entered` /
+`.exited` boundary events at generation N+1:
+
+```python
+DataEvents.condition_engine(engineid="default")
+```
+
+## 3. Declare the episode
+
+```python
+from kindling_ext_temporal import DataEpisodes
+
+DataEpisodes.episode(
+    episodeid="episode.temperature_high_active",
+    start_event="condition.temperature_high.entered",
+    end_event="condition.temperature_high.exited",
+    subject_type="machine",
+    expires_after_seconds=8 * 3600,   # synthetic expiration for stale opens
+    min_duration_seconds=60,          # blips invalidate, not close
+)
+```
+
+This registers two pipes: `temporal.episode.episode.temperature_high_active`
+(pairs boundaries into `silver.episodes` — open, closed, expired, or
+invalidated, upserted by deterministic `episode_id`) and
+`temporal.episode_event.episode.temperature_high_active` (emits
+`episode.temperature_high_active.closed` / `.expired` / `.invalidated`
+determination events back into `silver.events`, `correlation_id =
+episode_id`). Late real ends revise persisted episodes in place — see the
+execution contract.
+
+## 4. Optional: conditions over determination events
+
+Determination events are ordinary events at the next generation, so a
+higher-order condition can consume them — no joins, no special casing:
+
+```text
+condition_id:        condition.thermal_excursion_confirmed
+consumes_event_type: [episode.temperature_high_active.closed]
+parameters:          enter_when = payload['status'] = 'closed'
+                     exit_when  = false
+```
+
+## 5. Curate gold with an ordinary pipe
+
+The silver/gold boundary is mechanical: gold is business-specific curation
+over the generic episodes table, written as a plain Kindling pipe.
+
+```python
+from kindling.data_pipes import DataPipes
+from pyspark.sql import functions as F
+
+@DataPipes.pipe(
+    pipeid="gold.thermal_excursions",
+    name="Thermal excursions",
+    input_entity_ids=["silver.episodes"],
+    output_entity_id="gold.thermal_excursions",
+    output_type="delta",
+    tags={},
+    use_watermark=True,
+)
+def thermal_excursions(silver_episodes):
+    return (
+        silver_episodes.filter(
+            (F.col("episode_type") == "episode.temperature_high_active")
+            & F.col("status").isin("closed", "expired")
+        )
+        .select(
+            F.col("episode_id"),
+            F.col("subject_id").alias("machine_id"),
+            F.col("start_time"),
+            F.col("end_time"),
+            (F.col("duration_ms") / 60000).alias("duration_minutes"),
+            F.col("close_reason"),
+        )
+    )
+```
+
+## 6. Run it
+
+The declarations above lower to normal pipes; execute them like any others
+(`run_datapipes`/DAG orchestration). Generation layering orders them: base
+events → condition engine → episodes → determination events → gold. Two
+config keys matter operationally: `kindling.temporal.evaluation_time`
+(explicit batch evaluation time for synthetic boundaries — supply it on
+scheduler ticks so stale opens expire even with no arrivals) and
+`kindling.temporal.revise_persisted` (prior-state read switch, on by
+default).

--- a/docs/guide/temporal_streaming_contract.md
+++ b/docs/guide/temporal_streaming_contract.md
@@ -1,0 +1,111 @@
+# Temporal Execution Contract
+
+The contract for how the temporal extension (`kindling_ext_temporal`)
+processes events into conditions and episodes: ordering, incrementality,
+open-episode state, late events, synthetic boundaries, and closure. This
+documents the behavior of the implemented bounded engine and states, where
+relevant, what the planned streaming driver adds — streaming *execution* is
+not yet implemented; per the proposal it is a `foreachBatch` driver around
+this same engine, not a second implementation.
+
+## One engine, two drivers
+
+All episode determination is computed by one bounded engine
+(`ConditionEngineRunner`, `EpisodeRunner`): a bounded slice of events plus
+persisted episode state in, revised episode rows and determination events
+out. Today a scheduler drives it in batch mode. The streaming mode in the
+proposal drives the identical engine from a Structured Streaming
+`foreachBatch` trigger body; nothing in this contract changes between the
+two drivers except who supplies the slice.
+
+## Incrementality ownership — one owner per hop
+
+- The **events driving input** of every temporal pipe is watermarked with
+  Kindling's per-reader cursor (pipe input 0, per the runner's
+  driving-source convention). Routine runs see only new events.
+- **Prior episode state is not a pipe input.** The episode engine resolves
+  its own persisted state at execution time (JIT `silver_episodes` keyword →
+  `kindling.temporal.revise_persisted` config → provider read guarded by an
+  existence check). A first run proceeds with no prior state. The pipes
+  carry a `temporal.reads_prior_state` tag so lineage tooling can see the
+  feedback loop the pipe graph deliberately does not schedule around.
+- Under the planned streaming driver, the stream's checkpoint owns the
+  source→events hop and the same per-reader cursors own each downstream
+  hop — no double bookkeeping.
+
+## Ordering
+
+- Condition boundary events (`{condition_id}.entered` / `.exited`) are
+  emitted at `generation = source generation + 1`. Generations are computed,
+  never hand-specified; the event-type graph is validated (cycles rejected)
+  before execution.
+- Episode pairing is per subject: a start event pairs with the **earliest**
+  end event whose `event_ts` is not before the start (ties broken by
+  `event_id`).
+- `episode_id` is deterministic from the episode definition and the start
+  boundary only. End-boundary changes revise lifecycle fields; they never
+  change identity.
+
+## Open episode state
+
+A start with no visible end materializes an **open** episode row
+(`status = open`, null end fields). Open, expired, and
+synthetically-invalidated episodes form the *revisable set*: the engine
+reconstructs their start boundaries from the episodes table on later runs so
+an incremental batch containing only a late end event can still pair it.
+
+## Synthetic boundaries
+
+With no real end visible, two configured boundaries can close an episode
+synthetically, evaluated against the **evaluation time** (resolution order:
+per-execution `temporal_evaluation_time` argument →
+`kindling.temporal.evaluation_time` config → the bounded input horizon, the
+batch's max `event_ts`):
+
+- `expires_after_seconds` → `status = expired`, `close_reason = expiration`.
+- `max_duration_seconds` (open past it) → `status = invalidated`,
+  `close_reason = max_duration`.
+
+When both are configured, the **earliest synthetic boundary is terminal**:
+an episode that expired before its max-duration horizon stays expired in
+every later batch view, and vice versa. Closed episodes are also validated
+against `min_duration_seconds`/`max_duration_seconds` (real-end
+invalidation, `end_event_synthetic = false`).
+
+## Late events
+
+- A late **real end** supersedes a synthetic end: the episode is re-emitted
+  with the same `episode_id` as `closed` (or invalidated by duration
+  bounds), and the entity's `merge_columns=["episode_id"]` upsert makes the
+  re-emit an in-place revision.
+- Episodes ended by a **real** end event are terminal. A later-arriving end
+  earlier than the accepted one does not re-pair a closed episode
+  (documented limitation; grace-window semantics are future work).
+- A batch with no new events and no evaluation time emits **nothing** for
+  reconstructed episodes: persisted lifecycle state never regresses.
+- Duplicate replays of a start event deduplicate against the reconstructed
+  state by `event_id`.
+
+## Closure and determination events
+
+Every determination (`closed`, `expired`, `invalidated`) emits an event back
+into the canonical events entity: deterministic `event_id`
+(type + episode id), `event_class = episode`,
+`correlation_id = episode_id`, `event_ts` = the end boundary,
+`generation = max(start, end) + 1`. Corrective events (a `.closed` after an
+earlier `.expired`) are **appended alongside** the historical ones — the
+event log records what was determined and when; the episodes table holds
+current lifecycle state.
+
+## Residuals the batch driver does not solve
+
+- **Expiration with zero arrivals**: synthetic boundaries only fire when
+  something evaluates the engine. With no new events, run the episode pipes
+  on a scheduler tick with an explicit evaluation time (config or
+  parameter). The planned streaming driver has the same need
+  (empty-trigger ticks).
+- **Sub-second latency**: out of contract; the proposal tiers it as an
+  opt-in stateful-streaming optimization for specific conditions, not the
+  default model.
+- **Replay/backfill** (business-time condition filtering, cursor resets) is
+  specified in the proposal and not yet implemented.

--- a/packages/extensions/kindling_ext_temporal/README.md
+++ b/packages/extensions/kindling_ext_temporal/README.md
@@ -7,6 +7,10 @@ in `docs/proposals/temporal_event_segmentation.md`. It supports the core
 Event -> Condition boundary Events -> closed Episode path, but it is not yet the
 complete temporal-processing system described in the white paper and proposal.
 
+Operator docs: the execution/streaming contract is specified in
+`docs/guide/temporal_streaming_contract.md`; a worked telemetry-to-gold
+walkthrough is in `docs/guide/temporal_end_to_end.md`.
+
 ## Implemented
 
 - canonical `silver.events`, `silver.conditions`, and `silver.episodes` entity
@@ -127,4 +131,4 @@ mistaken for a full implementation:
 - cloud platform persistence/orchestration coverage beyond the local system
   test path;
 - a `kindling conditions set/remove` CLI on top of `ingest_conditions`;
-- production examples and operator documentation.
+- a runnable example data app packaging the end-to-end guide walkthrough.


### PR DESCRIPTION
## Summary

Documentation slice closing temporal MVP items 10 and 13 on top of the merged #164/#177/#178 behavior:

- `docs/guide/temporal_streaming_contract.md` — the execution contract: one engine/two drivers, incrementality ownership (watermarked driving input; engine-owned prior state), ordering and identity rules, open-episode state, synthetic boundaries with earliest-boundary-terminal semantics, late-event revision rules, determination events, and the residuals the batch driver does not solve (empty-trigger expiration ticks, subsecond tier, replay). Streaming *execution* is explicitly marked design-committed, not implemented.
- `docs/guide/temporal_end_to_end.md` — one worked telemetry-to-gold walkthrough using only the shipped API: base-event normalization, validated condition ingestion with quarantine, episode declaration, determination-event feedback for higher-order conditions, and a plain gold curation pipe.
- extension README links both and narrows the not-yet item to a runnable example app.

Docs-only; no runtime changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)