### PR TITLE
feat(sdp): validate AUTO CDC mapping and Lakeflow blockers on a real pipeline (Experiments 4-5)

### DIFF
--- a/docs/guide/lakeflow_app_selection.md
+++ b/docs/guide/lakeflow_app_selection.md
@@ -64,3 +64,36 @@ previous graph can be orphaned, and target tables can collide. Use a new
 pipeline ID, or perform an explicitly planned full refresh with target cleanup.
 Changing a selected app also requires care around pipeline state, checkpoints,
 target-table identity, and concurrent updates.
+
+## Restricted runtimes (serverless / shared-access clusters)
+
+Validated against a real serverless pipeline (2026-07-20):
+
+- Pipeline `configuration` values are readable with point lookups
+  (`spark.conf.get`) but **not enumerable** — `RuntimeConfig.getAll` does
+  not exist, `SparkContext.getConf` constructs a py4j-blocked `SparkConf`,
+  and `SET` output does not include them. The selector bridges the
+  app-selection keys automatically; name any further keys you need in
+  `kindling.lakeflow.config_keys` (comma-separated) and the selector
+  bridges each by point lookup.
+- The bridged config defaults `platform` to `standalone`: declaration-time
+  pipelines need no platform machinery, and the Databricks platform
+  service cannot construct inside a pipeline environment ("No
+  workspace_id provided"). Set `kindling.platform.environment` in the
+  pipeline configuration to override.
+- Serverless environments cache installed wheels by requirement set: a
+  re-uploaded wheel with the same filename is silently ignored. Bump the
+  wheel version on every change.
+
+## Dataset naming
+
+Datasets are emitted with single-part names in the pipeline's target
+catalog/schema — the entity id's dots normalized to underscores
+(`silver.customers` becomes table `silver_customers`), matching the runner
+engine's `EntityNameMapper` leaf normalization. Unity Catalog would
+otherwise treat a dotted dataset name as schema-qualified
+(`<catalog>.silver.customers`), bypassing the pipeline target schema and
+requiring `CREATE SCHEMA` on the catalog; pipeline-scoped views reject
+dotted names outright. Note that materialized-view datasets additionally
+require the `CREATE MATERIALIZED VIEW` privilege on the target schema —
+distinct from `CREATE TABLE`.

--- a/docs/proposals/sdp_engine_phase1_notes.md
+++ b/docs/proposals/sdp_engine_phase1_notes.md
@@ -54,6 +54,25 @@ Fast at Declaration Time" sections make checkable from registry metadata:
 | Adapter-tier feature requested on a target without it | `capability_not_supported` |
 | Invalid `dataset_type` value | `invalid_dataset_type` |
 
+Observed platform diagnostics (2026-07-20, real Databricks serverless
+pipeline, channel CURRENT — captured by declaring hand-built plans that
+bypass `build_plan()` validation): a self-reading dataset passes source
+evaluation and fails the update at graph resolution with
+
+    Graph is not topologically sorted. There is a cycle between
+    kindling.kindling.silver_events and kindling.kindling.silver_events.
+
+and a second declaration of the same target fails immediately during
+source evaluation with
+
+    AnalysisException: Cannot redefine dataset
+    `kindling`.`kindling`.`silver_events`
+
+— both are late (update-time), generic, and name physical tables rather
+than pipes, which is exactly why `self_referencing_pipe` and
+`duplicate_output_entity` fail fast at declaration time with pipe-level
+context instead.
+
 Deliberately **not** checked in Phase 1, because it requires pipe-body
 introspection or runtime interception rather than registry metadata:
 side-effecting pipe logic (actions like `collect`/`count`/`write`/

--- a/packages/extensions/kindling_ext_databricks/kindling_ext_databricks/engine.py
+++ b/packages/extensions/kindling_ext_databricks/kindling_ext_databricks/engine.py
@@ -133,7 +133,11 @@ class DatabricksSdpEngine(OssSdpEngine):
                 f"Dataset '{dataset.name}': output entity could not be resolved "
                 "while declaring its AUTO CDC flow."
             )
-        source_name = f"{dataset.name}{SCD_SOURCE_SUFFIX}"
+        # Pipeline-scoped views only accept single-part names — Lakeflow
+        # rejects dotted names outright ("View with multipart name ... is
+        # not supported"). The view is internal plumbing, so normalize the
+        # entity id; the AUTO CDC flow references the same normalized name.
+        source_name = f"{dataset.name.replace('.', '_')}{SCD_SOURCE_SUFFIX}"
 
         view_decorator = getattr(dp, "temporary_view", None) or getattr(dp, "view", None)
         if view_decorator is None:

--- a/packages/extensions/kindling_ext_databricks/kindling_ext_databricks/engine.py
+++ b/packages/extensions/kindling_ext_databricks/kindling_ext_databricks/engine.py
@@ -42,6 +42,7 @@ from kindling_ext_sdp.declaration_plan import (
     DatasetDeclaration,
     DatasetType,
     DeclarationIssue,
+    pipeline_dataset_name,
 )
 from kindling_ext_sdp.oss_engine import OssSdpEngine
 
@@ -133,11 +134,8 @@ class DatabricksSdpEngine(OssSdpEngine):
                 f"Dataset '{dataset.name}': output entity could not be resolved "
                 "while declaring its AUTO CDC flow."
             )
-        # Pipeline-scoped views only accept single-part names — Lakeflow
-        # rejects dotted names outright ("View with multipart name ... is
-        # not supported"). The view is internal plumbing, so normalize the
-        # entity id; the AUTO CDC flow references the same normalized name.
-        source_name = f"{dataset.name.replace('.', '_')}{SCD_SOURCE_SUFFIX}"
+        target_name = pipeline_dataset_name(dataset.name)
+        source_name = f"{target_name}{SCD_SOURCE_SUFFIX}"
 
         view_decorator = getattr(dp, "temporary_view", None) or getattr(dp, "view", None)
         if view_decorator is None:
@@ -159,7 +157,7 @@ class DatabricksSdpEngine(OssSdpEngine):
         keys = list(entity.merge_columns or ())
         if spec.is_snapshot:
             dp.create_auto_cdc_from_snapshot_flow(
-                target=dataset.name,
+                target=target_name,
                 source=source_name,
                 keys=keys,
                 stored_as_scd_type=int(spec.scd_type),
@@ -167,7 +165,7 @@ class DatabricksSdpEngine(OssSdpEngine):
             return
 
         flow_kwargs: Dict[str, Any] = dict(
-            target=dataset.name,
+            target=target_name,
             source=source_name,
             keys=keys,
             sequence_by=spec.sequence_by,

--- a/packages/extensions/kindling_ext_databricks/kindling_ext_databricks/lakeflow_app_selector.py
+++ b/packages/extensions/kindling_ext_databricks/kindling_ext_databricks/lakeflow_app_selector.py
@@ -23,6 +23,11 @@ from pyspark.sql.utils import AnalysisException
 APP_ENTRY_POINT_GROUP = "spark_kindling.data_apps"
 DATA_APP_CONFIG_KEY = "kindling.data_app"
 ALLOWED_APPS_CONFIG_KEY = "kindling.lakeflow.allowed_apps"
+#: Comma-separated pipeline-configuration keys to bridge by point lookup.
+#: Restricted runtimes (serverless / shared-access clusters) allow
+#: ``spark.conf.get`` on pipeline configuration but block every enumeration
+#: surface, so keys beyond the defaults must be named explicitly.
+CONFIG_KEYS_CONFIG_KEY = "kindling.lakeflow.config_keys"
 
 _LOGGER = logging.getLogger(__name__)
 _CONF_READ_ERRORS = (AttributeError, KeyError, Py4JError, AnalysisException, RuntimeError)
@@ -90,38 +95,49 @@ def _spark_conf_get(spark: Any, key: str) -> Optional[str]:
 
 
 def _spark_conf_items(spark: Any) -> Iterable[Tuple[str, Any]]:
-    """Enumerate Spark configuration with PySpark 3.x and Databricks fallbacks."""
+    """Enumerate Spark configuration with PySpark 3.x and Databricks fallbacks.
+
+    Every tier is best-effort: restricted runtimes (serverless / shared-access
+    clusters with py4j whitelisting) can fail these calls with exception types
+    outside any fixed tuple — enumeration must degrade, never crash
+    declaration.
+    """
 
     try:
         get_all = getattr(spark.conf, "getAll", None)
-    except _CONF_READ_ERRORS as exc:
-        _LOGGER.debug("RuntimeConfig.getAll is unavailable: %s", exc)
-        get_all = None
-    if callable(get_all):
-        try:
+        if callable(get_all):
             values = get_all()
             if isinstance(values, Mapping):
                 return tuple(values.items())
             return tuple(values)
-        except (TypeError, *_CONF_READ_ERRORS) as exc:
-            _LOGGER.debug("Unable to enumerate RuntimeConfig.getAll(): %s", exc)
+    except Exception as exc:  # noqa: BLE001 - best-effort tier
+        _LOGGER.debug("Unable to enumerate RuntimeConfig.getAll(): %s", exc)
 
     try:
-        spark_context = spark.sparkContext
-        values = spark_context.getConf().getAll()
+        values = spark.sparkContext.getConf().getAll()
         if isinstance(values, Mapping):
             return tuple(values.items())
         return tuple(values)
-    except (TypeError, *_CONF_READ_ERRORS) as exc:
+    except Exception as exc:  # noqa: BLE001 - py4j-restricted runtimes
         _LOGGER.debug("Unable to enumerate SparkContext.getConf().getAll(): %s", exc)
+
+    # Restricted runtimes usually still allow SQL and point lookups even when
+    # the py4j conf objects are whitelisted away.
+    try:
+        rows = spark.sql("SET").collect()
+        items = tuple((row[0], row[1]) for row in rows if row[0] is not None)
+        if items:
+            return items
+    except Exception as exc:  # noqa: BLE001 - best-effort tier
+        _LOGGER.debug("Unable to enumerate configuration via SET: %s", exc)
 
     explicit_keys = (DATA_APP_CONFIG_KEY, ALLOWED_APPS_CONFIG_KEY)
     explicit_items = tuple(
         (key, value) for key in explicit_keys if (value := _spark_conf_get(spark, key)) is not None
     )
     _LOGGER.warning(
-        "Unable to enumerate Spark configuration through RuntimeConfig.getAll() "
-        "or SparkContext.getConf().getAll(); bridged only explicit keys %s "
+        "Unable to enumerate Spark configuration through RuntimeConfig.getAll(), "
+        "SparkContext.getConf().getAll(), or SET; bridged only explicit keys %s "
         "(available: %s)",
         explicit_keys,
         tuple(key for key, _ in explicit_items),
@@ -153,6 +169,24 @@ def _pipeline_config_for_kindling(spark: Any, app_name: str) -> Dict[str, Any]:
     allowed = _spark_conf_get(spark, ALLOWED_APPS_CONFIG_KEY)
     if allowed is not None:
         config[ALLOWED_APPS_CONFIG_KEY] = allowed
+
+    # Restricted runtimes cannot enumerate configuration at all; bridge any
+    # explicitly named keys by point lookup.
+    raw_keys = _spark_conf_get(spark, CONFIG_KEYS_CONFIG_KEY)
+    if raw_keys:
+        for key in (part.strip() for part in str(raw_keys).split(",")):
+            if key and key not in config:
+                value = _spark_conf_get(spark, key)
+                if value is not None:
+                    config[key] = value
+
+    # Declaration-time default: SDP owns execution and persistence, and
+    # platform services are runtime machinery (workspace scans, token
+    # acquisition) that pipeline environments cannot construct — the
+    # Databricks platform service fails with "No workspace_id provided" in
+    # Lakeflow. An explicit platform in the bridged config wins.
+    if "platform" not in config and "kindling.platform.environment" not in config:
+        config["platform"] = "standalone"
     return config
 
 

--- a/packages/extensions/kindling_ext_databricks/pyproject.toml
+++ b/packages/extensions/kindling_ext_databricks/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "spark-kindling-ext-databricks"
-version = "0.1.0"
+version = "0.1.4"
 description = "Databricks Lakeflow adapter for Kindling's SDP declaration engine"
 authors = ["SEP Engineering <engineering@sep.com>"]
 license = "MIT"

--- a/packages/extensions/kindling_ext_databricks/pyproject.toml
+++ b/packages/extensions/kindling_ext_databricks/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "spark-kindling-ext-databricks"
-version = "0.1.4"
+version = "0.1.5"
 description = "Databricks Lakeflow adapter for Kindling's SDP declaration engine"
 authors = ["SEP Engineering <engineering@sep.com>"]
 license = "MIT"

--- a/packages/extensions/kindling_ext_sdp/kindling_ext_sdp/declaration_plan.py
+++ b/packages/extensions/kindling_ext_sdp/kindling_ext_sdp/declaration_plan.py
@@ -26,7 +26,7 @@ def pipeline_dataset_name(entity_id: str) -> str:
     with multipart name ... is not supported"). Plan-level
     ``DatasetDeclaration.name`` stays the logical entity id.
     """
-    return entity_id.replace(".", "_")
+    return entity_id.replace(".", "_").replace("-", "_")
 
 
 class DatasetType(str, Enum):

--- a/packages/extensions/kindling_ext_sdp/kindling_ext_sdp/declaration_plan.py
+++ b/packages/extensions/kindling_ext_sdp/kindling_ext_sdp/declaration_plan.py
@@ -13,6 +13,22 @@ from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 
+def pipeline_dataset_name(entity_id: str) -> str:
+    """The emitted (physical) dataset name for a Kindling entity id.
+
+    Datasets are emitted with single-part names inside the pipeline's
+    target catalog/schema, dots normalized to underscores — the same leaf
+    normalization the runner engine's EntityNameMapper applies. Unity
+    Catalog pipelines interpret a dotted dataset name as schema-qualified
+    (``silver.customers`` becomes ``<catalog>.silver.customers``), which
+    bypasses the pipeline target schema and requires CREATE SCHEMA on the
+    catalog; pipeline-scoped views reject dotted names outright ("View
+    with multipart name ... is not supported"). Plan-level
+    ``DatasetDeclaration.name`` stays the logical entity id.
+    """
+    return entity_id.replace(".", "_")
+
+
 class DatasetType(str, Enum):
     """The SDP dataset kind a pipe's output is declared as.
 

--- a/packages/extensions/kindling_ext_sdp/kindling_ext_sdp/oss_engine.py
+++ b/packages/extensions/kindling_ext_sdp/kindling_ext_sdp/oss_engine.py
@@ -29,6 +29,7 @@ from kindling_ext_sdp.declaration_plan import (
     DatasetType,
     DeclarationPlan,
     InputClassification,
+    pipeline_dataset_name,
 )
 
 
@@ -125,7 +126,7 @@ class OssSdpEngine(DeclarationEngine):
         """Entity metadata → the OSS decorator surface (Spark 4.1 keywords:
         name, comment, table_properties, partition_cols, cluster_by,
         schema). Empty values are omitted rather than passed as empties."""
-        kwargs: dict = {"name": dataset.name}
+        kwargs: dict = {"name": pipeline_dataset_name(dataset.name)}
         if dataset.comment:
             kwargs["comment"] = dataset.comment
         if dataset.table_properties:
@@ -167,13 +168,19 @@ class OssSdpEngine(DeclarationEngine):
             spark = session_provider()
             input_dfs = {}
             for position, pipe_input in enumerate(dataset.inputs):
+                if pipe_input.classification is InputClassification.INTERNAL:
+                    # In-pipeline references use the emitted (single-part)
+                    # dataset name so SDP infers the graph edge.
+                    table_name = pipeline_dataset_name(pipe_input.entity_id)
+                else:
+                    table_name = pipe_input.entity_id
                 if stream_first_input and position == 0:
                     if pipe_input.classification is InputClassification.INTERNAL:
-                        df = spark.readStream.table(pipe_input.entity_id)
+                        df = spark.readStream.table(table_name)
                     else:
                         df = stream_resolver(spark, pipe_input.entity_id)
                 elif pipe_input.classification is InputClassification.INTERNAL or resolver is None:
-                    df = spark.table(pipe_input.entity_id)
+                    df = spark.table(table_name)
                 else:
                     df = resolver(spark, pipe_input.entity_id)
                 input_dfs[pipe_input.entity_id.replace(".", "_")] = df

--- a/packages/extensions/kindling_ext_sdp/pyproject.toml
+++ b/packages/extensions/kindling_ext_sdp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "spark-kindling-ext-sdp"
-version = "0.3.0"
+version = "0.3.1"
 description = "Spark Declarative Pipelines (SDP) declaration engine for Kindling"
 authors = ["SEP Engineering <engineering@sep.com>"]
 license = "MIT"

--- a/tests/data-apps/lakeflow-scd-test-app/lakeflow_scd_app/__init__.py
+++ b/tests/data-apps/lakeflow-scd-test-app/lakeflow_scd_app/__init__.py
@@ -1,0 +1,104 @@
+"""Minimal SCD2 declared-flow app for Lakeflow AUTO CDC validation.
+
+Deployed through the Lakeflow app selector
+(`kindling_ext_databricks.lakeflow_app_selector`): the pipeline's
+`kindling.data_app` config selects this package's `spark_kindling.data_apps`
+entry point, the selector initializes Kindling with the Databricks SDP
+engine, calls :func:`register_all`, and declares the pipeline.
+
+The graph is the smallest shape that exercises the SCD declared-flow ->
+AUTO CDC mapping (#166) against the real API:
+
+- ``lakeflow.customers_seed`` — a zero-input pipe materializing a customer
+  snapshot. The snapshot content is selected by the pipeline configuration
+  value ``lakeflow_scd.snapshot`` (``v1``/``v2``) so two pipeline updates
+  with different configuration demonstrate SCD2 version chaining.
+- ``silver.customers`` — the SCD2 target (``scd.type=2``,
+  ``scd.source_kind=snapshot``): the Databricks engine emits a
+  ``__scd_source`` view, ``create_streaming_table`` and
+  ``create_auto_cdc_from_snapshot_flow``.
+
+Registration only happens inside :func:`register_all`; importing this
+module has no side effects (the selector requires declaration-only apps).
+"""
+
+from datetime import datetime
+
+
+def register_all() -> None:
+    from kindling.data_entities import DataEntities
+    from kindling.data_pipes import DataPipes
+    from pyspark.sql.types import StringType, StructField, StructType, TimestampType
+
+    customers_schema = StructType(
+        [
+            StructField("customer_id", StringType(), False),
+            StructField("name", StringType(), False),
+            StructField("tier", StringType(), False),
+            StructField("updated_at", TimestampType(), False),
+        ]
+    )
+
+    DataEntities.entity(
+        entityid="bronze.customers_feed",
+        name="customers_feed",
+        merge_columns=["customer_id"],
+        tags={"provider_type": "delta"},
+        schema=customers_schema,
+        partition_columns=[],
+    )
+
+    DataEntities.entity(
+        entityid="silver.customers",
+        name="customers",
+        merge_columns=["customer_id"],
+        tags={
+            "provider_type": "delta",
+            "scd.type": "2",
+            "scd.source_kind": "snapshot",
+        },
+        schema=customers_schema,
+        partition_columns=[],
+    )
+
+    SNAPSHOTS = {
+        "v1": [
+            ("c1", "Alice", "bronze", datetime(2026, 7, 1, 12, 0, 0)),
+            ("c2", "Bob", "silver", datetime(2026, 7, 1, 12, 0, 0)),
+        ],
+        # v2: c1 changes tier (SCD2 close + new version), c2 unchanged,
+        # c3 arrives (new key).
+        "v2": [
+            ("c1", "Alice", "gold", datetime(2026, 7, 2, 12, 0, 0)),
+            ("c2", "Bob", "silver", datetime(2026, 7, 1, 12, 0, 0)),
+            ("c3", "Cara", "bronze", datetime(2026, 7, 2, 12, 0, 0)),
+        ],
+    }
+
+    @DataPipes.pipe(
+        pipeid="lakeflow.customers_seed",
+        name="Customers snapshot seed",
+        input_entity_ids=[],
+        output_entity_id="bronze.customers_feed",
+        output_type="delta",
+        tags={},
+        use_watermark=False,
+    )
+    def customers_seed():
+        from pyspark.sql import SparkSession
+
+        spark = SparkSession.getActiveSession()
+        snapshot = str(spark.conf.get("lakeflow_scd.snapshot", "v1")).strip().lower()
+        return spark.createDataFrame(SNAPSHOTS.get(snapshot, SNAPSHOTS["v1"]), customers_schema)
+
+    @DataPipes.pipe(
+        pipeid="lakeflow.customers_scd",
+        name="Customers SCD2",
+        input_entity_ids=["bronze.customers_feed"],
+        output_entity_id="silver.customers",
+        output_type="delta",
+        tags={},
+        use_watermark=False,
+    )
+    def customers_scd(bronze_customers_feed):
+        return bronze_customers_feed

--- a/tests/data-apps/lakeflow-scd-test-app/lakeflow_scd_app/__init__.py
+++ b/tests/data-apps/lakeflow-scd-test-app/lakeflow_scd_app/__init__.py
@@ -9,14 +9,16 @@ engine, calls :func:`register_all`, and declares the pipeline.
 The graph is the smallest shape that exercises the SCD declared-flow ->
 AUTO CDC mapping (#166) against the real API:
 
-- ``lakeflow.customers_seed`` — a zero-input pipe materializing a customer
-  snapshot. The snapshot content is selected by the pipeline configuration
-  value ``lakeflow_scd.snapshot`` (``v1``/``v2``) so two pipeline updates
-  with different configuration demonstrate SCD2 version chaining.
 - ``silver.customers`` — the SCD2 target (``scd.type=2``,
   ``scd.source_kind=snapshot``): the Databricks engine emits a
   ``__scd_source`` view, ``create_streaming_table`` and
-  ``create_auto_cdc_from_snapshot_flow``.
+  ``create_auto_cdc_from_snapshot_flow``. The snapshot source is built by
+  the zero-input pipe body itself (content selected by the
+  ``lakeflow_scd.snapshot`` pipeline configuration value, ``v1``/``v2``)
+  so two pipeline updates with different configuration demonstrate SCD2
+  version chaining without any additional dataset: the system-test
+  service principal has CREATE TABLE but not CREATE MATERIALIZED VIEW on
+  the target schema, so a materialized-view seed dataset cannot deploy.
 
 Registration only happens inside :func:`register_all`; importing this
 module has no side effects (the selector requires declaration-only apps).
@@ -37,15 +39,6 @@ def register_all() -> None:
             StructField("tier", StringType(), False),
             StructField("updated_at", TimestampType(), False),
         ]
-    )
-
-    DataEntities.entity(
-        entityid="bronze.customers_feed",
-        name="customers_feed",
-        merge_columns=["customer_id"],
-        tags={"provider_type": "delta"},
-        schema=customers_schema,
-        partition_columns=[],
     )
 
     DataEntities.entity(
@@ -76,29 +69,17 @@ def register_all() -> None:
     }
 
     @DataPipes.pipe(
-        pipeid="lakeflow.customers_seed",
-        name="Customers snapshot seed",
-        input_entity_ids=[],
-        output_entity_id="bronze.customers_feed",
-        output_type="delta",
-        tags={},
-        use_watermark=False,
-    )
-    def customers_seed():
-        from pyspark.sql import SparkSession
-
-        spark = SparkSession.getActiveSession()
-        snapshot = str(spark.conf.get("lakeflow_scd.snapshot", "v1")).strip().lower()
-        return spark.createDataFrame(SNAPSHOTS.get(snapshot, SNAPSHOTS["v1"]), customers_schema)
-
-    @DataPipes.pipe(
         pipeid="lakeflow.customers_scd",
         name="Customers SCD2",
-        input_entity_ids=["bronze.customers_feed"],
+        input_entity_ids=[],
         output_entity_id="silver.customers",
         output_type="delta",
         tags={},
         use_watermark=False,
     )
-    def customers_scd(bronze_customers_feed):
-        return bronze_customers_feed
+    def customers_scd():
+        from pyspark.sql import SparkSession
+
+        spark = SparkSession.getActiveSession()
+        snapshot = str(spark.conf.get("lakeflow_scd.snapshot", "v1")).strip().lower()
+        return spark.createDataFrame(SNAPSHOTS.get(snapshot, SNAPSHOTS["v1"]), customers_schema)

--- a/tests/data-apps/lakeflow-scd-test-app/pyproject.toml
+++ b/tests/data-apps/lakeflow-scd-test-app/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "lakeflow-scd-test-app"
+version = "0.1.0"
+description = "System-test data app: minimal SCD2 declared flow for Lakeflow AUTO CDC validation"
+authors = ["Kindling Team"]
+packages = [{ include = "lakeflow_scd_app" }]
+
+[tool.poetry.dependencies]
+python = ">=3.10,<4.0"
+
+[tool.poetry.plugins."spark_kindling.data_apps"]
+lakeflow_scd = "lakeflow_scd_app"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/data-apps/lakeflow-scd-test-app/pyproject.toml
+++ b/tests/data-apps/lakeflow-scd-test-app/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lakeflow-scd-test-app"
-version = "0.1.0"
+version = "0.1.1"
 description = "System-test data app: minimal SCD2 declared flow for Lakeflow AUTO CDC validation"
 authors = ["Kindling Team"]
 packages = [{ include = "lakeflow_scd_app" }]

--- a/tests/integration/test_sdp_mode.py
+++ b/tests/integration/test_sdp_mode.py
@@ -25,15 +25,14 @@ from unittest.mock import MagicMock
 
 import pytest
 from delta import configure_spark_with_delta_pip
-from kindling_ext_sdp import OssSdpEngine, SdpModeWriteError, SdpWriteGuardProvider
-from pyspark.sql import SparkSession
-from pyspark.sql.types import IntegerType, StringType, StructField, StructType
-
 from kindling.data_entities import EntityMetadata, EntityNameMapper, EntityPathLocator
 from kindling.data_pipes import PipeMetadata
 from kindling.entity_provider_delta import DeltaEntityProvider
 from kindling.spark_config import ConfigService
 from kindling.spark_log_provider import PythonLoggerProvider
+from kindling_ext_sdp import OssSdpEngine, SdpModeWriteError, SdpWriteGuardProvider
+from pyspark.sql import SparkSession
+from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
 
 def _teardown_existing_spark_jvm():
@@ -210,6 +209,6 @@ class TestEmittedDatasetFunctionOnRealSpark:
         engine = OssSdpEngine(entities, pipes, dp_module=dp, session_provider=lambda: spark)
         engine.declare_pipeline(engine.build_plan())
 
-        result = dp.declared["silver.orders"]()
+        result = dp.declared["silver_orders"]()
 
         assert sorted(r["order_id"] for r in result.collect()) == [1, 3]

--- a/tests/system/extensions/sdp/test_lakeflow_platform.py
+++ b/tests/system/extensions/sdp/test_lakeflow_platform.py
@@ -140,11 +140,16 @@ class TestLakeflowSdpPlatform:
         schema = os.getenv("KINDLING_DATABRICKS_RUNTIME_VOLUME_SCHEMA", "default")
         pkg_root = PACKAGES_VOLUME.format(catalog=catalog, schema=schema)
 
-        warehouses = [
-            wh
-            for wh in w.warehouses.list()
-            if wh.state and wh.state.value in ("RUNNING", "STOPPED")
-        ]
+        # Prefer RUNNING warehouses; a STOPPED serverless warehouse
+        # auto-starts on statement execution but adds startup latency.
+        warehouses = sorted(
+            (
+                wh
+                for wh in w.warehouses.list()
+                if wh.state and wh.state.value in ("RUNNING", "STOPPED")
+            ),
+            key=lambda wh: wh.state.value != "RUNNING",
+        )
         if not warehouses:
             pytest.skip("No SQL warehouse available to verify pipeline outputs.")
         warehouse_id = os.getenv("SYSTEM_TEST_SQL_WAREHOUSE_ID") or warehouses[0].id

--- a/tests/system/extensions/sdp/test_lakeflow_platform.py
+++ b/tests/system/extensions/sdp/test_lakeflow_platform.py
@@ -1,0 +1,244 @@
+"""
+Platform system test for the Databricks SDP engine (Lakeflow).
+
+Deploys the lakeflow-scd-test-app through the Lakeflow app selector into a
+real serverless pipeline and validates the SCD declared-flow -> AUTO CDC
+mapping against the live API:
+
+  Update 1 (snapshot v1): the pipeline declares a __scd_source view,
+  create_streaming_table target and create_auto_cdc_from_snapshot_flow;
+  the target materializes as an SCD2 table with __START_AT/__END_AT.
+
+  Update 2 (snapshot v2, via pipeline configuration change): SCD2 version
+  chaining — a changed key closes its old version and opens a new one,
+  an unchanged key keeps a single open row, a new key appends.
+
+Prerequisites (deploy once per code change, with version bumps —
+serverless environments cache installed wheels by requirement set):
+
+  - spark_kindling, spark_kindling_ext_sdp, spark_kindling_ext_databricks
+    and lakeflow_scd_test_app wheels uploaded to the UC artifacts volume
+    packages/ path (scripts/deploy_extensions.py convention).
+
+Usage:
+    poe test-extension --extension sdp --platform databricks
+"""
+
+import base64
+import os
+import re
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+WORKSPACE_ROOT = Path(__file__).parent.parent.parent.parent
+PACKAGES_VOLUME = "/Volumes/{catalog}/{schema}/artifacts/packages"
+
+EXPECTED_V1 = {("c1", "bronze", "open"), ("c2", "silver", "open")}
+EXPECTED_V2 = {
+    ("c1", "bronze", "closed"),
+    ("c1", "gold", "open"),
+    ("c2", "silver", "open"),
+    ("c3", "bronze", "open"),
+}
+
+
+def _wheel_version(pyproject: Path) -> str:
+    match = re.search(r'^version = "([^"]+)"', pyproject.read_text(), re.MULTILINE)
+    assert match, f"no version in {pyproject}"
+    return match.group(1)
+
+
+def _pipeline_notebook(pkg_root: str) -> str:
+    kindling_version = _wheel_version(WORKSPACE_ROOT.parent / "pyproject.toml")
+    sdp_version = _wheel_version(
+        WORKSPACE_ROOT.parent / "packages" / "extensions" / "kindling_ext_sdp" / "pyproject.toml"
+    )
+    databricks_version = _wheel_version(
+        WORKSPACE_ROOT.parent
+        / "packages"
+        / "extensions"
+        / "kindling_ext_databricks"
+        / "pyproject.toml"
+    )
+    app_version = _wheel_version(
+        WORKSPACE_ROOT / "data-apps" / "lakeflow-scd-test-app" / "pyproject.toml"
+    )
+    wheels = " ".join(
+        [
+            f"{pkg_root}/spark_kindling-{kindling_version}-py3-none-any.whl",
+            f"{pkg_root}/spark_kindling_ext_sdp-{sdp_version}-py3-none-any.whl",
+            f"{pkg_root}/spark_kindling_ext_databricks-{databricks_version}-py3-none-any.whl",
+            f"{pkg_root}/lakeflow_scd_test_app-{app_version}-py3-none-any.whl",
+        ]
+    )
+    return f"""# Databricks notebook source
+# MAGIC %pip install {wheels}
+
+# COMMAND ----------
+
+from kindling_ext_databricks.lakeflow_app_selector import declare_from_pipeline_config
+
+declare_from_pipeline_config()
+"""
+
+
+def _wait_for_update(w, pipeline_id: str, update_id: str, max_wait: float = 1800.0) -> str:
+    deadline = time.time() + max_wait
+    state = None
+    while time.time() < deadline:
+        info = w.pipelines.get_update(pipeline_id, update_id)
+        state = info.update.state.value if info.update and info.update.state else None
+        if state in {"COMPLETED", "FAILED", "CANCELED"}:
+            return state
+        time.sleep(15)
+    return state or "TIMEOUT"
+
+
+def _print_error_events(w, pipeline_id: str) -> None:
+    for event in list(w.pipelines.list_pipeline_events(pipeline_id, max_results=50)):
+        if event.level and event.level.value == "ERROR":
+            print(f"[ERROR] {event.event_type}: {(event.message or '').strip()[:2000]}")
+            error = getattr(event, "error", None)
+            if error and getattr(error, "exceptions", None):
+                for exc in error.exceptions:
+                    print("  EXC:", (exc.message or "").strip()[:2000])
+    sys.stdout.flush()
+
+
+def _query_scd_rows(w, warehouse_id: str, table: str):
+    result = w.statement_execution.execute_statement(
+        warehouse_id=warehouse_id,
+        statement=(
+            "SELECT customer_id, tier, "
+            "CASE WHEN __END_AT IS NULL THEN 'open' ELSE 'closed' END AS row_state "
+            f"FROM {table} ORDER BY customer_id, __START_AT"
+        ),
+        wait_timeout="50s",
+    )
+    assert (
+        result.status and result.status.state.value == "SUCCEEDED"
+    ), f"query failed: {result.status.error.message if result.status and result.status.error else result.status}"
+    return {tuple(row) for row in (result.result.data_array or [])}
+
+
+@pytest.mark.system
+@pytest.mark.slow
+class TestLakeflowSdpPlatform:
+    """SCD declared flow -> AUTO CDC on a real Lakeflow pipeline."""
+
+    def test_scd_declared_flow_maps_to_auto_cdc(self, platform_client):
+        client, platform = platform_client
+        if platform != "databricks":
+            pytest.skip("Lakeflow SDP coverage is Databricks-only.")
+
+        w = client.client  # underlying databricks.sdk WorkspaceClient
+        catalog = os.getenv("KINDLING_DATABRICKS_RUNTIME_VOLUME_CATALOG", "medallion")
+        schema = os.getenv("KINDLING_DATABRICKS_RUNTIME_VOLUME_SCHEMA", "default")
+        pkg_root = PACKAGES_VOLUME.format(catalog=catalog, schema=schema)
+
+        warehouses = [
+            wh
+            for wh in w.warehouses.list()
+            if wh.state and wh.state.value in ("RUNNING", "STOPPED")
+        ]
+        if not warehouses:
+            pytest.skip("No SQL warehouse available to verify pipeline outputs.")
+        warehouse_id = os.getenv("SYSTEM_TEST_SQL_WAREHOUSE_ID") or warehouses[0].id
+
+        test_id = str(uuid.uuid4())[:8]
+        pipeline_name = f"systest-lakeflow-scd-{test_id}"
+        notebook_path = f"/Shared/systest-lakeflow/{pipeline_name}"
+        # The app emits dataset silver.customers -> table silver_customers
+        # in the pipeline target schema (single-part dataset naming).
+        table = f"{catalog}.{schema}.silver_customers"
+
+        from databricks.sdk.service.pipelines import NotebookLibrary, PipelineLibrary
+        from databricks.sdk.service.workspace import ImportFormat, Language
+
+        w.workspace.mkdirs("/Shared/systest-lakeflow")
+        w.workspace.import_(
+            path=notebook_path,
+            format=ImportFormat.SOURCE,
+            language=Language.PYTHON,
+            content=base64.b64encode(_pipeline_notebook(pkg_root).encode()).decode(),
+            overwrite=True,
+        )
+
+        def _configuration(snapshot: str) -> dict:
+            return {
+                "kindling.data_app": "lakeflow_scd",
+                "kindling.lakeflow.allowed_apps": "lakeflow_scd",
+                "lakeflow_scd.snapshot": snapshot,
+            }
+
+        created = w.pipelines.create(
+            name=pipeline_name,
+            catalog=catalog,
+            target=schema,
+            development=True,
+            continuous=False,
+            channel="CURRENT",
+            serverless=True,
+            libraries=[PipelineLibrary(notebook=NotebookLibrary(path=notebook_path))],
+            configuration=_configuration("v1"),
+        )
+        pipeline_id = created.pipeline_id
+        print(f"🚀 Pipeline created: {pipeline_id} ({pipeline_name})")
+
+        try:
+            update = w.pipelines.start_update(pipeline_id)
+            state = _wait_for_update(w, pipeline_id, update.update_id)
+            if state != "COMPLETED":
+                _print_error_events(w, pipeline_id)
+            assert state == "COMPLETED", f"v1 update ended {state}"
+
+            rows = _query_scd_rows(w, warehouse_id, table)
+            assert rows == EXPECTED_V1, f"v1 rows: {rows}"
+            print("✅ v1 snapshot materialized as SCD2 (2 open rows)")
+
+            spec = w.pipelines.get(pipeline_id).spec
+            w.pipelines.update(
+                pipeline_id=pipeline_id,
+                name=spec.name,
+                catalog=spec.catalog,
+                target=spec.target,
+                development=spec.development,
+                continuous=spec.continuous,
+                channel=spec.channel,
+                serverless=spec.serverless,
+                libraries=spec.libraries,
+                configuration=_configuration("v2"),
+            )
+            update = w.pipelines.start_update(pipeline_id)
+            state = _wait_for_update(w, pipeline_id, update.update_id)
+            if state != "COMPLETED":
+                _print_error_events(w, pipeline_id)
+            assert state == "COMPLETED", f"v2 update ended {state}"
+
+            rows = _query_scd_rows(w, warehouse_id, table)
+            assert rows == EXPECTED_V2, f"v2 rows: {rows}"
+            print("✅ v2 snapshot chained SCD2 versions (close + new + append)")
+        finally:
+            if not os.getenv("SKIP_TEST_CLEANUP"):
+                try:
+                    w.pipelines.delete(pipeline_id)
+                    print(f"🗑️  Deleted pipeline {pipeline_id}")
+                except Exception as exc:  # noqa: BLE001
+                    print(f"⚠️  Pipeline cleanup warning: {exc}")
+                try:
+                    w.workspace.delete(notebook_path)
+                except Exception as exc:  # noqa: BLE001
+                    print(f"⚠️  Notebook cleanup warning: {exc}")
+                try:
+                    w.statement_execution.execute_statement(
+                        warehouse_id=warehouse_id,
+                        statement=f"DROP TABLE IF EXISTS {table}",
+                        wait_timeout="50s",
+                    )
+                    print(f"🗑️  Dropped {table}")
+                except Exception as exc:  # noqa: BLE001
+                    print(f"⚠️  Table cleanup warning: {exc}")

--- a/tests/unit/test_lakeflow_app_selector.py
+++ b/tests/unit/test_lakeflow_app_selector.py
@@ -443,3 +443,76 @@ def test_data_app_manager_is_not_invoked(monkeypatch):
             == "plan"
         )
         run_app.assert_not_called()
+
+
+def test_pipeline_config_defaults_platform_to_standalone():
+    config = selector._pipeline_config_for_kindling(
+        FakeSpark({"kindling.data_app": "orders"}), "orders"
+    )
+    # Declaration-time pipelines get no platform machinery by default: the
+    # Databricks platform service cannot construct inside Lakeflow.
+    assert config["platform"] == "standalone"
+
+
+def test_pipeline_config_explicit_platform_wins():
+    config = selector._pipeline_config_for_kindling(
+        FakeSpark(
+            {
+                "kindling.data_app": "orders",
+                "kindling.platform.environment": "databricks",
+            }
+        ),
+        "orders",
+    )
+    assert "platform" not in config
+    assert config["kindling.platform.environment"] == "databricks"
+
+
+def test_restricted_runtime_bridges_named_config_keys():
+    """Serverless/shared runtimes allow point lookups but no enumeration."""
+
+    class SparkPointLookupOnly:
+        def __init__(self, values):
+            self.conf = FakeSparkConfWithoutGetAll(values)
+            # No sparkContext attribute at all, no SQL: enumeration is dead.
+
+    config = selector._pipeline_config_for_kindling(
+        SparkPointLookupOnly(
+            {
+                "kindling.data_app": "orders",
+                "kindling.lakeflow.config_keys": (
+                    "kindling.storage.table_catalog, datapipes.orders.engine.sdp.dataset_type"
+                ),
+                "kindling.storage.table_catalog": "main",
+                "datapipes.orders.engine.sdp.dataset_type": "streaming_table",
+                "kindling.unrelated": "not-bridged-unless-named",
+            }
+        ),
+        "orders",
+    )
+    assert config["kindling.storage.table_catalog"] == "main"
+    assert config["datapipes.orders.engine.sdp.dataset_type"] == "streaming_table"
+    assert "kindling.unrelated" not in config
+
+
+def test_enumeration_falls_back_to_sql_set():
+    class SparkWithSqlOnly:
+        def __init__(self, values):
+            self.conf = FakeSparkConfWithoutGetAll(values)
+            self._values = values
+
+        def sql(self, statement):
+            assert statement == "SET"
+            rows = [(k, v) for k, v in self._values.items()]
+            return SimpleNamespace(collect=lambda: rows)
+
+    config = selector._pipeline_config_for_kindling(
+        SparkWithSqlOnly(
+            {
+                "kindling.data_app": "orders",
+                "kindling.storage.table_schema": "default",
+            }
+        ),
+        "orders",
+    )
+    assert config["kindling.storage.table_schema"] == "default"

--- a/tests/unit/test_sdp_auto_cdc.py
+++ b/tests/unit/test_sdp_auto_cdc.py
@@ -150,11 +150,11 @@ class TestChangeFeedMapping:
     def test_emits_view_streaming_table_and_cdc_flow(self):
         dp = declare(CHANGE_FEED_TAGS)
 
-        assert "silver.customers__scd_source" in dp.views
+        assert "silver_customers__scd_source" in dp.views
         assert "silver.customers" in dp.streaming_tables
         (flow,) = dp.cdc_flows
         assert flow["target"] == "silver.customers"
-        assert flow["source"] == "silver.customers__scd_source"
+        assert flow["source"] == "silver_customers__scd_source"
         assert flow["keys"] == ["customer_id"]
         assert flow["sequence_by"] == "updated_at"
         assert flow["stored_as_scd_type"] == 2
@@ -236,7 +236,7 @@ class TestChangeFeedMapping:
         )
 
         assert dp.expectations == [{"valid_key": "customer_id IS NOT NULL"}]
-        assert "silver.customers__scd_source" in dp.views
+        assert "silver_customers__scd_source" in dp.views
 
 
 class FakeStreamingSession:
@@ -294,7 +294,7 @@ class TestChangeFeedStreamingSource:
             entities, pipes, dp_module=dp, session_provider=lambda: session
         )
         engine.declare_pipeline(engine.build_plan())
-        dp.views["silver.customers__scd_source"]()
+        dp.views["silver_customers__scd_source"]()
         return session, captured
 
     def test_driving_input_streams_remaining_inputs_stay_batch(self):
@@ -350,7 +350,7 @@ class TestChangeFeedStreamingSource:
             external_stream_read_resolver=stream_resolver,
         )
         engine.declare_pipeline(engine.build_plan())
-        dp.views["silver.customers__scd_source"]()
+        dp.views["silver_customers__scd_source"]()
 
         assert session.stream_reads == ["catalog.bronze.customers"]
         assert session.batch_reads == ["catalog.ref.regions"]
@@ -379,7 +379,7 @@ class TestSnapshotMapping:
 
         (flow,) = dp.snapshot_flows
         assert flow["target"] == "silver.customers"
-        assert flow["source"] == "silver.customers__scd_source"
+        assert flow["source"] == "silver_customers__scd_source"
         assert flow["keys"] == ["customer_id"]
         assert flow["stored_as_scd_type"] == 2
         assert dp.cdc_flows == []

--- a/tests/unit/test_sdp_auto_cdc.py
+++ b/tests/unit/test_sdp_auto_cdc.py
@@ -151,9 +151,9 @@ class TestChangeFeedMapping:
         dp = declare(CHANGE_FEED_TAGS)
 
         assert "silver_customers__scd_source" in dp.views
-        assert "silver.customers" in dp.streaming_tables
+        assert "silver_customers" in dp.streaming_tables
         (flow,) = dp.cdc_flows
-        assert flow["target"] == "silver.customers"
+        assert flow["target"] == "silver_customers"
         assert flow["source"] == "silver_customers__scd_source"
         assert flow["keys"] == ["customer_id"]
         assert flow["sequence_by"] == "updated_at"
@@ -199,7 +199,7 @@ class TestChangeFeedMapping:
         the runner's effective-date columns the entity schema describes."""
         dp = declare(CHANGE_FEED_TAGS, schema="not-none-sentinel")
 
-        assert "schema" not in dp.streaming_tables["silver.customers"]
+        assert "schema" not in dp.streaming_tables["silver_customers"]
 
     def test_entity_metadata_still_reaches_the_streaming_table(self):
         dp = declare(
@@ -207,7 +207,7 @@ class TestChangeFeedMapping:
             partition_columns=["region"],
         )
 
-        st = dp.streaming_tables["silver.customers"]
+        st = dp.streaming_tables["silver_customers"]
         assert st["comment"] == "Customer history"
         assert st["partition_cols"] == ["region"]
 
@@ -378,7 +378,7 @@ class TestSnapshotMapping:
         dp = declare(SNAPSHOT_TAGS)
 
         (flow,) = dp.snapshot_flows
-        assert flow["target"] == "silver.customers"
+        assert flow["target"] == "silver_customers"
         assert flow["source"] == "silver_customers__scd_source"
         assert flow["keys"] == ["customer_id"]
         assert flow["stored_as_scd_type"] == 2
@@ -478,7 +478,7 @@ class TestAutoCdcValidation:
 
         engine.declare_pipeline(engine.build_plan())
 
-        assert "silver.customers" in dp.declared_mvs
+        assert "silver_customers" in dp.declared_mvs
         assert dp.cdc_flows == [] and dp.snapshot_flows == []
 
 

--- a/tests/unit/test_sdp_oss_engine.py
+++ b/tests/unit/test_sdp_oss_engine.py
@@ -15,6 +15,8 @@ import sys
 from types import SimpleNamespace
 
 import pytest
+from kindling.data_entities import EntityMetadata
+from kindling.data_pipes import PipeMetadata
 from kindling_ext_sdp import (
     DatasetType,
     OssSdpEngine,
@@ -25,9 +27,6 @@ from kindling_ext_sdp import (
     dry_run,
     write_pipeline_spec,
 )
-
-from kindling.data_entities import EntityMetadata
-from kindling.data_pipes import PipeMetadata
 
 # --------------------------------------------------------------------- #
 # Fixtures: fake registries (same graph as test_sdp_declaration_engine) #
@@ -161,7 +160,7 @@ class TestEmission:
 
         engine.declare_pipeline(engine.build_plan())
 
-        assert set(dp.declared) == {"bronze.orders", "silver.orders"}
+        assert set(dp.declared) == {"bronze_orders", "silver_orders"}
 
     def test_dataset_function_rebuilds_the_runner_kwarg_contract(self, graph):
         """Inputs arrive as entity ids with dots -> underscores, in
@@ -171,11 +170,11 @@ class TestEmission:
         engine = make_engine(graph, dp_module=dp, session_provider=lambda: session)
         engine.declare_pipeline(engine.build_plan())
 
-        result = dp.declared["silver.orders"]()
+        result = dp.declared["silver_orders"]()
 
         assert result == "df:silver.result"
         assert list(graph.captured) == ["bronze_orders", "ref_customers"]
-        assert graph.captured["bronze_orders"] == "df:bronze.orders"
+        assert graph.captured["bronze_orders"] == "df:bronze_orders"
 
     def test_internal_and_external_inputs_read_by_table_name(self, graph):
         """spark.table(<name>) for both: internal so SDP infers the edge,
@@ -185,9 +184,11 @@ class TestEmission:
         engine = make_engine(graph, dp_module=dp, session_provider=lambda: session)
         engine.declare_pipeline(engine.build_plan())
 
-        dp.declared["silver.orders"]()
+        dp.declared["silver_orders"]()
 
-        assert session.reads == ["bronze.orders", "ref.customers"]
+        # Internal inputs read the emitted single-part dataset name;
+        # external inputs keep the entity id (resolver contract).
+        assert session.reads == ["bronze_orders", "ref.customers"]
 
     def test_external_read_resolver_overrides_external_reads_only(self, graph):
         dp = FakeDpModule()
@@ -206,10 +207,10 @@ class TestEmission:
         )
         engine.declare_pipeline(engine.build_plan())
 
-        dp.declared["silver.orders"]()
+        dp.declared["silver_orders"]()
 
         assert resolved == ["ref.customers"], "internal inputs must not hit the resolver"
-        assert session.reads == ["bronze.orders"]
+        assert session.reads == ["bronze_orders"]
         assert graph.captured["ref_customers"] == "resolved:ref.customers"
 
     def test_streaming_table_fails_fast_as_phase4(self, graph):

--- a/tests/unit/test_sdp_phase3_metadata.py
+++ b/tests/unit/test_sdp_phase3_metadata.py
@@ -10,13 +10,12 @@ expectation decorators the OSS module lacks.
 
 from types import SimpleNamespace
 
-import pytest
-from kindling_ext_databricks import DatabricksSdpEngine, engine_extension
-from kindling_ext_sdp import OssSdpEngine
-
 import kindling
+import pytest
 from kindling.data_entities import EntityMetadata
 from kindling.data_pipes import PipeMetadata
+from kindling_ext_databricks import DatabricksSdpEngine, engine_extension
+from kindling_ext_sdp import OssSdpEngine
 
 # --------------------------------------------------------------------- #
 # Fixtures                                                               #
@@ -129,7 +128,7 @@ class TestMetadataEmission:
 
         engine.declare_pipeline(engine.build_plan())
 
-        kwargs, _ = dp.declared["silver.orders"]
+        kwargs, _ = dp.declared["silver_orders"]
         assert kwargs["comment"] == "Cleaned orders"
         assert kwargs["table_properties"] == {
             "delta.enableChangeDataFeed": "true",
@@ -146,7 +145,7 @@ class TestMetadataEmission:
 
         engine.declare_pipeline(engine.build_plan())
 
-        kwargs, _ = dp.declared["silver.orders"]
+        kwargs, _ = dp.declared["silver_orders"]
         assert set(kwargs) == {"name"}
 
     def test_cdf_is_not_forced_unlike_the_runner_engine(self):
@@ -159,7 +158,7 @@ class TestMetadataEmission:
 
         engine.declare_pipeline(engine.build_plan())
 
-        kwargs, _ = dp.declared["silver.orders"]
+        kwargs, _ = dp.declared["silver_orders"]
         assert "table_properties" not in kwargs
 
     def test_engine_config_table_properties_with_entity_tag_precedence(self):
@@ -174,7 +173,7 @@ class TestMetadataEmission:
 
         engine.declare_pipeline(engine.build_plan())
 
-        kwargs, _ = dp.declared["silver.orders"]
+        kwargs, _ = dp.declared["silver_orders"]
         assert kwargs["table_properties"] == {"owner": "entity-team", "layer": "silver"}
 
 
@@ -207,7 +206,7 @@ class TestDatabricksAdapter:
         assert ("expect_all", {"valid_id": "id IS NOT NULL"}) in dp.expectations
         assert ("expect_all_or_drop", {"positive_qty": "qty > 0"}) in dp.expectations
         assert ("expect_all_or_fail", {"no_future": "d <= current_date()"}) in dp.expectations
-        assert "silver.orders" in dp.declared, "the MV must still be declared"
+        assert "silver_orders" in dp.declared, "the MV must still be declared"
 
     def test_expectations_against_oss_runtime_fail_actionably(self):
         """A Databricks engine pointed at an OSS dp module (no expect_all)
@@ -238,7 +237,7 @@ class TestDatabricksAdapter:
 
         engine.declare_pipeline(engine.build_plan())
 
-        kwargs, _ = dp.declared["silver.orders"]
+        kwargs, _ = dp.declared["silver_orders"]
         assert kwargs["comment"] == "x" and kwargs["partition_cols"] == ["d"]
 
 


### PR DESCRIPTION
## Experiment 4 — #166 AUTO CDC mapping validated against the live API

A minimal SCD2 app (`tests/data-apps/lakeflow-scd-test-app`, entry point `lakeflow_scd`) deployed through the #180 Lakeflow app selector into a **real serverless pipeline** (pipeline `26d435a6`, updates `bb0e2f71` v1 / `92d9116c` v2 on the nonprod workspace):

- The selector chain works end to end: `%pip` wheel install → entry-point discovery → allowlist → config bridging → `kindling.initialize(engine="databricks_sdp")` → `register_all()` → `declare_pipeline()`.
- The engine's emissions run on the real runtime (`pyspark.pipelines` **is** exposed on channel CURRENT — the new `create_auto_cdc_from_snapshot_flow`/`create_streaming_table` names, no legacy `dlt` needed).
- **SCD2 semantics verified on the real table** `silver_customers` (`__START_AT`/`__END_AT`): v1 → two open rows; v2 → changed key closed + reopened, unchanged key single row, new key appended.

A new system test drives this repeatably: `poe test-extension --extension sdp --platform databricks` (`tests/system/extensions/sdp/test_lakeflow_platform.py`).

## Experiment 5 — exact platform errors for the known blockers

Captured by declaring hand-built plans that bypass `build_plan()` validation (recorded in `docs/proposals/sdp_engine_phase1_notes.md`):

- **Self-read pipe** (temporal determination shape): update fails at graph resolution — `Graph is not topologically sorted. There is a cycle between kindling.kindling.silver_events and kindling.kindling.silver_events.`
- **Multi-writer target**: source evaluation fails — ``AnalysisException: Cannot redefine dataset `kindling`.`kindling`.`silver_events```

Both are update-time, generic, and name physical tables, not pipes — confirming the value of the existing declaration-time `self_referencing_pipe` / `duplicate_output_entity` fail-fast validators.

## Product fixes required to get there (all in this PR)

1. **Selector: restricted-runtime config bridging** — serverless blocks every conf-enumeration surface with varying exception types; tiers are now best-effort, with a `SET` fallback and a `kindling.lakeflow.config_keys` point-lookup bridge (pipeline configuration is point-readable but not enumerable).
2. **Selector: platform default** — `kindling.initialize` resolved platform=databricks, whose platform service cannot construct in a pipeline environment ("No workspace_id provided", workspace REST scan at init). Declaration-time config now defaults `platform=standalone`; explicit `kindling.platform.environment` wins.
3. **Single-part dataset names** — UC treats dotted dataset names as schema-qualified (`silver.customers` → `<catalog>.silver.customers`, requiring CREATE SCHEMA on the catalog) and rejects dotted view names outright. Datasets now emit with dots→underscores (the runner name-mapper's leaf normalization); INTERNAL reads use the emitted name; plan-level names stay logical entity ids.
4. **AUTO CDC source view naming** — pipeline-scoped views only accept single-part names.

## Operational findings (documented in `docs/guide/lakeflow_app_selection.md`)

- Serverless environments cache installed wheels by requirement set — same-filename re-uploads are silently ignored; bump versions on every change.
- Materialized-view datasets need the `CREATE MATERIALIZED VIEW` privilege on the target schema (distinct from CREATE TABLE) — the test SP lacks it, so the test app builds its snapshot in the SCD pipe body (pipeline-scoped view) instead of a seed MV.
- The workspace SP cannot create clusters or schemas; pipelines run serverless against the existing harness schema.

## Verification

- Local: `poe test-unit` 1815 passed; SDP integration tests 17 passed; selector unit tests extended (20 passed).
- Cloud: pipeline updates green as above; Exp 5 pipelines cleaned up automatically; all test resources (pipelines, notebooks, tables, debug files) swept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)