### PR TITLE
feat(databricks): select Kindling data apps in Lakeflow pipelines

### DIFF
--- a/docs/guide/lakeflow_app_selection.md
+++ b/docs/guide/lakeflow_app_selection.md
@@ -1,0 +1,62 @@
+# Lakeflow data-app selection
+
+Kindling's Databricks extension can be used as the declaration entrypoint for
+a generic Lakeflow Declarative Pipeline. The pipeline configuration selects a
+data app by name:
+
+```hcl
+dlt_pipelines = [
+  {
+    name          = "kindling-orders-lakeflow"
+    target_schema = "orders"
+    file_glob     = "/Repos/my-org/kindling_lakeflow_pipeline.py"
+    development   = true
+    continuous    = false
+    configuration = {
+      "kindling.data_app"              = "orders"
+      "kindling.lakeflow.allowed_apps" = "orders,customers"
+    }
+  }
+]
+```
+
+The generic source file is:
+
+```python
+from kindling_ext_databricks.lakeflow_app_selector import declare_from_pipeline_config
+
+declare_from_pipeline_config()
+```
+
+An app distribution advertises a declaration module through the
+`spark_kindling.data_apps` entry-point group. Its value names a module with a
+callable `register_all()`:
+
+```toml
+[tool.poetry.plugins."spark_kindling.data_apps"]
+orders = "orders_kindling_app"
+```
+
+The selector performs this sequence during Lakeflow source evaluation:
+
+1. Read `kindling.data_app` from Spark configuration.
+2. Discover the app entry points and authorize the selected app using the
+   comma-separated `kindling.lakeflow.allowed_apps` value. An absent or empty
+   allowlist authorizes every discovered app.
+3. Bridge `kindling.*` and `datapipes.*` pipeline settings into Kindling's
+   configuration service and initialize with `engine="databricks_sdp"`.
+4. Import the selected declaration module and call `register_all()`.
+5. Call `kindling.declare_pipeline()` last; Lakeflow then owns graph
+   orchestration.
+
+`register_all()` must be declaration-only. It must not run jobs, write data,
+install dependencies, or invoke `DataAppManager.run_app()`. App code and
+dependencies must already be supplied through the pipeline's libraries,
+wheel, `root_path`, or environment configuration.
+
+This is a templating mechanism with one pipeline per app. Do not repoint an
+existing pipeline ID at another app: streaming tables and checkpoints from the
+previous graph can be orphaned, and target tables can collide. Use a new
+pipeline ID, or perform an explicitly planned full refresh with target cleanup.
+Changing a selected app also requires care around pipeline state, checkpoints,
+target-table identity, and concurrent updates.

--- a/docs/guide/lakeflow_app_selection.md
+++ b/docs/guide/lakeflow_app_selection.md
@@ -44,7 +44,11 @@ The selector performs this sequence during Lakeflow source evaluation:
    comma-separated `kindling.lakeflow.allowed_apps` value. An absent or empty
    allowlist authorizes every discovered app.
 3. Bridge `kindling.*` and `datapipes.*` pipeline settings into Kindling's
-   configuration service and initialize with `engine="databricks_sdp"`.
+   configuration service and initialize with `engine="databricks_sdp"`. The
+   bridge first enumerates `RuntimeConfig.getAll()`, falls back to
+   `SparkContext.getConf().getAll()` for PySpark 3.x, and finally reads only
+   the explicit app-selection keys with a warning if neither enumeration API
+   is available.
 4. Import the selected declaration module and call `register_all()`.
 5. Call `kindling.declare_pipeline()` last; Lakeflow then owns graph
    orchestration.

--- a/iac/databricks/workspace/examples/kindling_lakeflow_pipeline.py
+++ b/iac/databricks/workspace/examples/kindling_lakeflow_pipeline.py
@@ -1,0 +1,5 @@
+"""Generic Lakeflow source for a Kindling data-app pipeline."""
+
+from kindling_ext_databricks.lakeflow_app_selector import declare_from_pipeline_config
+
+declare_from_pipeline_config()

--- a/iac/databricks/workspace/terraform.tfvars.example
+++ b/iac/databricks/workspace/terraform.tfvars.example
@@ -132,6 +132,17 @@ dlt_pipelines = [
   #   notebook_path = "/my-org/run_ingestion_dlts"
   #   development   = true
   # },
+  # {
+  #   name          = "kindling-orders-lakeflow"
+  #   target_schema = "orders"
+  #   file_glob     = "/Repos/my-org/kindling_lakeflow_pipeline.py"
+  #   development   = true
+  #   continuous    = false
+  #   configuration = {
+  #     "kindling.data_app"              = "orders"
+  #     "kindling.lakeflow.allowed_apps" = "orders,customers"
+  #   }
+  # },
 ]
 
 # -- Workspace Config ---------------------------------------------------------

--- a/packages/extensions/kindling_ext_databricks/kindling_ext_databricks/__init__.py
+++ b/packages/extensions/kindling_ext_databricks/kindling_ext_databricks/__init__.py
@@ -17,15 +17,35 @@ from kindling_ext_databricks.engine_extension import (
     DatabricksSdpEngineExtension,
     engine_extension,
 )
+from kindling_ext_databricks.lakeflow_app_selector import (
+    ALLOWED_APPS_CONFIG_KEY,
+    APP_ENTRY_POINT_GROUP,
+    DATA_APP_CONFIG_KEY,
+    LakeflowAppConflictError,
+    LakeflowAppDeclarationError,
+    LakeflowAppNotAuthorizedError,
+    LakeflowAppNotFoundError,
+    LakeflowAppSelectionError,
+    declare_from_pipeline_config,
+)
 
 __version__ = "0.2.0"
 
 __all__ = [
     "DatabricksSdpEngine",
     "DatabricksSdpEngineExtension",
+    "ALLOWED_APPS_CONFIG_KEY",
+    "APP_ENTRY_POINT_GROUP",
+    "DATA_APP_CONFIG_KEY",
     "EXPECTATION_DECORATORS",
+    "LakeflowAppConflictError",
+    "LakeflowAppDeclarationError",
+    "LakeflowAppNotAuthorizedError",
+    "LakeflowAppNotFoundError",
+    "LakeflowAppSelectionError",
     "SCD_SOURCE_SUFFIX",
     "ScdSpec",
+    "declare_from_pipeline_config",
     "engine_extension",
     "scd_spec_from_tags",
     "validate_scd_spec",

--- a/packages/extensions/kindling_ext_databricks/kindling_ext_databricks/lakeflow_app_selector.py
+++ b/packages/extensions/kindling_ext_databricks/kindling_ext_databricks/lakeflow_app_selector.py
@@ -1,0 +1,309 @@
+"""Select and declare a Kindling data app from Lakeflow configuration.
+
+This module is intentionally a declaration-time adapter.  It does not use
+``DataAppManager``: Lakeflow must see the selected app's declarations while it
+is evaluating the pipeline source, before it builds the dependency graph.
+
+Applications advertise declaration modules through the
+``spark_kindling.data_apps`` entry-point group.  The entry-point value is a
+module containing a callable ``register_all()`` function.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import logging
+from types import ModuleType
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Tuple
+
+APP_ENTRY_POINT_GROUP = "spark_kindling.data_apps"
+DATA_APP_CONFIG_KEY = "kindling.data_app"
+ALLOWED_APPS_CONFIG_KEY = "kindling.lakeflow.allowed_apps"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class LakeflowAppSelectionError(RuntimeError):
+    """Base error for invalid Lakeflow data-app selection."""
+
+
+class LakeflowAppNotFoundError(LakeflowAppSelectionError):
+    """The configured app is not advertised by an installed distribution."""
+
+
+class LakeflowAppNotAuthorizedError(LakeflowAppSelectionError):
+    """The configured app is discovered but not allowlisted."""
+
+
+class LakeflowAppDeclarationError(LakeflowAppSelectionError):
+    """The selected app cannot provide declaration-only registrations."""
+
+
+class LakeflowAppConflictError(LakeflowAppSelectionError):
+    """An app changed an already-registered entity or pipe definition."""
+
+
+def _registered_data_app_entry_points() -> Dict[str, Any]:
+    """Return data-app entry points without importing their target modules."""
+    from importlib.metadata import entry_points
+
+    return {ep.name: ep for ep in entry_points(group=APP_ENTRY_POINT_GROUP)}
+
+
+def _active_spark(spark: Any = None) -> Any:
+    if spark is not None:
+        return spark
+
+    from pyspark.sql import SparkSession
+
+    active = SparkSession.getActiveSession()
+    if active is not None:
+        return active
+    return SparkSession.builder.getOrCreate()
+
+
+def _spark_conf_get(spark: Any, key: str) -> Optional[str]:
+    """Read a RuntimeConfig key while remaining compatible with test fakes."""
+    try:
+        value = spark.conf.get(key, None)
+    except TypeError:
+        try:
+            value = spark.conf.get(key)
+        except Exception:
+            return None
+    except Exception:
+        return None
+
+    if value is None:
+        return None
+    return str(value)
+
+
+def _spark_conf_items(spark: Any) -> Iterable[Tuple[str, Any]]:
+    try:
+        values = spark.conf.getAll()
+    except Exception:
+        return ()
+
+    if isinstance(values, Mapping):
+        return values.items()
+    return values
+
+
+def _pipeline_config_for_kindling(spark: Any, app_name: str) -> Dict[str, Any]:
+    """Bridge application Spark configuration into Kindling's ConfigService.
+
+    Lakeflow exposes pipeline configuration through Spark's RuntimeConfig.  A
+    normal Kindling initialization also looks for ``spark.kindling.*`` keys,
+    but Lakeflow configuration commonly arrives as ``kindling.*`` or
+    ``datapipes.*``.  Passing those values explicitly makes them available to
+    Dynaconf and therefore to the declaration engine as well.
+    """
+    config: Dict[str, Any] = {}
+    for key, value in _spark_conf_items(spark):
+        if not isinstance(key, str):
+            continue
+        if key.startswith("spark.kindling."):
+            config[f"kindling.{key[len('spark.kindling.') :]}"] = value
+        elif key.startswith(("kindling.", "datapipes.")):
+            config[key] = value
+
+    # These are read before initialization, so make the exact selected values
+    # available to ConfigService even when a fake or runtime only exposes get().
+    config[DATA_APP_CONFIG_KEY] = app_name
+    allowed = _spark_conf_get(spark, ALLOWED_APPS_CONFIG_KEY)
+    if allowed is not None:
+        config[ALLOWED_APPS_CONFIG_KEY] = allowed
+    return config
+
+
+def _parse_allowlist(raw: Optional[str]) -> set[str]:
+    if raw is None or not raw.strip():
+        return set()
+    return {item.strip() for item in raw.split(",") if item.strip()}
+
+
+def _entry_point_module_name(entry_point: Any, app_name: str) -> str:
+    value = str(getattr(entry_point, "value", "")).strip()
+    module_name, separator, attribute = value.partition(":")
+    if not module_name:
+        raise LakeflowAppDeclarationError(
+            f"Lakeflow data app '{app_name}' has an invalid entry point value {value!r}. "
+            "Expected a module exposing register_all()."
+        )
+    if separator and attribute not in {"", "register_all"}:
+        raise LakeflowAppDeclarationError(
+            f"Lakeflow data app '{app_name}' entry point {value!r} must target "
+            "the module or its register_all function."
+        )
+    return module_name
+
+
+def _load_declaration_module(
+    entry_point: Any, app_name: str
+) -> Tuple[ModuleType, Callable[[], Any]]:
+    module_name = _entry_point_module_name(entry_point, app_name)
+    try:
+        module = importlib.import_module(module_name)
+    except Exception as exc:
+        raise LakeflowAppDeclarationError(
+            f"Unable to import declaration module '{module_name}' for Lakeflow "
+            f"data app '{app_name}'. The module must be available in the "
+            "pipeline environment and must perform declaration-only work."
+        ) from exc
+
+    register_all = getattr(module, "register_all", None)
+    if not callable(register_all):
+        raise LakeflowAppDeclarationError(
+            f"Lakeflow data app '{app_name}' module '{module_name}' does not "
+            "expose a callable register_all(). Provide a declaration-only "
+            "register_all() entrypoint."
+        )
+    return module, register_all
+
+
+def _callable_signature(value: Callable[..., Any]) -> Tuple[Any, ...]:
+    code = getattr(value, "__code__", None)
+    if code is None:
+        return ("callable", value.__class__.__module__, value.__class__.__qualname__)
+
+    closure = getattr(value, "__closure__", None) or ()
+    closure_values = tuple(_stable_signature(cell.cell_contents) for cell in closure)
+    return (
+        "callable",
+        getattr(value, "__module__", None),
+        getattr(value, "__qualname__", None),
+        code.co_code,
+        repr(code.co_consts),
+        code.co_names,
+        repr(getattr(value, "__defaults__", None)),
+        repr(getattr(value, "__kwdefaults__", None)),
+        closure_values,
+    )
+
+
+def _stable_signature(value: Any) -> Any:
+    if callable(value):
+        return _callable_signature(value)
+    if dataclasses.is_dataclass(value):
+        return (
+            value.__class__.__module__,
+            value.__class__.__qualname__,
+            tuple(
+                (field.name, _stable_signature(getattr(value, field.name)))
+                for field in dataclasses.fields(value)
+            ),
+        )
+    if isinstance(value, Mapping):
+        return tuple(
+            sorted(
+                (
+                    repr(key),
+                    _stable_signature(item),
+                )
+                for key, item in value.items()
+            )
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(_stable_signature(item) for item in value)
+    if isinstance(value, set):
+        return tuple(sorted(_stable_signature(item) for item in value))
+    try:
+        hash(value)
+    except Exception:
+        return repr(value)
+    return value
+
+
+def _registry_snapshot() -> Dict[str, Dict[str, Any]]:
+    from kindling.data_entities import DataEntityRegistry
+    from kindling.data_pipes import DataPipesRegistry
+    from kindling.injection import GlobalInjector
+
+    entity_registry = GlobalInjector.get(DataEntityRegistry)
+    pipe_registry = GlobalInjector.get(DataPipesRegistry)
+    return {
+        "entity": {
+            entity_id: _stable_signature(entity_registry.get_entity_definition(entity_id))
+            for entity_id in entity_registry.get_entity_ids()
+        },
+        "pipe": {
+            pipe_id: _stable_signature(pipe_registry.get_pipe_definition(pipe_id))
+            for pipe_id in pipe_registry.get_pipe_ids()
+        },
+    }
+
+
+def _raise_on_conflicts(
+    before: Mapping[str, Mapping[str, Any]],
+    after: Mapping[str, Mapping[str, Any]],
+    app_name: str,
+) -> None:
+    for kind in ("entity", "pipe"):
+        for item_id, previous in before[kind].items():
+            current = after[kind].get(item_id)
+            if current is not None and current != previous:
+                raise LakeflowAppConflictError(
+                    f"Lakeflow data app '{app_name}' re-registered {kind} "
+                    f"'{item_id}' with different content. Existing registrations "
+                    "must be identical or use distinct IDs."
+                )
+
+
+def declare_from_pipeline_config(spark: Any = None) -> Any:
+    """Resolve, register, and declare the configured Lakeflow data app.
+
+    The lifecycle is deliberately fixed: read and authorize metadata, bridge
+    Spark configuration, initialize Kindling, import/register the app, then
+    declare the pipeline as the final operation.
+    """
+    spark = _active_spark(spark)
+    app_name = (_spark_conf_get(spark, DATA_APP_CONFIG_KEY) or "").strip()
+    if not app_name:
+        raise LakeflowAppSelectionError(
+            f"Lakeflow requires a non-empty Spark configuration value for "
+            f"'{DATA_APP_CONFIG_KEY}'. Set it to a registered Kindling data app name."
+        )
+
+    entry_points = _registered_data_app_entry_points()
+    discovered = sorted(entry_points)
+    entry_point = entry_points.get(app_name)
+    if entry_point is None:
+        discovered_text = ", ".join(discovered) if discovered else "<none>"
+        raise LakeflowAppNotFoundError(
+            f"Unknown Lakeflow data app '{app_name}'. Discovered apps: {discovered_text}. "
+            f"Check '{DATA_APP_CONFIG_KEY}' and install the app distribution."
+        )
+
+    allowed = _parse_allowlist(_spark_conf_get(spark, ALLOWED_APPS_CONFIG_KEY))
+    if allowed and app_name not in allowed:
+        raise LakeflowAppNotAuthorizedError(
+            f"Lakeflow data app '{app_name}' was discovered but is not authorized by "
+            f"'{ALLOWED_APPS_CONFIG_KEY}'. Allowed apps: {', '.join(sorted(allowed))}."
+        )
+
+    import kindling
+
+    kindling.initialize(
+        config=_pipeline_config_for_kindling(spark, app_name),
+        engine="databricks_sdp",
+    )
+
+    before = _registry_snapshot()
+    _, register_all = _load_declaration_module(entry_point, app_name)
+    try:
+        register_all()
+    except LakeflowAppSelectionError:
+        raise
+    except Exception as exc:
+        raise LakeflowAppDeclarationError(
+            f"Declaration registration failed for Lakeflow data app '{app_name}'. "
+            "register_all() must only register Kindling entities and pipes; "
+            "dependency installation and imperative execution are unsupported."
+        ) from exc
+
+    after = _registry_snapshot()
+    _raise_on_conflicts(before, after, app_name)
+    _LOGGER.info("Declaring Lakeflow graph for Kindling data app '%s'", app_name)
+    return kindling.declare_pipeline()

--- a/packages/extensions/kindling_ext_databricks/kindling_ext_databricks/lakeflow_app_selector.py
+++ b/packages/extensions/kindling_ext_databricks/kindling_ext_databricks/lakeflow_app_selector.py
@@ -14,14 +14,20 @@ from __future__ import annotations
 import dataclasses
 import importlib
 import logging
-from types import ModuleType
+from types import CodeType, ModuleType
 from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Tuple
+
+from py4j.protocol import Py4JError
+from pyspark.sql.utils import AnalysisException
 
 APP_ENTRY_POINT_GROUP = "spark_kindling.data_apps"
 DATA_APP_CONFIG_KEY = "kindling.data_app"
 ALLOWED_APPS_CONFIG_KEY = "kindling.lakeflow.allowed_apps"
 
 _LOGGER = logging.getLogger(__name__)
+_CONF_READ_ERRORS = (AttributeError, KeyError, Py4JError, AnalysisException, RuntimeError)
+# RuntimeError covers restricted/serverless SparkContext access, where the
+# context exists conceptually but is not exposed to the Python evaluation.
 
 
 class LakeflowAppSelectionError(RuntimeError):
@@ -67,12 +73,15 @@ def _spark_conf_get(spark: Any, key: str) -> Optional[str]:
     """Read a RuntimeConfig key while remaining compatible with test fakes."""
     try:
         value = spark.conf.get(key, None)
-    except TypeError:
+    except TypeError as exc:
+        _LOGGER.debug("RuntimeConfig.get(key, default) is unavailable for %s: %s", key, exc)
         try:
             value = spark.conf.get(key)
-        except Exception:
+        except (TypeError, *_CONF_READ_ERRORS) as fallback_exc:
+            _LOGGER.debug("Unable to read Spark configuration key %s: %s", key, fallback_exc)
             return None
-    except Exception:
+    except _CONF_READ_ERRORS as exc:
+        _LOGGER.debug("Unable to read Spark configuration key %s: %s", key, exc)
         return None
 
     if value is None:
@@ -81,14 +90,43 @@ def _spark_conf_get(spark: Any, key: str) -> Optional[str]:
 
 
 def _spark_conf_items(spark: Any) -> Iterable[Tuple[str, Any]]:
-    try:
-        values = spark.conf.getAll()
-    except Exception:
-        return ()
+    """Enumerate Spark configuration with PySpark 3.x and Databricks fallbacks."""
 
-    if isinstance(values, Mapping):
-        return values.items()
-    return values
+    try:
+        get_all = getattr(spark.conf, "getAll", None)
+    except _CONF_READ_ERRORS as exc:
+        _LOGGER.debug("RuntimeConfig.getAll is unavailable: %s", exc)
+        get_all = None
+    if callable(get_all):
+        try:
+            values = get_all()
+            if isinstance(values, Mapping):
+                return tuple(values.items())
+            return tuple(values)
+        except (TypeError, *_CONF_READ_ERRORS) as exc:
+            _LOGGER.debug("Unable to enumerate RuntimeConfig.getAll(): %s", exc)
+
+    try:
+        spark_context = spark.sparkContext
+        values = spark_context.getConf().getAll()
+        if isinstance(values, Mapping):
+            return tuple(values.items())
+        return tuple(values)
+    except (TypeError, *_CONF_READ_ERRORS) as exc:
+        _LOGGER.debug("Unable to enumerate SparkContext.getConf().getAll(): %s", exc)
+
+    explicit_keys = (DATA_APP_CONFIG_KEY, ALLOWED_APPS_CONFIG_KEY)
+    explicit_items = tuple(
+        (key, value) for key in explicit_keys if (value := _spark_conf_get(spark, key)) is not None
+    )
+    _LOGGER.warning(
+        "Unable to enumerate Spark configuration through RuntimeConfig.getAll() "
+        "or SparkContext.getConf().getAll(); bridged only explicit keys %s "
+        "(available: %s)",
+        explicit_keys,
+        tuple(key for key, _ in explicit_items),
+    )
+    return explicit_items
 
 
 def _pipeline_config_for_kindling(spark: Any, app_name: str) -> Dict[str, Any]:
@@ -174,16 +212,33 @@ def _callable_signature(value: Callable[..., Any]) -> Tuple[Any, ...]:
         "callable",
         getattr(value, "__module__", None),
         getattr(value, "__qualname__", None),
-        code.co_code,
-        repr(code.co_consts),
-        code.co_names,
-        repr(getattr(value, "__defaults__", None)),
-        repr(getattr(value, "__kwdefaults__", None)),
+        _code_signature(code),
+        _stable_signature(getattr(value, "__defaults__", None)),
+        _stable_signature(getattr(value, "__kwdefaults__", None)),
         closure_values,
     )
 
 
+def _code_signature(code: CodeType) -> Tuple[Any, ...]:
+    """Return a structural signature that is stable across module imports."""
+    return (
+        "code",
+        code.co_code,
+        code.co_names,
+        tuple(_stable_signature(constant) for constant in code.co_consts),
+        code.co_varnames,
+        code.co_freevars,
+        code.co_cellvars,
+        code.co_argcount,
+        code.co_posonlyargcount,
+        code.co_kwonlyargcount,
+        code.co_flags,
+    )
+
+
 def _stable_signature(value: Any) -> Any:
+    if isinstance(value, CodeType):
+        return _code_signature(value)
     if callable(value):
         return _callable_signature(value)
     if dataclasses.is_dataclass(value):

--- a/tests/unit/test_lakeflow_app_selector.py
+++ b/tests/unit/test_lakeflow_app_selector.py
@@ -1,8 +1,7 @@
 """Hermetic tests for evaluation-time Lakeflow Kindling app selection."""
 
-import sys
 from types import ModuleType, SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from kindling_ext_databricks import lakeflow_app_selector as selector
@@ -22,6 +21,33 @@ class FakeConf:
 class FakeSpark:
     def __init__(self, values=None):
         self.conf = FakeConf(values)
+
+
+class FakeSparkConfWithoutGetAll:
+    """The PySpark 3.x RuntimeConfig surface: get(), but no getAll()."""
+
+    def __init__(self, values=None):
+        self.values = dict(values or {})
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+
+class FakeSparkContext:
+    def __init__(self, values=None):
+        self.values = dict(values or {})
+
+    def getConf(self):
+        return self
+
+    def getAll(self):
+        return tuple(self.values.items())
+
+
+class FakeSpark3:
+    def __init__(self, values=None):
+        self.conf = FakeSparkConfWithoutGetAll(values)
+        self.sparkContext = FakeSparkContext(values)
 
 
 class FakeEntryPoint:
@@ -198,6 +224,58 @@ def test_pipeline_configuration_is_bridged_to_kindling(monkeypatch):
     assert "spark.sql.shuffle.partitions" not in captured["config"]
 
 
+def test_pipeline_configuration_falls_back_to_spark_context_conf(monkeypatch):
+    captured = {}
+    spark = FakeSpark3(
+        {
+            "kindling.data_app": "orders",
+            "kindling.lakeflow.allowed_apps": "orders",
+            "datapipes.silver.orders.engine": '{"dataset_type": "materialized_view"}',
+            "spark.sql.shuffle.partitions": "10",
+        }
+    )
+    monkeypatch.setattr(
+        selector,
+        "_registered_data_app_entry_points",
+        lambda: {"orders": FakeEntryPoint("orders", "orders_app")},
+    )
+    monkeypatch.setattr(selector, "_registry_snapshot", lambda: {"entity": {}, "pipe": {}})
+    monkeypatch.setattr("kindling.initialize", lambda **kwargs: captured.update(kwargs))
+    monkeypatch.setattr(
+        selector,
+        "importlib",
+        SimpleNamespace(import_module=lambda _: _module("orders_app", lambda: None)),
+    )
+    monkeypatch.setattr("kindling.declare_pipeline", lambda: "plan")
+
+    assert selector.declare_from_pipeline_config(spark) == "plan"
+    assert captured["config"]["kindling.data_app"] == "orders"
+    assert captured["config"]["kindling.lakeflow.allowed_apps"] == "orders"
+    assert "datapipes.silver.orders.engine" in captured["config"]
+    assert "spark.sql.shuffle.partitions" not in captured["config"]
+
+
+def test_pipeline_configuration_warns_when_only_explicit_keys_are_available(caplog):
+    class SparkWithoutConfigEnumeration:
+        def __init__(self):
+            self.conf = FakeSparkConfWithoutGetAll(
+                {
+                    "kindling.data_app": "orders",
+                    "kindling.lakeflow.allowed_apps": "orders",
+                }
+            )
+
+    with caplog.at_level("WARNING", logger=selector.__name__):
+        items = dict(selector._spark_conf_items(SparkWithoutConfigEnumeration()))
+
+    assert items == {
+        "kindling.data_app": "orders",
+        "kindling.lakeflow.allowed_apps": "orders",
+    }
+    assert "RuntimeConfig.getAll()" in caplog.text
+    assert "kindling.data_app" in caplog.text
+
+
 def test_double_evaluation_is_idempotent(monkeypatch):
     register_calls = []
     snapshot = {"entity": {"orders": ("same",)}, "pipe": {"orders": ("same",)}}
@@ -223,6 +301,97 @@ def test_double_evaluation_is_idempotent(monkeypatch):
     assert selector.declare_from_pipeline_config(spark) == "plan"
     assert selector.declare_from_pipeline_config(spark) == "plan"
     assert register_calls == ["registered", "registered"]
+
+
+def test_double_evaluation_calls_real_kindling_initialize_twice(monkeypatch):
+    import kindling
+
+    extension = SimpleNamespace(owns_incrementality=True, activate=MagicMock())
+    monkeypatch.setattr(kindling, "_active_engine_extension", None)
+    monkeypatch.setattr(kindling, "_load_engine_extension", lambda _: extension)
+    monkeypatch.setattr(kindling, "initialize_framework", MagicMock())
+    monkeypatch.setattr(kindling, "declare_pipeline", lambda: "plan")
+    monkeypatch.setattr(
+        selector,
+        "_registered_data_app_entry_points",
+        lambda: {"orders": FakeEntryPoint("orders", "orders_app")},
+    )
+    monkeypatch.setattr(selector, "_registry_snapshot", lambda: {"entity": {}, "pipe": {}})
+    monkeypatch.setattr(
+        selector,
+        "importlib",
+        SimpleNamespace(import_module=lambda _: _module("orders_app", lambda: None)),
+    )
+    spark = FakeSpark({"kindling.data_app": "orders"})
+
+    assert selector.declare_from_pipeline_config(spark) == "plan"
+    assert selector.declare_from_pipeline_config(spark) == "plan"
+    assert extension.activate.call_count == 2
+
+
+def test_real_registry_snapshot_round_trip_is_stable(monkeypatch):
+    from kindling.data_entities import DataEntityManager, DataEntityRegistry
+    from kindling.data_pipes import DataPipesManager, DataPipesRegistry
+    from kindling.injection import GlobalInjector
+    from pyspark.sql.types import StringType, StructField, StructType
+
+    entity_registry = DataEntityManager()
+    logger_provider = MagicMock()
+    logger_provider.get_logger.return_value = MagicMock()
+    pipe_registry = DataPipesManager(logger_provider)
+    entity_registry.register_entity(
+        "orders",
+        name="orders",
+        merge_columns=["id"],
+        tags={},
+        schema=StructType([StructField("id", StringType(), nullable=False)]),
+    )
+
+    def execute(**dataframes):
+        def identity(value):
+            return value
+
+        return identity(dataframes)
+
+    pipe_registry.register_pipe(
+        "orders.pipe",
+        name="orders.pipe",
+        execute=execute,
+        tags={},
+        input_entity_ids=["orders"],
+        output_entity_id="orders",
+        output_type="delta",
+    )
+
+    def get_registry(interface):
+        if interface is DataEntityRegistry:
+            return entity_registry
+        if interface is DataPipesRegistry:
+            return pipe_registry
+        raise AssertionError(f"Unexpected registry request: {interface}")
+
+    monkeypatch.setattr(GlobalInjector, "get", get_registry)
+    before = selector._registry_snapshot()
+    after = selector._registry_snapshot()
+
+    selector._raise_on_conflicts(before, after, "orders")
+
+
+def test_structural_callable_signatures_ignore_fresh_nested_code_objects():
+    source = """
+def transform(value):
+    def nested(item):
+        return item + 1
+    return nested(value)
+"""
+    first_namespace = {}
+    second_namespace = {}
+    exec(source, first_namespace)
+    exec(source, second_namespace)
+
+    assert selector._stable_signature(first_namespace["transform"]) == selector._stable_signature(
+        second_namespace["transform"]
+    )
 
 
 def test_conflicting_reregistration_names_the_id(monkeypatch):

--- a/tests/unit/test_lakeflow_app_selector.py
+++ b/tests/unit/test_lakeflow_app_selector.py
@@ -1,0 +1,276 @@
+"""Hermetic tests for evaluation-time Lakeflow Kindling app selection."""
+
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from kindling_ext_databricks import lakeflow_app_selector as selector
+
+
+class FakeConf:
+    def __init__(self, values=None):
+        self.values = dict(values or {})
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+    def getAll(self):
+        return dict(self.values)
+
+
+class FakeSpark:
+    def __init__(self, values=None):
+        self.conf = FakeConf(values)
+
+
+class FakeEntryPoint:
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+
+
+def _module(name, register_all):
+    module = ModuleType(name)
+    module.register_all = register_all
+    return module
+
+
+def test_data_app_entry_point_group_is_discovered_without_loading_modules(monkeypatch):
+    entry_point = FakeEntryPoint("orders", "orders_app")
+    observed = {}
+
+    def entry_points(**kwargs):
+        observed.update(kwargs)
+        return [entry_point]
+
+    monkeypatch.setattr("importlib.metadata.entry_points", entry_points)
+
+    assert selector._registered_data_app_entry_points() == {"orders": entry_point}
+    assert observed == {"group": "spark_kindling.data_apps"}
+
+
+def test_selected_module_must_expose_register_all(monkeypatch):
+    monkeypatch.setattr(
+        selector,
+        "_registered_data_app_entry_points",
+        lambda: {"orders": FakeEntryPoint("orders", "orders_app")},
+    )
+    monkeypatch.setattr(selector, "_registry_snapshot", lambda: {"entity": {}, "pipe": {}})
+    monkeypatch.setattr(
+        selector,
+        "importlib",
+        SimpleNamespace(import_module=lambda _: ModuleType("orders_app")),
+    )
+    monkeypatch.setattr("kindling.initialize", lambda **kwargs: None)
+
+    with pytest.raises(selector.LakeflowAppDeclarationError, match="register_all"):
+        selector.declare_from_pipeline_config(FakeSpark({"kindling.data_app": "orders"}))
+
+
+def test_two_app_names_select_their_declaration_graphs(monkeypatch):
+    declared = []
+    initialized = []
+
+    for app_name, graph in (("orders", "orders-graph"), ("customers", "customers-graph")):
+
+        def register(graph=graph):
+            declared.append(graph)
+
+        spark = FakeSpark({"kindling.data_app": app_name})
+        monkeypatch.setattr(
+            selector,
+            "_registered_data_app_entry_points",
+            lambda app_name=app_name: {app_name: FakeEntryPoint(app_name, f"app_{app_name}")},
+        )
+        monkeypatch.setattr(selector, "_registry_snapshot", lambda: {"entity": {}, "pipe": {}})
+        monkeypatch.setattr(
+            selector,
+            "importlib",
+            SimpleNamespace(
+                import_module=lambda _, register=register, app_name=app_name: _module(
+                    f"app_{app_name}", register
+                )
+            ),
+        )
+        monkeypatch.setattr("kindling.initialize", lambda **kwargs: initialized.append(kwargs))
+        monkeypatch.setattr("kindling.declare_pipeline", lambda: declared[-1])
+
+        assert selector.declare_from_pipeline_config(spark) == graph
+
+    assert declared == ["orders-graph", "customers-graph"]
+    assert [call["engine"] for call in initialized] == ["databricks_sdp", "databricks_sdp"]
+
+
+@pytest.mark.parametrize(
+    ("values", "error", "message"),
+    [
+        ({}, selector.LakeflowAppSelectionError, "kindling.data_app"),
+        (
+            {"kindling.data_app": "missing"},
+            selector.LakeflowAppNotFoundError,
+            "Discovered apps: orders",
+        ),
+        (
+            {
+                "kindling.data_app": "orders",
+                "kindling.lakeflow.allowed_apps": "customers",
+            },
+            selector.LakeflowAppNotAuthorizedError,
+            "kindling.lakeflow.allowed_apps",
+        ),
+    ],
+)
+def test_selection_errors_are_distinct_and_actionable(monkeypatch, values, error, message):
+    spark = FakeSpark(values)
+    monkeypatch.setattr(
+        selector,
+        "_registered_data_app_entry_points",
+        lambda: {"orders": FakeEntryPoint("orders", "orders_app")},
+    )
+
+    with pytest.raises(error, match=message):
+        selector.declare_from_pipeline_config(spark)
+
+
+def test_initialize_completes_before_app_import(monkeypatch):
+    events = []
+
+    def initialize(**kwargs):
+        events.append("initialize")
+
+    def register_all():
+        events.append("register_all")
+
+    spark = FakeSpark({"kindling.data_app": "probe"})
+    monkeypatch.setattr(
+        selector,
+        "_registered_data_app_entry_points",
+        lambda: {"probe": FakeEntryPoint("probe", "probe_app")},
+    )
+    monkeypatch.setattr(selector, "_registry_snapshot", lambda: {"entity": {}, "pipe": {}})
+    monkeypatch.setattr("kindling.initialize", initialize)
+    monkeypatch.setattr("kindling.declare_pipeline", lambda: events.append("declare"))
+
+    def import_module(_):
+        events.append("import")
+        return _module("probe_app", register_all)
+
+    monkeypatch.setattr(
+        selector,
+        "importlib",
+        SimpleNamespace(import_module=import_module),
+    )
+
+    selector.declare_from_pipeline_config(spark)
+    assert events == ["initialize", "import", "register_all", "declare"]
+
+
+def test_pipeline_configuration_is_bridged_to_kindling(monkeypatch):
+    captured = {}
+    spark = FakeSpark(
+        {
+            "kindling.data_app": "orders",
+            "kindling.lakeflow.allowed_apps": "orders",
+            "datapipes.silver.orders.engine": '{"dataset_type": "materialized_view"}',
+            "spark.sql.shuffle.partitions": "10",
+        }
+    )
+    monkeypatch.setattr(
+        selector,
+        "_registered_data_app_entry_points",
+        lambda: {"orders": FakeEntryPoint("orders", "orders_app")},
+    )
+    monkeypatch.setattr(selector, "_registry_snapshot", lambda: {"entity": {}, "pipe": {}})
+    monkeypatch.setattr("kindling.initialize", lambda **kwargs: captured.update(kwargs))
+    monkeypatch.setattr(
+        selector,
+        "importlib",
+        SimpleNamespace(import_module=lambda _: _module("orders_app", lambda: None)),
+    )
+    monkeypatch.setattr("kindling.declare_pipeline", lambda: "plan")
+
+    assert selector.declare_from_pipeline_config(spark) == "plan"
+    assert captured["engine"] == "databricks_sdp"
+    assert captured["config"]["kindling.data_app"] == "orders"
+    assert captured["config"]["kindling.lakeflow.allowed_apps"] == "orders"
+    assert "datapipes.silver.orders.engine" in captured["config"]
+    assert "spark.sql.shuffle.partitions" not in captured["config"]
+
+
+def test_double_evaluation_is_idempotent(monkeypatch):
+    register_calls = []
+    snapshot = {"entity": {"orders": ("same",)}, "pipe": {"orders": ("same",)}}
+    monkeypatch.setattr(
+        selector,
+        "_registered_data_app_entry_points",
+        lambda: {"orders": FakeEntryPoint("orders", "orders_app")},
+    )
+    monkeypatch.setattr(selector, "_registry_snapshot", lambda: snapshot)
+    monkeypatch.setattr(
+        selector,
+        "importlib",
+        SimpleNamespace(
+            import_module=lambda _: _module(
+                "orders_app", lambda: register_calls.append("registered")
+            )
+        ),
+    )
+    monkeypatch.setattr("kindling.initialize", lambda **kwargs: None)
+    monkeypatch.setattr("kindling.declare_pipeline", lambda: "plan")
+    spark = FakeSpark({"kindling.data_app": "orders"})
+
+    assert selector.declare_from_pipeline_config(spark) == "plan"
+    assert selector.declare_from_pipeline_config(spark) == "plan"
+    assert register_calls == ["registered", "registered"]
+
+
+def test_conflicting_reregistration_names_the_id(monkeypatch):
+    snapshots = iter(
+        [
+            {"entity": {"orders": ("old",)}, "pipe": {}},
+            {"entity": {"orders": ("new",)}, "pipe": {}},
+        ]
+    )
+    monkeypatch.setattr(
+        selector,
+        "_registered_data_app_entry_points",
+        lambda: {"orders": FakeEntryPoint("orders", "orders_app")},
+    )
+    monkeypatch.setattr(selector, "_registry_snapshot", lambda: next(snapshots))
+    monkeypatch.setattr(
+        selector,
+        "importlib",
+        SimpleNamespace(import_module=lambda _: _module("orders_app", lambda: None)),
+    )
+    monkeypatch.setattr("kindling.initialize", lambda **kwargs: None)
+
+    with pytest.raises(selector.LakeflowAppConflictError, match="orders"):
+        selector.declare_from_pipeline_config(FakeSpark({"kindling.data_app": "orders"}))
+
+
+def test_data_app_manager_is_not_invoked(monkeypatch):
+    from kindling.data_apps import DataAppManager
+
+    with patch.object(
+        DataAppManager, "run_app", side_effect=AssertionError("must not run")
+    ) as run_app:
+        monkeypatch.setattr(
+            selector,
+            "_registered_data_app_entry_points",
+            lambda: {"orders": FakeEntryPoint("orders", "orders_app")},
+        )
+        monkeypatch.setattr(selector, "_registry_snapshot", lambda: {"entity": {}, "pipe": {}})
+        monkeypatch.setattr(
+            selector,
+            "importlib",
+            SimpleNamespace(import_module=lambda _: _module("orders_app", lambda: None)),
+        )
+        monkeypatch.setattr("kindling.initialize", lambda **kwargs: None)
+        monkeypatch.setattr("kindling.declare_pipeline", lambda: "plan")
+
+        assert (
+            selector.declare_from_pipeline_config(FakeSpark({"kindling.data_app": "orders"}))
+            == "plan"
+        )
+        run_app.assert_not_called()


### PR DESCRIPTION
## Summary

Adds a declaration-time Lakeflow entrypoint that selects a Kindling data app from `kindling.data_app`, registers its declaration graph, and delegates orchestration to Databricks SDP/Lakeflow.

## What changed

- Added `kindling_ext_databricks.lakeflow_app_selector`.
- Added `spark_kindling.data_apps` entry-point discovery.
- Added `kindling.lakeflow.allowed_apps` authorization with actionable selection errors.
- Bridges `kindling.*` and `datapipes.*` Spark configuration into Kindling initialization via `RuntimeConfig.getAll()`, the PySpark 3.x `SparkContext.getConf().getAll()` fallback, and a warning-bearing explicit-key fallback.
- Narrows expected Spark configuration API errors and logs reader fallbacks at debug level.
- Enforces the lifecycle: read/authorize, initialize `databricks_sdp`, import `register_all()`, conflict-check registries, then call `kindling.declare_pipeline()` last.
- Uses structural callable/code signatures so equivalent registrations remain stable across fresh module imports.
- Verifies re-entrant initialization by calling the real `kindling.initialize` twice with engine internals mocked; no guard is added.
- Added real registry snapshot/conflict coverage, including entity schemas and pipe metadata closures.
- Explicitly avoids `DataAppManager.run_app()` and dependency installation in the declarator.
- Added a generic Lakeflow source, Terraform example, guide, and hermetic unit tests.

## Deployment rule and limitations

This is a templating mechanism: use one Lakeflow pipeline per app. Do not repoint an existing pipeline ID at another app without an explicitly planned full refresh and target cleanup. Changing the selected graph can orphan streaming tables/checkpoints and can cause target-table collisions. Pipeline state, checkpoints, concurrent updates, and app dependencies remain deployment concerns.

`register_all()` must be declaration-only; application code and dependencies must already be available through pipeline libraries, wheels, `root_path`, or the pipeline environment.

## Validation

- `poe test-unit`
- 1,784 passed, 1 skipped, 1 repository warning
- Pre-commit hooks: trailing whitespace, EOF, YAML, large files, merge conflicts, private key detection, Black, isort, and flake8