### PR TITLE
feat(temporal): Databricks system test — end-to-end flow, cross-run revision, gold aggregation

### DIFF
--- a/packages/extensions/kindling_ext_temporal/README.md
+++ b/packages/extensions/kindling_ext_temporal/README.md
@@ -57,7 +57,12 @@ walkthrough is in `docs/guide/temporal_end_to_end.md`.
   conditions entity's SCD2 merge; `validated_conditions_transform` gates a
   `FileIngestion` file-drop entry with the same validation, rejecting a file
   whole on any invalid row;
-- unit, integration, and system coverage for the first executable slice.
+- unit, integration, and system coverage for the first executable slice,
+  including a Databricks system test (`tests/system/extensions/temporal/`,
+  `tests/data-apps/temporal-test-app`) that validates the end-to-end flow,
+  validated conditions ingestion with per-row quarantine, and cross-run
+  late-end revision (two separate job executions over shared catalog
+  storage) on a real workspace.
 
 ## Configuration
 
@@ -128,7 +133,7 @@ mistaken for a full implementation:
 - multi-generation orchestration beyond one condition-engine pass;
 - interval hierarchy and temporal-relation reasoning;
 - aggregation, correlation, and inference-derived event paths;
-- cloud platform persistence/orchestration coverage beyond the local system
-  test path;
+- cloud platform coverage beyond Databricks (the Fabric/Synapse legs of the
+  platform system test);
 - a `kindling conditions set/remove` CLI on top of `ingest_conditions`;
 - a runnable example data app packaging the end-to-end guide walkthrough.

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/conditions.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/conditions.py
@@ -79,11 +79,28 @@ def _provider_for(entity):
     return GlobalInjector.get(EntityProviderRegistry).get_provider_for_entity(entity)
 
 
-def _write_quarantine(spark, invalids, quarantine_entity_id, provider_factory):
-    from kindling.data_entities import EntityMetadata
-    from pyspark.sql import functions as F
+def _quarantine_entity(quarantine_entity_id):
+    """Resolve the registered quarantine entity; fall back to ad-hoc metadata.
 
-    entity = EntityMetadata(
+    An app that registered the entity owns its storage configuration
+    (provider tags, paths); fabricating metadata here would silently write
+    to a different location than the registered entity reads from.
+    """
+    try:
+        from kindling.data_entities import DataEntityRegistry
+        from kindling.injection import GlobalInjector
+
+        registered = GlobalInjector.get(DataEntityRegistry).get_entity_definition(
+            quarantine_entity_id
+        )
+        if registered is not None:
+            return registered
+    except Exception:  # noqa: BLE001 - registry unavailable in bare tests
+        pass
+
+    from kindling.data_entities import EntityMetadata
+
+    return EntityMetadata(
         entityid=quarantine_entity_id,
         name=quarantine_entity_id.split(".")[-1],
         merge_columns=[],
@@ -91,6 +108,12 @@ def _write_quarantine(spark, invalids, quarantine_entity_id, provider_factory):
         schema=condition_quarantine_schema(),
         partition_columns=[],
     )
+
+
+def _write_quarantine(spark, invalids, quarantine_entity_id, provider_factory):
+    from pyspark.sql import functions as F
+
+    entity = _quarantine_entity(quarantine_entity_id)
     rows = [
         (
             invalid.condition_id or None,

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/engine.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/engine.py
@@ -140,6 +140,11 @@ class EpisodeRunner:
             episode,
             evaluation_time=evaluation_time,
             existing_episodes_df=existing_episodes_df,
+            # The episode pipe runs first and revises persisted state, so a
+            # late real end's episode is already closed (terminal) by the
+            # time this pipe runs; reconstruct episodes whose real end is in
+            # this batch so the corrective determination event still fires.
+            reconstruct_batch_closed=True,
         ).filter(F.col("status").isin("closed", "expired", "invalidated"))
         determination_event = episode.determination_event or f"{episode.episodeid}.closed"
         expiration_event = episode.expiration_event or f"{episode.episodeid}.expired"
@@ -216,7 +221,13 @@ class EpisodeRunner:
         )
 
     @staticmethod
-    def _paired_boundaries(events_df, episode, evaluation_time=None, existing_episodes_df=None):
+    def _paired_boundaries(
+        events_df,
+        episode,
+        evaluation_time=None,
+        existing_episodes_df=None,
+        reconstruct_batch_closed=False,
+    ):
         from pyspark.sql import functions as F
         from pyspark.sql.window import Window
 
@@ -229,7 +240,11 @@ class EpisodeRunner:
         starts = starts.withColumn("__temporal_reconstructed_start", F.lit(False))
         if existing_episodes_df is not None:
             reconstructed = (
-                EpisodeRunner._reconstruct_start_boundaries(existing_episodes_df, episode)
+                EpisodeRunner._reconstruct_start_boundaries(
+                    existing_episodes_df,
+                    episode,
+                    batch_events_df=events_df if reconstruct_batch_closed else None,
+                )
                 .dropDuplicates(["event_id"])
                 .join(starts.select("event_id"), on="event_id", how="left_anti")
             )
@@ -387,7 +402,7 @@ class EpisodeRunner:
         )
 
     @staticmethod
-    def _reconstruct_start_boundaries(episodes_df, episode):
+    def _reconstruct_start_boundaries(episodes_df, episode, batch_events_df=None):
         """Rebuild start-boundary event rows for persisted revisable episodes.
 
         Revisable means the episode has no real end yet: open, expired, or
@@ -395,16 +410,32 @@ class EpisodeRunner:
         terminal and never revised. The reconstructed rows let an incremental
         batch that only contains a late real end event pair it against a start
         consumed by an earlier batch.
+
+        When ``batch_events_df`` is given (the determination path), episodes
+        already closed by a real end event WHOSE end event is part of this
+        batch are reconstructed too: in sequential execution the episode pipe
+        revises persisted state before the determination pipe runs, so a
+        late-end revision would otherwise be terminal by the time its
+        corrective determination event should be emitted. Deterministic
+        determination event ids keep the re-emit idempotent.
         """
         from pyspark.sql import functions as F
 
-        revisable = episodes_df.filter(
-            (F.col("episode_type") == F.lit(episode.episodeid))
-            & (
-                F.col("status").isin("open", "expired")
-                | ((F.col("status") == F.lit("invalidated")) & F.col("end_event_synthetic"))
-            )
+        scoped = episodes_df.filter(F.col("episode_type") == F.lit(episode.episodeid))
+        revisable = scoped.filter(
+            F.col("status").isin("open", "expired")
+            | ((F.col("status") == F.lit("invalidated")) & F.col("end_event_synthetic"))
         )
+        if batch_events_df is not None:
+            batch_end_ids = (
+                batch_events_df.filter(F.col("event_type") == F.lit(episode.end_event))
+                .select(F.col("event_id").alias("end_event_id"))
+                .distinct()
+            )
+            closed_in_batch = scoped.filter(
+                (F.col("status") == F.lit("closed")) & ~F.col("end_event_synthetic")
+            ).join(batch_end_ids, on="end_event_id", how="leftsemi")
+            revisable = revisable.unionByName(closed_in_batch)
         if episode.subject_type:
             revisable = revisable.filter(F.col("subject_type") == F.lit(episode.subject_type))
 

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/engine.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/engine.py
@@ -233,8 +233,12 @@ class EpisodeRunner:
                 .dropDuplicates(["event_id"])
                 .join(starts.select("event_id"), on="event_id", how="left_anti")
             )
+            # allowMissingColumns: the driving events frame can carry
+            # incremental-read bookkeeping columns (SourceVersion,
+            # SourceTimestamp) that reconstructed prior-state rows lack.
             starts = starts.unionByName(
-                reconstructed.withColumn("__temporal_reconstructed_start", F.lit(True))
+                reconstructed.withColumn("__temporal_reconstructed_start", F.lit(True)),
+                allowMissingColumns=True,
             )
 
         starts = starts.alias("start")

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/validation.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/validation.py
@@ -50,7 +50,12 @@ class ActiveSparkSqlExpressionParser:
         if spark is None:
             raise RuntimeError("No active SparkSession available for expression parsing")
 
-        spark._jsparkSession.sessionState().sqlParser().parseExpression(expression)
+        # functions.expr parses eagerly through public API. The direct route
+        # (spark._jsparkSession.sessionState().sqlParser()) is blocked by
+        # py4j security whitelisting on Databricks shared-access clusters.
+        from pyspark.sql import functions as F
+
+        F.expr(expression)
 
 
 @dataclass(frozen=True)

--- a/packages/kindling/data_pipes.py
+++ b/packages/kindling/data_pipes.py
@@ -342,7 +342,11 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
         pipe_activator = self.erps.create_pipe_persist_activator
 
         try:
-            with self.tp.span(component="data_pipes_executer", operation="execute_datapipes"):
+            # reraise=True: a swallowed span exception would leave the failed
+            # run looking successful to the caller.
+            with self.tp.span(
+                component="data_pipes_executer", operation="execute_datapipes", reraise=True
+            ):
                 for index, pipeid in enumerate(pipes):
                     pipe = self.dpr.get_pipe_definition(pipeid)
                     if no_watermark and pipe.use_watermark:
@@ -363,6 +367,7 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
                             operation="execute_datapipe",
                             component=f"pipe-{pipeid}",
                             details=pipe.tags,
+                            reraise=True,
                         ):
                             was_skipped = self._execute_datapipe(
                                 pipe_entity_reader(pipe), pipe_activator(pipe), pipe

--- a/packages/kindling/entity_provider_current_view.py
+++ b/packages/kindling/entity_provider_current_view.py
@@ -30,10 +30,14 @@ class CurrentViewEntityProvider(BaseEntityProvider):
                 "scd.companion_of tag for current_view provider"
             )
 
-        from .data_entities import DataEntityManager
+        from .data_entities import DataEntityRegistry
         from .entity_provider_registry import EntityProviderRegistry
 
-        entity_manager = GlobalInjector.get(DataEntityManager)
+        # Resolve through the DataEntityRegistry interface — the binding all
+        # registrations go through. Injector singletons cache per binding
+        # key, so resolving the concrete manager class here would return a
+        # second, empty registry instance in a bootstrapped app.
+        entity_manager = GlobalInjector.get(DataEntityRegistry)
         provider_registry = GlobalInjector.get(EntityProviderRegistry)
         base_entity = entity_manager.get_entity_definition(base_entity_id)
         if base_entity is None:

--- a/packages/kindling/entity_provider_delta.py
+++ b/packages/kindling/entity_provider_delta.py
@@ -162,15 +162,32 @@ def _quote_sql_identifier(name: str, alias: Optional[str] = None) -> str:
 
 
 def _build_null_safe_change_condition(
-    source_alias: str, target_alias: str, tracked_columns: list[str]
+    source_alias: str, target_alias: str, tracked_columns: list[str], schema=None
 ) -> str:
     if not tracked_columns:
         return "false"
 
+    from pyspark.sql.types import MapType
+
+    unorderable = {
+        field.name
+        for field in (schema.fields if schema else [])
+        if isinstance(field.dataType, MapType)
+    }
+
+    def _comparable(column: str, alias: str) -> str:
+        ident = _quote_sql_identifier(column, alias)
+        # Spark's binary comparison does not support ordering on MAP types;
+        # compare their JSON projection instead (same approach as the
+        # optimize_unchanged hash path).
+        if column in unorderable:
+            return f"to_json({ident})"
+        return ident
+
     return " OR ".join(
         [
-            f"({_quote_sql_identifier(column, source_alias)} != "
-            f"{_quote_sql_identifier(column, target_alias)} OR "
+            f"({_comparable(column, source_alias)} != "
+            f"{_comparable(column, target_alias)} OR "
             f"({_quote_sql_identifier(column, source_alias)} IS NULL) != "
             f"({_quote_sql_identifier(column, target_alias)} IS NULL))"
             for column in tracked_columns
@@ -325,7 +342,9 @@ def _execute_scd2_merge(delta_table, df: DataFrame, entity) -> None:
             )
         new_rows = upserts_df.join(current_target, on=business_keys, how="left_anti")
     else:
-        change_condition = _build_null_safe_change_condition("source", "target", tracked_columns)
+        change_condition = _build_null_safe_change_condition(
+            "source", "target", tracked_columns, schema=upserts_df.schema
+        )
         changed_where = change_condition
         if seq_guard:
             changed_where = f"({change_condition}) AND {seq_guard}"
@@ -463,10 +482,33 @@ class DeltaTableReference:
     def get_delta_table(self) -> DeltaTable:
         """Get DeltaTable instance using appropriate method"""
         if self.access_mode == DeltaAccessMode.CATALOG:
-            return DeltaTable.forName(self.spark, self.get_read_path())
+            try:
+                return DeltaTable.forName(self.spark, self.table_name)
+            except Exception as name_error:
+                # DeltaTable.forName cannot parse catalog-qualified 3-part
+                # names on OSS Delta (and is restricted on some managed
+                # runtimes). Resolve the table's storage location through the
+                # catalog and fall back to a path handle.
+                location = self._resolve_catalog_location()
+                if location is None:
+                    raise name_error
+                return DeltaTable.forPath(self.spark, location)
         elif self.access_mode == DeltaAccessMode.STORAGE:
             return DeltaTable.forPath(self.spark, self.get_read_path())
         raise ValueError(f"Unsupported Delta access mode: {self.access_mode}")
+
+    def _resolve_catalog_location(self) -> Optional[str]:
+        """Resolve a catalog table's storage location, or None if unavailable."""
+        try:
+            quoted = ".".join(
+                f"`{part.strip().replace('`', '``')}`"
+                for part in self.table_name.split(".")
+                if part.strip()
+            )
+            row = self.spark.sql(f"DESCRIBE DETAIL {quoted}").select("location").first()
+            return row["location"] if row else None
+        except Exception:
+            return None
 
     def get_spark_read_stream(self, spark, options=None):
         base = spark.readStream.format("delta")
@@ -1496,7 +1538,10 @@ class DeltaEntityProvider(
             version = table_ref.get_delta_table().history(1).select("version").collect()[0][0]
             self.logger.debug(f"Retrieved table {table_ref.table_name} version: {version}")
             return version
-        except Exception:
+        except Exception as e:
+            # Version 0 doubles as "no table" upstream; an existing table
+            # whose handle fails must be loud, not silently invisible.
+            self.logger.warning(f"Version lookup failed for {table_ref.table_name}: {e}")
             return 0
 
     def _build_merge_condition(self, alias1: str, alias2: str, cols: list[str]) -> str:
@@ -1697,10 +1742,13 @@ class DeltaEntityProvider(
         )
 
         try:
-            if self._check_table_exists(table_ref):
-                self._merge_to_delta_table(df, entity, table_ref)
-            else:
-                self.write_to_entity(df, entity)
+            if not self._check_table_exists(table_ref):
+                # Create the table empty and still run the merge strategy:
+                # writing the raw dataframe would skip SCD bookkeeping (an
+                # SCD2 entity's first rows would land with NULL
+                # is_current/effective columns, invisible to current views).
+                self.ensure_entity_table(entity)
+            self._merge_to_delta_table(df, entity, table_ref)
 
             duration = time.time() - start_time
             self.emit(
@@ -1772,11 +1820,14 @@ class DeltaEntityProvider(
         watermark will record even if more commits land before an action.
         """
         watermark_version = int(cursor) if cursor is not None else None
-        current_version = self.get_entity_version(entity)
 
-        if watermark_version is None and current_version == 0:
-            # Source table does not exist yet.
+        if watermark_version is None and not self.check_entity_exists(entity):
+            # Source table does not exist yet. (Existence is checked
+            # explicitly: version 0 is also a real, readable table whose
+            # creation commit may already contain data.)
             return None, None
+
+        current_version = self.get_entity_version(entity)
 
         if watermark_version is None:
             # Initial load: full read stamped with the version it covers.

--- a/packages/kindling/entity_provider_delta.py
+++ b/packages/kindling/entity_provider_delta.py
@@ -1402,6 +1402,9 @@ class DeltaEntityProvider(
                 # versions the caller's watermark will record, even if more
                 # commits land before an action runs the plan.
                 reader = reader.option("endingVersion", end_version)
+            if self._is_for_name_mode(table_ref.access_mode) and table_ref.table_name:
+                # load() expects a filesystem path; catalog tables read by name.
+                return reader.table(table_ref.table_name)
             return reader.load(table_ref.get_read_path())
         else:
             # Use spark.read.table for catalog-managed tables rather than DeltaTable.forName,

--- a/packages/kindling/watermarking.py
+++ b/packages/kindling/watermarking.py
@@ -204,7 +204,14 @@ class WatermarkManager(WatermarkService, SignalEmitter):
             )
             row = None if df.isEmpty() else df.first()
         except AnalysisException as e:
-            if "DELTA_MISSING_DELTA_TABLE" in str(e):
+            missing_markers = (
+                "DELTA_MISSING_DELTA_TABLE",
+                # Catalog-managed watermark tables surface as missing
+                # tables/views rather than missing Delta paths.
+                "TABLE_OR_VIEW_NOT_FOUND",
+                "DELTA_TABLE_NOT_FOUND",
+            )
+            if any(marker in str(e) for marker in missing_markers):
                 self.logger.debug("Watermarks table does not exist yet")
                 self.emit(
                     "watermark.watermark_missing",
@@ -367,10 +374,13 @@ class WatermarkManager(WatermarkService, SignalEmitter):
         legacy EntityProvider interface but not
         IncrementalReadableEntityProvider."""
         watermark_version = int(cursor) if cursor is not None else None
-        current_version = provider.get_entity_version(entity)
 
-        if watermark_version is None and current_version == 0:
+        if watermark_version is None and not provider.check_entity_exists(entity):
+            # Existence is checked explicitly: version 0 is also a real,
+            # readable table whose creation commit may already contain data.
             return None, None
+
+        current_version = provider.get_entity_version(entity)
 
         if watermark_version is None:
             df = remove_duplicates(

--- a/packages/kindling_cli/pyproject.toml
+++ b/packages/kindling_cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "spark-kindling-cli"
-version = "0.10.44"
+version = "0.10.45a1"
 description = "Command-line tooling for Kindling"
 authors = ["SEP Engineering <engineering@sep.com>"]
 license = "MIT"

--- a/packages/kindling_sdk/pyproject.toml
+++ b/packages/kindling_sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "spark-kindling-sdk"
-version = "0.10.44"
+version = "0.10.45a1"
 description = "Design-time platform SDK for Kindling"
 authors = ["SEP Engineering <engineering@sep.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "spark-kindling"
-version = "0.10.44"
+version = "0.10.45a1"
 description = "A unified framework for data apps across Fabric, Synapse, and Databricks"
 authors = ["SEP Engineering <engineering@sep.com>"]
 license = "MIT"

--- a/tests/data-apps/temporal-test-app/app.py
+++ b/tests/data-apps/temporal-test-app/app.py
@@ -1,0 +1,698 @@
+#!/usr/bin/env python3
+"""
+Temporal Extension Test App
+
+Validates the kindling-ext-temporal batch contract on a real platform
+(Delta storage, real providers, real watermark cursors) across TWO separate
+job executions sharing one test_id-scoped storage root:
+
+  Scenario run1 — end-to-end flow + open/expired seed (Experiment 1)
+    1. ingest_conditions: one valid rule merges, one malformed rule is
+       quarantined per row (real quarantine table write)
+    2. telemetry -> base events -> condition engine -> episodes ->
+       determination events, executed through the framework pipe runner
+    3. machine-hot closes with a real end event; machine-late has a start
+       only and expires synthetically at the configured
+       kindling.temporal.evaluation_time
+    4. first-run tolerance: the episode engine's prior-state read must not
+       fail when the episodes table does not exist yet
+
+  Scenario run2 — cross-run late-end revision (Experiment 2) + gold
+    1. only the late real end telemetry for machine-late is ingested
+    2. the engine reconstructs the persisted expired episode (engine-owned
+       prior-state read across processes) and revises it in place to closed
+       with end_event_synthetic=false, same episode_id
+    3. the corrective .closed determination event is appended alongside the
+       historical .expired event
+    4. gold interval-join aggregation (Experiment 3): avg temperature per
+       closed episode window
+
+The scenario is selected by the `temporal_test_scenario` config value the
+system test passes per job; the evaluation time comes from
+`kindling.temporal.evaluation_time` config, exercising the documented
+config path (not the per-execution kwarg).
+
+Each step emits a TEST_ID= marker so the system test harness can validate
+individual outcomes from streamed stdout.
+"""
+
+import sys
+from datetime import datetime
+
+from kindling.data_entities import DataEntities, DataEntityRegistry, EntityMetadata
+from kindling.data_pipes import DataPipes, DataPipesExecution
+from kindling.entity_provider_registry import EntityProviderRegistry
+from kindling.injection import GlobalInjector, get_kindling_service
+from kindling.platform_provider import PlatformServiceProvider
+from kindling.spark_config import ConfigService
+from kindling.spark_log_provider import SparkLoggerProvider
+from kindling.spark_session import get_or_create_spark_session
+from kindling_ext_temporal import (
+    DataEpisodes,
+    DataEvents,
+    TemporalEntityResolver,
+    condition_quarantine_schema,
+    conditions_schema,
+    episodes_schema,
+    events_schema,
+    ingest_conditions,
+)
+from pyspark.sql import functions as F
+from pyspark.sql.types import (
+    DoubleType,
+    StringType,
+    StructField,
+    StructType,
+    TimestampType,
+)
+
+# ---------------------------------------------------------------------------
+# Bootstrap
+# ---------------------------------------------------------------------------
+
+logger = get_kindling_service(SparkLoggerProvider).get_logger("temporal-test-app")
+config_service = get_kindling_service(ConfigService)
+
+test_id = str(config_service.get("test_id") or "unknown").replace("-", "_")
+scenario = str(config_service.get("temporal_test_scenario") or "run1").strip().lower()
+
+platform_service = get_kindling_service(PlatformServiceProvider).get_service()
+platform_name = platform_service.get_platform_name() if platform_service else "unknown"
+
+msg = f"TEST_ID={test_id} status=STARTED platform={platform_name} scenario={scenario}"
+logger.info(msg)
+print(msg, flush=True)
+
+spark = get_or_create_spark_session()
+
+table_root = config_service.get("kindling.storage.table_root") or "Tables"
+temporal_root = f"{table_root}/temporal_test"
+
+# ---------------------------------------------------------------------------
+# Entities — storage-mode paths under the test_id-scoped table_root so the
+# run is isolated from other tests and cleaned up by cleanup_test_storage.
+# ---------------------------------------------------------------------------
+
+
+def _storage_tags(leaf: str, extra: dict = None) -> dict:
+    tags = {
+        "provider_type": "delta",
+        "provider.path": f"{temporal_root}/{leaf}",
+        "provider.access_mode": "storage",
+    }
+    if extra:
+        tags.update(extra)
+    return tags
+
+
+class SystemTestTemporalEntityResolver(TemporalEntityResolver):
+    """Test-scoped resolver: canonical temporal entities at explicit paths."""
+
+    def __init__(self):
+        self._events_entity = EntityMetadata(
+            entityid="silver.events",
+            name="events",
+            merge_columns=["event_id"],
+            tags=_storage_tags("events", {"temporal.kind": "events"}),
+            schema=events_schema(),
+            partition_columns=[],
+        )
+        self._conditions_entity = EntityMetadata(
+            entityid="silver.conditions",
+            name="conditions",
+            merge_columns=["condition_id"],
+            tags=_storage_tags(
+                "conditions",
+                {
+                    "temporal.kind": "conditions",
+                    "scd.type": "2",
+                    "scd.routing_key": "hash",
+                    "scd.close_on_missing": "true",
+                    "scd.current_entity_id": "silver.conditions.current",
+                },
+            ),
+            schema=conditions_schema(),
+            partition_columns=[],
+        )
+        self._episodes_entity = EntityMetadata(
+            entityid="silver.episodes",
+            name="episodes",
+            merge_columns=["episode_id"],
+            tags=_storage_tags("episodes", {"temporal.kind": "episodes"}),
+            schema=episodes_schema(),
+            partition_columns=[],
+        )
+
+    def get_events_entity(self) -> EntityMetadata:
+        return self._events_entity
+
+    def get_conditions_entity(self) -> EntityMetadata:
+        return self._conditions_entity
+
+    def get_episodes_entity(self) -> EntityMetadata:
+        return self._episodes_entity
+
+
+resolver = SystemTestTemporalEntityResolver()
+GlobalInjector.bind(TemporalEntityResolver, resolver)
+
+TELEMETRY_SCHEMA = StructType(
+    [
+        StructField("machine_id", StringType(), False),
+        StructField("reading_ts", TimestampType(), False),
+        StructField("temperature", DoubleType(), False),
+    ]
+)
+
+QUARANTINE_SCHEMA = StructType(
+    list(condition_quarantine_schema().fields)
+    + [StructField("quarantined_at", TimestampType(), True)]
+)
+
+DataEntities.entity(
+    entityid="bronze.telemetry",
+    name="telemetry",
+    merge_columns=["machine_id", "reading_ts"],
+    tags=_storage_tags("telemetry"),
+    schema=TELEMETRY_SCHEMA,
+    partition_columns=[],
+)
+
+DataEntities.entity(
+    entityid="silver.conditions.quarantine",
+    name="conditions_quarantine",
+    merge_columns=[],
+    tags=_storage_tags("conditions_quarantine"),
+    schema=QUARANTINE_SCHEMA,
+    partition_columns=[],
+)
+
+GOLD_SCHEMA = StructType(
+    [
+        StructField("episode_id", StringType(), False),
+        StructField("machine_id", StringType(), False),
+        StructField("start_time", TimestampType(), False),
+        StructField("end_time", TimestampType(), True),
+        StructField("avg_temperature", DoubleType(), True),
+        StructField("reading_count", StringType(), True),
+    ]
+)
+
+DataEntities.entity(
+    entityid="gold.thermal_excursions",
+    name="thermal_excursions",
+    merge_columns=["episode_id"],
+    tags=_storage_tags("thermal_excursions"),
+    schema=GOLD_SCHEMA,
+    partition_columns=[],
+)
+
+# ---------------------------------------------------------------------------
+# Temporal declarations — telemetry -> events -> condition -> episode
+# ---------------------------------------------------------------------------
+
+
+@DataEvents.base_event(
+    eventid="telemetry.base",
+    input_entity_id="bronze.telemetry",
+    subject_type="machine",
+    subject_keys=["machine_id"],
+    time_column="reading_ts",
+    event_type="telemetry.observed",
+    payload_columns=["temperature"],
+    source_system="system-test",
+    use_watermark=True,
+)
+def normalize_telemetry(df):
+    return df
+
+
+DataEvents.condition_engine(engineid="default")
+
+EPISODE_ID = "episode.temperature_high_active"
+
+DataEpisodes.episode(
+    episodeid=EPISODE_ID,
+    start_event="condition.temperature_high.entered",
+    end_event="condition.temperature_high.exited",
+    subject_type="machine",
+    expires_after_seconds=300,
+)
+
+
+@DataPipes.pipe(
+    pipeid="gold.thermal_excursions",
+    name="Thermal excursions",
+    input_entity_ids=["silver.episodes", "bronze.telemetry"],
+    output_entity_id="gold.thermal_excursions",
+    output_type="delta",
+    tags={},
+    use_watermark=False,
+)
+def thermal_excursions(silver_episodes, bronze_telemetry):
+    episodes = silver_episodes.filter(
+        (F.col("episode_type") == EPISODE_ID) & (F.col("status") == "closed")
+    ).select("episode_id", "subject_id", "start_time", "end_time")
+    return (
+        episodes.join(
+            bronze_telemetry,
+            (episodes.subject_id == bronze_telemetry.machine_id)
+            & (bronze_telemetry.reading_ts >= episodes.start_time)
+            & (bronze_telemetry.reading_ts <= episodes.end_time),
+        )
+        .groupBy("episode_id", "machine_id", "start_time", "end_time")
+        .agg(
+            F.avg("temperature").alias("avg_temperature"),
+            F.count("*").cast("string").alias("reading_count"),
+        )
+    )
+
+
+TEMPORAL_PIPES = [
+    "temporal.event.telemetry.base",
+    "temporal.condition.default",
+    f"temporal.episode.{EPISODE_ID}",
+    f"temporal.episode_event.{EPISODE_ID}",
+]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+T0 = datetime(2026, 7, 14, 12, 0, 0)
+T_END = datetime(2026, 7, 14, 12, 10, 0)
+EXPIRED_END = datetime(2026, 7, 14, 12, 5, 0)  # T0 + expires_after_seconds
+
+test_results = {}
+
+
+def _pass(test_name: str) -> None:
+    test_results[test_name] = True
+    line = f"TEST_ID={test_id} test={test_name} status=PASSED"
+    logger.info(line)
+    print(line, flush=True)
+
+
+def _fail(test_name: str, reason: str) -> None:
+    test_results[test_name] = False
+    line = f"TEST_ID={test_id} test={test_name} status=FAILED reason={reason}"
+    logger.error(line)
+    print(line, flush=True)
+
+
+def _check(test_name: str, condition: bool, reason: str = "") -> None:
+    if condition:
+        _pass(test_name)
+    else:
+        _fail(test_name, (reason or "condition was False").replace("\n", " | "))
+
+
+def _step(test_name: str, fn) -> None:
+    """Run one assertion step; an exception fails this step only."""
+    try:
+        fn()
+    except Exception as exc:  # noqa: BLE001 - keep later steps observable
+        import traceback
+
+        traceback.print_exc()
+        _fail(test_name, f"exception: {exc}".replace("\n", " | "))
+
+
+def _diag(label: str, value) -> None:
+    print(f"DIAG {label}: {value}", flush=True)
+
+
+def _entity(entity_id: str) -> EntityMetadata:
+    return GlobalInjector.get(DataEntityRegistry).get_entity_definition(entity_id)
+
+
+def _read(entity_id: str):
+    entity = _entity(entity_id)
+    return (
+        GlobalInjector.get(EntityProviderRegistry)
+        .get_provider_for_entity(entity)
+        .read_entity(entity)
+    )
+
+
+def _append(entity_id: str, df) -> None:
+    entity = _entity(entity_id)
+    GlobalInjector.get(EntityProviderRegistry).get_provider_for_entity(entity).append_to_entity(
+        df, entity
+    )
+
+
+def _run_temporal_pipes() -> None:
+    get_kindling_service(DataPipesExecution).run_datapipes(TEMPORAL_PIPES)
+
+
+def _ensure_tables() -> None:
+    """Pre-create Delta tables empty (idempotent), mirroring the migration
+    pattern core apps use. Watermarked first reads treat a table whose
+    creation commit already contains data (version 0) as having no new
+    data, so seed/pipe writes must land at version >= 1.
+
+    The conditions entity is deliberately excluded: its table is created by
+    the SCD2 merge inside ingest_conditions, which owns its bookkeeping
+    columns.
+    """
+    for entity_id in [
+        "bronze.telemetry",
+        "silver.events",
+        "silver.episodes",
+        "silver.conditions.quarantine",
+        "gold.thermal_excursions",
+    ]:
+        entity = _entity(entity_id)
+        provider = GlobalInjector.get(EntityProviderRegistry).get_provider_for_entity(entity)
+        provider.ensure_entity_table(entity)
+
+
+def _episode_rows(subject_id: str):
+    return (
+        _read("silver.episodes")
+        .filter((F.col("episode_type") == EPISODE_ID) & (F.col("subject_id") == subject_id))
+        .collect()
+    )
+
+
+def _determination_events(subject_id: str):
+    return (
+        _read("silver.events")
+        .filter((F.col("event_class") == "episode") & (F.col("subject_id") == subject_id))
+        .collect()
+    )
+
+
+def _diag_tables() -> None:
+    def dump(entity_id, columns):
+        try:
+            rows = _read(entity_id).select(*columns).collect()
+            _diag(entity_id, [tuple(row) for row in rows])
+        except Exception as exc:  # noqa: BLE001 - diagnostics only
+            _diag(entity_id, f"unreadable: {exc}")
+
+    dump("silver.events", ["event_type", "generation", "event_class", "subject_id", "event_ts"])
+    dump(
+        "silver.episodes",
+        ["episode_type", "subject_id", "status", "close_reason", "end_event_synthetic"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenario run1 — Experiment 1: end-to-end flow on real storage
+# ---------------------------------------------------------------------------
+
+
+def scenario_run1():
+    # Rules-as-data ingestion: one valid rule, one malformed rule.
+    conditions_df = spark.createDataFrame(
+        [
+            (
+                "condition.temperature_high",
+                ["telemetry.observed"],
+                "machine",
+                {
+                    "enter_when": "cast(payload['temperature'] as double) > 90",
+                    "exit_when": "cast(payload['temperature'] as double) <= 90",
+                },
+                True,
+                datetime(2026, 7, 14, 11, 0, 0),
+                None,
+            ),
+            (
+                "condition.bad_rule",
+                ["telemetry.observed"],
+                "machine",
+                {
+                    "enter_when": "this is ! not (valid sql",
+                    "exit_when": "false",
+                },
+                True,
+                datetime(2026, 7, 14, 11, 0, 0),
+                None,
+            ),
+        ],
+        conditions_schema(),
+    )
+    result = ingest_conditions(conditions_df)
+    _diag(
+        "ingestion result",
+        {
+            "ingested_count": result.ingested_count,
+            "quarantined": [(q.condition_id, q.errors) for q in result.quarantined],
+            "quarantine_entity_id": result.quarantine_entity_id,
+        },
+    )
+    _check(
+        "run1_conditions_ingested",
+        result.ingested_count == 1,
+        f"expected 1 ingested, got {result.ingested_count}",
+    )
+    _check(
+        "run1_conditions_quarantined",
+        len(result.quarantined) == 1 and result.quarantined[0].condition_id == "condition.bad_rule",
+        f"expected condition.bad_rule quarantined, got "
+        f"{[(q.condition_id, q.errors) for q in result.quarantined]}",
+    )
+
+    def check_quarantine_persisted():
+        quarantine_rows = _read("silver.conditions.quarantine").collect()
+        _diag("quarantine rows", [(r.condition_id, r.errors) for r in quarantine_rows])
+        _check(
+            "run1_quarantine_persisted",
+            len(quarantine_rows) == 1 and quarantine_rows[0].condition_id == "condition.bad_rule",
+            f"expected 1 persisted quarantine row, got {len(quarantine_rows)}",
+        )
+
+    _step("run1_quarantine_persisted", check_quarantine_persisted)
+
+    def check_current_view():
+        current_rows = _read("silver.conditions.current").collect()
+        _diag("conditions current rows", [r.condition_id for r in current_rows])
+        _check(
+            "run1_conditions_current_view",
+            len(current_rows) == 1 and current_rows[0].condition_id == "condition.temperature_high",
+            f"expected temperature_high current, got {[r.condition_id for r in current_rows]}",
+        )
+
+    _step("run1_conditions_current_view", check_current_view)
+
+    # Telemetry: machine-hot has start+end in-batch; machine-late start only.
+    _append(
+        "bronze.telemetry",
+        spark.createDataFrame(
+            [
+                ("machine-hot", T0, 95.0),
+                ("machine-hot", T_END, 80.0),
+                ("machine-late", T0, 95.0),
+            ],
+            TELEMETRY_SCHEMA,
+        ),
+    )
+
+    # First-run tolerance: episodes table does not exist yet; the engine's
+    # prior-state read must proceed with no prior state instead of failing.
+    def run_pipes_first_time():
+        _run_temporal_pipes()
+        _pass("run1_first_run_pipes_executed")
+
+    _step("run1_first_run_pipes_executed", run_pipes_first_time)
+
+    _diag_tables()
+
+    def check_hot_closed():
+        hot = _episode_rows("machine-hot")
+        _check(
+            "run1_hot_episode_closed",
+            len(hot) == 1
+            and hot[0].status == "closed"
+            and hot[0].close_reason == "end_event"
+            and hot[0].end_event_synthetic is False
+            and hot[0].duration_ms == 600000,
+            f"machine-hot rows: {[(r.status, r.close_reason, r.duration_ms) for r in hot]}",
+        )
+
+    _step("run1_hot_episode_closed", check_hot_closed)
+
+    def check_late_expired():
+        late = _episode_rows("machine-late")
+        _check(
+            "run1_late_episode_expired",
+            len(late) == 1
+            and late[0].status == "expired"
+            and late[0].close_reason == "expiration"
+            and late[0].end_event_synthetic is True
+            and late[0].end_time == EXPIRED_END,
+            f"machine-late rows: {[(r.status, r.close_reason, r.end_time) for r in late]}",
+        )
+
+    _step("run1_late_episode_expired", check_late_expired)
+
+    def check_hot_determination():
+        hot = _episode_rows("machine-hot")
+        hot_events = _determination_events("machine-hot")
+        _check(
+            "run1_hot_determination_event",
+            len(hot_events) == 1
+            and hot_events[0].event_type == f"{EPISODE_ID}.closed"
+            and hot_events[0].generation == 2
+            and len(hot) == 1
+            and hot_events[0].correlation_id == hot[0].episode_id,
+            f"machine-hot determination events: "
+            f"{[(e.event_type, e.generation) for e in hot_events]}",
+        )
+
+    _step("run1_hot_determination_event", check_hot_determination)
+
+    def check_late_expiration_event():
+        late = _episode_rows("machine-late")
+        late_events = _determination_events("machine-late")
+        _check(
+            "run1_late_expiration_event",
+            len(late_events) == 1
+            and late_events[0].event_type == f"{EPISODE_ID}.expired"
+            and len(late) == 1
+            and late_events[0].correlation_id == late[0].episode_id,
+            f"machine-late determination events: {[e.event_type for e in late_events]}",
+        )
+
+    _step("run1_late_expiration_event", check_late_expiration_event)
+
+
+# ---------------------------------------------------------------------------
+# Scenario run2 — Experiment 2: cross-run late-end revision, Experiment 3: gold
+# ---------------------------------------------------------------------------
+
+
+def scenario_run2():
+    # Only the late real end arrives in this process; everything else is
+    # persisted state from the run1 job execution.
+    _append(
+        "bronze.telemetry",
+        spark.createDataFrame([("machine-late", T_END, 80.0)], TELEMETRY_SCHEMA),
+    )
+
+    expired_before = _episode_rows("machine-late")
+    _check(
+        "run2_sees_persisted_expired_episode",
+        len(expired_before) == 1 and expired_before[0].status == "expired",
+        f"expected persisted expired episode, got {[(r.status,) for r in expired_before]}",
+    )
+
+    def run_pipes():
+        _run_temporal_pipes()
+        _pass("run2_pipes_executed")
+
+    _step("run2_pipes_executed", run_pipes)
+
+    _diag_tables()
+
+    def check_revised_in_place():
+        late = _episode_rows("machine-late")
+        _check(
+            "run2_late_episode_revised_in_place",
+            len(late) == 1
+            and late[0].status == "closed"
+            and late[0].close_reason == "end_event"
+            and late[0].end_event_synthetic is False
+            and late[0].end_time == T_END
+            and late[0].duration_ms == 600000,
+            f"machine-late rows: "
+            f"{[(r.status, r.close_reason, r.end_time, r.duration_ms) for r in late]}",
+        )
+        _check(
+            "run2_same_episode_id",
+            len(late) == 1
+            and len(expired_before) == 1
+            and late[0].episode_id == expired_before[0].episode_id
+            and late[0].start_event_id == expired_before[0].start_event_id,
+            "revised episode did not keep its identity",
+        )
+
+    _step("run2_late_episode_revised_in_place", check_revised_in_place)
+
+    def check_corrective_event():
+        late = _episode_rows("machine-late")
+        late_events = _determination_events("machine-late")
+        event_types = sorted(e.event_type for e in late_events)
+        _check(
+            "run2_corrective_event_appended",
+            event_types == [f"{EPISODE_ID}.closed", f"{EPISODE_ID}.expired"]
+            and len(late) == 1
+            and all(e.correlation_id == late[0].episode_id for e in late_events),
+            f"expected historical expired + corrective closed, got {event_types}",
+        )
+
+    _step("run2_corrective_event_appended", check_corrective_event)
+
+    def check_hot_untouched():
+        hot = _episode_rows("machine-hot")
+        _check(
+            "run2_hot_episode_untouched",
+            len(hot) == 1 and hot[0].status == "closed" and hot[0].end_event_synthetic is False,
+            f"machine-hot rows: {[(r.status,) for r in hot]}",
+        )
+
+    _step("run2_hot_episode_untouched", check_hot_untouched)
+
+    # Experiment 3: gold interval-join aggregation after revision.
+    def check_gold():
+        get_kindling_service(DataPipesExecution).run_datapipes(["gold.thermal_excursions"])
+        gold = {row.machine_id: row for row in _read("gold.thermal_excursions").collect()}
+        _diag(
+            "gold rows",
+            [(m, r.avg_temperature, r.reading_count) for m, r in gold.items()],
+        )
+        _check(
+            "run2_gold_aggregation",
+            set(gold) == {"machine-hot", "machine-late"}
+            and all(abs(row.avg_temperature - 87.5) < 1e-9 for row in gold.values())
+            and all(row.reading_count == "2" for row in gold.values()),
+            f"gold rows: {[(m, r.avg_temperature, r.reading_count) for m, r in gold.items()]}",
+        )
+
+    _step("run2_gold_aggregation", check_gold)
+
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+_diag(
+    "config",
+    {
+        "temporal_test_scenario": config_service.get("temporal_test_scenario", None),
+        "kindling.temporal.evaluation_time": config_service.get(
+            "kindling.temporal.evaluation_time", None
+        ),
+        "kindling.temporal.conditions.quarantine_entity_id": config_service.get(
+            "kindling.temporal.conditions.quarantine_entity_id", None
+        ),
+        "kindling.storage.table_root": table_root,
+    },
+)
+
+try:
+    _ensure_tables()
+    if scenario == "run2":
+        scenario_run2()
+    else:
+        scenario_run1()
+except Exception as exc:  # noqa: BLE001 - report and exit nonzero
+    import traceback
+
+    traceback.print_exc()
+    _fail(f"{scenario}_overall", str(exc))
+
+overall = all(test_results.values()) if test_results else False
+overall_status = "PASSED" if overall else "FAILED"
+failed = [name for name, ok in test_results.items() if not ok]
+
+msg = f"TEST_ID={test_id} status=COMPLETED result={overall_status}"
+if failed:
+    msg += f" failed_tests={','.join(failed)}"
+logger.info(msg)
+print(msg, flush=True)
+
+sys.exit(0 if overall else 1)

--- a/tests/data-apps/temporal-test-app/app.py
+++ b/tests/data-apps/temporal-test-app/app.py
@@ -50,11 +50,8 @@ from kindling.spark_session import get_or_create_spark_session
 from kindling_ext_temporal import (
     DataEpisodes,
     DataEvents,
-    TemporalEntityResolver,
     condition_quarantine_schema,
     conditions_schema,
-    episodes_schema,
-    events_schema,
     ingest_conditions,
 )
 from pyspark.sql import functions as F
@@ -86,75 +83,15 @@ print(msg, flush=True)
 spark = get_or_create_spark_session()
 
 table_root = config_service.get("kindling.storage.table_root") or "Tables"
-temporal_root = f"{table_root}/temporal_test"
 
 # ---------------------------------------------------------------------------
-# Entities — storage-mode paths under the test_id-scoped table_root so the
-# run is isolated from other tests and cleaned up by cleanup_test_storage.
+# Entities — the shipped SimpleTemporalEntityResolver supplies the canonical
+# temporal entities. All tables are catalog-managed: the system test passes
+# kindling.storage.table_catalog / table_schema / table_name_prefix so every
+# entity (including system.watermarks) lands in a UC-supported, test-scoped
+# namespace. Delta tables at /Volumes paths are not durable on UC shared
+# clusters, so no provider.path tags here.
 # ---------------------------------------------------------------------------
-
-
-def _storage_tags(leaf: str, extra: dict = None) -> dict:
-    tags = {
-        "provider_type": "delta",
-        "provider.path": f"{temporal_root}/{leaf}",
-        "provider.access_mode": "storage",
-    }
-    if extra:
-        tags.update(extra)
-    return tags
-
-
-class SystemTestTemporalEntityResolver(TemporalEntityResolver):
-    """Test-scoped resolver: canonical temporal entities at explicit paths."""
-
-    def __init__(self):
-        self._events_entity = EntityMetadata(
-            entityid="silver.events",
-            name="events",
-            merge_columns=["event_id"],
-            tags=_storage_tags("events", {"temporal.kind": "events"}),
-            schema=events_schema(),
-            partition_columns=[],
-        )
-        self._conditions_entity = EntityMetadata(
-            entityid="silver.conditions",
-            name="conditions",
-            merge_columns=["condition_id"],
-            tags=_storage_tags(
-                "conditions",
-                {
-                    "temporal.kind": "conditions",
-                    "scd.type": "2",
-                    "scd.routing_key": "hash",
-                    "scd.close_on_missing": "true",
-                    "scd.current_entity_id": "silver.conditions.current",
-                },
-            ),
-            schema=conditions_schema(),
-            partition_columns=[],
-        )
-        self._episodes_entity = EntityMetadata(
-            entityid="silver.episodes",
-            name="episodes",
-            merge_columns=["episode_id"],
-            tags=_storage_tags("episodes", {"temporal.kind": "episodes"}),
-            schema=episodes_schema(),
-            partition_columns=[],
-        )
-
-    def get_events_entity(self) -> EntityMetadata:
-        return self._events_entity
-
-    def get_conditions_entity(self) -> EntityMetadata:
-        return self._conditions_entity
-
-    def get_episodes_entity(self) -> EntityMetadata:
-        return self._episodes_entity
-
-
-resolver = SystemTestTemporalEntityResolver()
-GlobalInjector.bind(TemporalEntityResolver, resolver)
 
 TELEMETRY_SCHEMA = StructType(
     [
@@ -173,7 +110,7 @@ DataEntities.entity(
     entityid="bronze.telemetry",
     name="telemetry",
     merge_columns=["machine_id", "reading_ts"],
-    tags=_storage_tags("telemetry"),
+    tags={"provider_type": "delta"},
     schema=TELEMETRY_SCHEMA,
     partition_columns=[],
 )
@@ -182,7 +119,7 @@ DataEntities.entity(
     entityid="silver.conditions.quarantine",
     name="conditions_quarantine",
     merge_columns=[],
-    tags=_storage_tags("conditions_quarantine"),
+    tags={"provider_type": "delta"},
     schema=QUARANTINE_SCHEMA,
     partition_columns=[],
 )
@@ -202,7 +139,7 @@ DataEntities.entity(
     entityid="gold.thermal_excursions",
     name="thermal_excursions",
     merge_columns=["episode_id"],
-    tags=_storage_tags("thermal_excursions"),
+    tags={"provider_type": "delta"},
     schema=GOLD_SCHEMA,
     partition_columns=[],
 )
@@ -670,6 +607,13 @@ _diag(
             "kindling.temporal.conditions.quarantine_entity_id", None
         ),
         "kindling.storage.table_root": table_root,
+        "kindling.storage.table_catalog": config_service.get(
+            "kindling.storage.table_catalog", None
+        ),
+        "kindling.storage.table_schema": config_service.get("kindling.storage.table_schema", None),
+        "kindling.storage.table_name_prefix": config_service.get(
+            "kindling.storage.table_name_prefix", None
+        ),
     },
 )
 
@@ -688,6 +632,32 @@ except Exception as exc:  # noqa: BLE001 - report and exit nonzero
 overall = all(test_results.values()) if test_results else False
 overall_status = "PASSED" if overall else "FAILED"
 failed = [name for name, ok in test_results.items() if not ok]
+
+if scenario == "run2" and overall:
+    # The tables are prefix-scoped catalog tables the storage cleanup path
+    # does not cover; drop them once the full lifecycle has been asserted.
+    # A failed run keeps them for debugging.
+    from kindling.data_entities import EntityNameMapper
+
+    name_mapper = GlobalInjector.get(EntityNameMapper)
+    for entity_id in [
+        "bronze.telemetry",
+        "silver.events",
+        "silver.conditions",
+        "silver.episodes",
+        "silver.conditions.quarantine",
+        "gold.thermal_excursions",
+        "system.watermarks",
+    ]:
+        try:
+            entity = _entity(entity_id)
+            table_name = name_mapper.get_table_name(
+                entity if entity is not None else type("E", (), {"entityid": entity_id})()
+            )
+            spark.sql(f"DROP TABLE IF EXISTS {table_name}")
+            _diag("dropped", table_name)
+        except Exception as exc:  # noqa: BLE001 - cleanup is best-effort
+            _diag("drop failed", f"{entity_id}: {exc}")
 
 msg = f"TEST_ID={test_id} status=COMPLETED result={overall_status}"
 if failed:

--- a/tests/data-apps/temporal-test-app/settings.yaml
+++ b/tests/data-apps/temporal-test-app/settings.yaml
@@ -1,0 +1,3 @@
+kindling:
+  extensions:
+    - kindling-ext-temporal==0.1.0

--- a/tests/system/extensions/temporal/test_temporal_platform.py
+++ b/tests/system/extensions/temporal/test_temporal_platform.py
@@ -1,0 +1,227 @@
+"""
+Platform system test for the temporal extension (kindling-ext-temporal).
+
+Deploys tests/data-apps/temporal-test-app once and runs it as TWO separate
+job executions sharing one test_id-scoped storage root:
+
+  Run 1 (scenario run1) — Experiment 1: telemetry -> base events ->
+  condition engine (rules ingested via ingest_conditions, malformed row
+  quarantined) -> episodes -> determination events, all persisted to real
+  Delta storage. machine-hot closes with a real end; machine-late is
+  start-only and expires at the configured
+  kindling.temporal.evaluation_time. Also proves first-run tolerance (the
+  engine-owned prior-state read with no episodes table yet).
+
+  Run 2 (scenario run2) — Experiment 2: a separate process ingests only the
+  late real end event. The engine reconstructs the persisted expired
+  episode across processes and revises it in place (same episode_id,
+  status=closed, end_event_synthetic=false) and appends the corrective
+  .closed determination event alongside the historical .expired one.
+  Experiment 3: a gold interval-join aggregation (avg temperature per
+  closed episode window) asserted after revision.
+
+Per-run configuration travels through job-level config_overrides
+(kindling.temporal.evaluation_time, temporal_test_scenario) because
+Databricks run-time python_params would replace the bootstrap args — two
+job definitions over one deployed app is the supported per-run config
+mechanism.
+
+The in-app assertions emit TEST_ID markers; this test validates them from
+the streamed stdout, mirroring tests/system/core conventions.
+
+Usage:
+    poe test-extension --extension temporal --platform databricks
+"""
+
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+from tests.system.test_helpers import (
+    cleanup_test_storage,
+    get_system_test_poll_interval,
+    get_system_test_stream_max_wait,
+)
+
+EXPECTED_RUN1_TESTS = [
+    "run1_conditions_ingested",
+    "run1_conditions_quarantined",
+    "run1_quarantine_persisted",
+    "run1_conditions_current_view",
+    "run1_first_run_pipes_executed",
+    "run1_hot_episode_closed",
+    "run1_late_episode_expired",
+    "run1_hot_determination_event",
+    "run1_late_expiration_event",
+]
+
+EXPECTED_RUN2_TESTS = [
+    "run2_sees_persisted_expired_episode",
+    "run2_pipes_executed",
+    "run2_late_episode_revised_in_place",
+    "run2_same_episode_id",
+    "run2_corrective_event_appended",
+    "run2_hot_episode_untouched",
+    "run2_gold_aggregation",
+]
+
+TEMPORAL_EXTENSION_SPEC = "kindling-ext-temporal==0.1.0"
+
+
+def _run_scenario(
+    client,
+    stdout_validator,
+    *,
+    job_id: str,
+    test_id: str,
+    scenario: str,
+    platform: str,
+    expected_tests,
+):
+    """Run one job execution and validate its in-app TEST_ID markers."""
+    run_id = client.run_job(job_id=job_id)
+    print(f"🏃 {scenario} started: run_id={run_id}")
+    sys.stdout.flush()
+
+    stdout_validator.stream_with_callback(
+        job_id=job_id,
+        run_id=run_id,
+        print_lines=True,
+        poll_interval=get_system_test_poll_interval(10.0),
+        max_wait=get_system_test_stream_max_wait(900.0, platform),
+    )
+
+    status_info = client.get_job_status(run_id=run_id)
+    final_status = str(status_info.get("status") or "").upper()
+    print(f"📊 {scenario} final status: {final_status}")
+
+    test_results = stdout_validator.validate_tests(test_id, expected_tests)
+    failed = {
+        name: result["status"] for name, result in test_results.items() if not result["passed"]
+    }
+    completion = stdout_validator.validate_completion(test_id)
+
+    assert not failed, f"{scenario} in-app assertions failed or missing: {failed}"
+    assert completion["passed"], f"{scenario} did not complete PASSED: {completion['message']}"
+    assert final_status not in {
+        "FAILED",
+        "ERROR",
+        "CANCELLED",
+    }, f"{scenario} job ended {final_status}"
+    print(f"✅ {scenario} validated: {len(expected_tests)} in-app assertions PASSED")
+    return run_id
+
+
+@pytest.mark.system
+@pytest.mark.slow
+class TestTemporalExtensionPlatform:
+    """Temporal extension lifecycle against real platform storage."""
+
+    def test_temporal_cross_run_lifecycle(self, platform_client, app_packager, stdout_validator):
+        client, platform = platform_client
+        if platform != "databricks":
+            pytest.skip(
+                "Temporal platform coverage is currently validated on Databricks only; "
+                "the app itself is platform-agnostic."
+            )
+
+        workspace_root = Path(__file__).parent.parent.parent.parent
+        app_path = workspace_root / "data-apps" / "temporal-test-app"
+        assert app_path.exists(), f"Test app not found at {app_path}"
+
+        test_id = str(uuid.uuid4())[:8]
+        app_name = f"temporal-test-app-{test_id}"
+        print(f"\n🧪 Temporal extension system test on {platform.upper()} (test_id={test_id})")
+
+        app_files = app_packager.prepare_app_files(str(app_path))
+        print(f"📦 Prepared {len(app_files)} app files")
+        client.deploy_app(app_name, app_files)
+        print(f"📂 Deployed app: {app_name}")
+
+        def _job_config(scenario: str, evaluation_time: str) -> dict:
+            # Both jobs share test_id, so they share the test-scoped storage
+            # root: run2 revises the episodes run1 persisted.
+            return {
+                "job_name": f"systest-temporal-{scenario}-{test_id}",
+                "app_name": app_name,
+                "entry_point": "app.py",
+                "test_id": test_id,
+                "config_overrides": {
+                    "temporal_test_scenario": scenario,
+                    "kindling": {
+                        # settings.yaml also declares the extension, but the
+                        # harness's kindling.extensions override replaces that
+                        # key wholesale, so declare it here to survive the merge.
+                        "extensions": [TEMPORAL_EXTENSION_SPEC],
+                        "temporal": {
+                            "evaluation_time": evaluation_time,
+                            "conditions": {"quarantine_entity_id": "silver.conditions.quarantine"},
+                        },
+                    },
+                },
+            }
+
+        job_ids = []
+        try:
+            run1 = client.create_job(
+                job_name=f"systest-temporal-run1-{test_id}",
+                job_config=_job_config("run1", "2026-07-14 12:30:00"),
+            )
+            job_ids.append(run1["job_id"])
+            _run_scenario(
+                client,
+                stdout_validator,
+                job_id=run1["job_id"],
+                test_id=test_id.replace("-", "_"),
+                scenario="run1",
+                platform=platform,
+                expected_tests=EXPECTED_RUN1_TESTS,
+            )
+
+            extension_results = stdout_validator.validate_extension_loading("kindling-ext-temporal")
+            stdout_validator.print_validation_summary(
+                extension_results, "Temporal Extension Loading"
+            )
+            assert extension_results.get(
+                "extension_install"
+            ), "kindling-ext-temporal installation not found in stdout"
+
+            run2 = client.create_job(
+                job_name=f"systest-temporal-run2-{test_id}",
+                job_config=_job_config("run2", "2026-07-14 12:45:00"),
+            )
+            job_ids.append(run2["job_id"])
+            _run_scenario(
+                client,
+                stdout_validator,
+                job_id=run2["job_id"],
+                test_id=test_id.replace("-", "_"),
+                scenario="run2",
+                platform=platform,
+                expected_tests=EXPECTED_RUN2_TESTS,
+            )
+
+            print("\n📊 Temporal system test summary:")
+            print("   ✅ Experiment 1: end-to-end flow persisted on real storage")
+            print("   ✅ Experiment 2: cross-run late-end revision (two job executions)")
+            print("   ✅ Experiment 3: gold interval-join aggregation after revision")
+        finally:
+            if not os.getenv("SKIP_TEST_CLEANUP"):
+                for job_id in job_ids:
+                    try:
+                        client.delete_job(job_id)
+                        print(f"🗑️  Cleaned up job: {job_id}")
+                    except Exception as exc:  # noqa: BLE001
+                        print(f"⚠️  Job cleanup warning: {exc}")
+                try:
+                    client.cleanup_app(app_name)
+                    print(f"🗑️  Cleaned up app: {app_name}")
+                except Exception as exc:  # noqa: BLE001
+                    print(f"⚠️  App cleanup warning: {exc}")
+                try:
+                    cleanup_test_storage(platform, test_id)
+                except Exception as exc:  # noqa: BLE001
+                    print(f"⚠️  Storage cleanup warning: {exc}")

--- a/tests/system/extensions/temporal/test_temporal_platform.py
+++ b/tests/system/extensions/temporal/test_temporal_platform.py
@@ -141,9 +141,18 @@ class TestTemporalExtensionPlatform:
         client.deploy_app(app_name, app_files)
         print(f"📂 Deployed app: {app_name}")
 
+        # All app tables are catalog-managed in the UC catalog/schema the
+        # system-test volumes live in, isolated per run by a table-name
+        # prefix. Delta tables written to /Volumes paths are not durable on
+        # UC shared-access clusters, so path-based storage mode is not an
+        # option here; the app drops the prefixed tables when run2 passes.
+        uc_catalog = os.getenv("KINDLING_DATABRICKS_RUNTIME_VOLUME_CATALOG", "medallion")
+        uc_schema = os.getenv("KINDLING_DATABRICKS_RUNTIME_VOLUME_SCHEMA", "default")
+        table_prefix = f"systest_temporal_{test_id}_"
+
         def _job_config(scenario: str, evaluation_time: str) -> dict:
-            # Both jobs share test_id, so they share the test-scoped storage
-            # root: run2 revises the episodes run1 persisted.
+            # Both jobs share test_id, so they share the test-scoped tables:
+            # run2 revises the episodes run1 persisted.
             return {
                 "job_name": f"systest-temporal-{scenario}-{test_id}",
                 "app_name": app_name,
@@ -156,6 +165,11 @@ class TestTemporalExtensionPlatform:
                         # harness's kindling.extensions override replaces that
                         # key wholesale, so declare it here to survive the merge.
                         "extensions": [TEMPORAL_EXTENSION_SPEC],
+                        "storage": {
+                            "table_catalog": uc_catalog,
+                            "table_schema": uc_schema,
+                            "table_name_prefix": table_prefix,
+                        },
                         "temporal": {
                             "evaluation_time": evaluation_time,
                             "conditions": {"quarantine_entity_id": "silver.conditions.quarantine"},

--- a/tests/unit/test_current_view_provider.py
+++ b/tests/unit/test_current_view_provider.py
@@ -1,10 +1,9 @@
 from unittest.mock import MagicMock
 
 import pytest
-from pyspark.sql.types import StringType, StructField, StructType
-
 from kindling.data_entities import EntityMetadata
 from kindling.entity_provider_current_view import CurrentViewEntityProvider
+from pyspark.sql.types import StringType, StructField, StructType
 
 
 class Expr:
@@ -58,7 +57,7 @@ def _wire_provider(monkeypatch, companion, base=None, base_provider=None):
     provider_registry.get_provider_for_entity.return_value = base_provider
 
     def fake_get(cls):
-        if cls.__name__ == "DataEntityManager":
+        if cls.__name__ == "DataEntityRegistry":
             return entity_manager
         if cls.__name__ == "EntityProviderRegistry":
             return provider_registry


### PR DESCRIPTION
## What this validates on real Databricks

Closes the temporal extension's cloud-coverage gap: `poe test-extension --extension temporal --platform databricks` now deploys a real KDA app and runs it as **two separate job executions** over shared, test-scoped catalog storage.

**Experiment 1 — end-to-end flow (run 1, job run `1100191019791926`, 9/9 in-app assertions):**
telemetry → base events → condition engine (rules ingested via `ingest_conditions`, malformed rule quarantined to a real quarantine table, SCD2 current view read) → episodes → determination events, on real Delta catalog storage. Also proves first-run tolerance: the engine-owned prior-state read proceeds with no episodes table.

**Experiment 2 — cross-run late-end revision (run 2, job run `120006668277671`, 7/7 in-app assertions):**
a separate job execution ingests only the late real end event with an explicit `kindling.temporal.evaluation_time`; the engine reconstructs the persisted expired episode **across processes**, revises it in place (same `episode_id`, `status=closed`, `end_event_synthetic=false`), and appends the corrective `.closed` determination event alongside the historical `.expired` one.

**Experiment 3 — gold interval-join aggregation:** avg temperature per closed episode window (both machines 87.5 over 2 readings), asserted after revision.

Test evidence: `test_id=272aa06c`, cluster `Kindling Test Cluster` (13.3.x), suite result `1 passed, 1 skipped in 26:17`. The app drops its prefix-scoped tables when run 2 passes; jobs/app/storage cleanup follows core conventions.

## New pieces

- `tests/data-apps/temporal-test-app/` — deployable app using the shipped `SimpleTemporalEntityResolver`; catalog-managed tables scoped by `kindling.storage.table_name_prefix` (UC shared clusters don't durably support Delta tables at `/Volumes` paths); scenario + evaluation time via config overrides (per-run `python_params` are unusable on Databricks — two job definitions over one deployed app).
- `tests/system/extensions/temporal/test_temporal_platform.py` — mirrors the core platform-test pattern (`platform_client` fixture, stdout `TEST_ID` markers). Fabric/Synapse legs skip explicitly (follow-up). The local-Spark test is untouched and still green.

## Divergences found on the real platform (all fixed here)

This is the first system test to exercise batch watermarked pipes + SCD2 on Databricks catalog mode. It surfaced 8 real defects — 6 in core:

1. **Pipe executor swallowed failures** — tracing spans default `reraise=False`; failed pipes reported success while writing nothing (`data_pipes.py`).
2. **`DeltaTable.forName` can't parse 3-part names** — catalog-mode table handles failed; `_get_table_version` silently returned 0 ("no table"). Now falls back to a `DESCRIBE DETAIL` location + path handle, and logs.
3. **Version-0 trap** — a table whose creation commit contains data was invisible to first watermarked reads (`read_entity_changes`/`_legacy_version_read` treated v0 as "missing"; now checks existence explicitly).
4. **SCD2 first write skipped bookkeeping** — `merge_to_entity`'s missing-table fallback wrote the raw dataframe (NULL `__is_current`, invisible to current views). Now ensures the table and runs the merge strategy.
5. **SCD2 change detection crashed on MAP columns** (`parameters`); map columns now compare via `to_json`, mirroring the `optimize_unchanged` hash path.
6. **Current-view provider resolved an empty registry** — injector singletons cache per binding key; resolving concrete `DataEntityManager` returned a second instance. Now resolves the `DataEntityRegistry` interface.
7. **Extension: expression parser blocked by py4j whitelisting** on shared clusters (`SessionState.sqlParser()`) — every rule quarantined. Now parses via public `functions.expr`.
8. **Extension: corrective determination events never fired in sequential runs** — the episode pipe revises persisted state to terminal before the determination pipe reads it. The determination path now also reconstructs episodes whose real end event is in the current batch (idempotent via deterministic event ids). Also: the start-boundary union now tolerates incremental-read bookkeeping columns, `_write_quarantine` resolves the registered quarantine entity instead of fabricating untagged metadata, and `get_cursor` treats catalog-mode `TABLE_OR_VIEW_NOT_FOUND` as a missing watermarks table.

**Observed, not fixed:** occasional Databricks job first attempts died with `internal_error` and retried — seen only while the swallowed-exception bug was in place; the final green run had no retries.

## Verification

- Databricks: both jobs green (run IDs above), all 16 in-app assertions PASSED.
- Local: `poe test-unit` 1811 passed; integration suite 120 passed; local-Spark temporal system test still green; a local two-execution repro of the app passes both scenarios.
- Version bumped to 0.10.45a1; wheels + temporal extension deployed to the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)