### PR TITLE
fix(databricks): home Lakeflow temporal execution in the databricks extension

### DIFF
--- a/packages/extensions/kindling_ext_databricks/kindling_ext_databricks/engine.py
+++ b/packages/extensions/kindling_ext_databricks/kindling_ext_databricks/engine.py
@@ -140,12 +140,14 @@ class DatabricksSdpEngine(OssSdpEngine):
         here too, so both halves share one wiring computation.
         """
         try:
+            from kindling_ext_databricks.temporal_lowering import (
+                declare_stratified_temporal,
+            )
             from kindling_ext_temporal.chain import (
                 DEFAULT_MAX_GENERATIONS,
                 MAX_GENERATIONS_CONFIG_KEY,
                 chain_episodes_pipe_id,
             )
-            from kindling_ext_temporal.sdp_lowering import declare_stratified_temporal
         except ImportError as exc:
             raise RuntimeError(
                 f"Dataset '{dataset.name}' is a temporal chain pipe but "

--- a/packages/extensions/kindling_ext_databricks/kindling_ext_databricks/temporal_lowering.py
+++ b/packages/extensions/kindling_ext_databricks/kindling_ext_databricks/temporal_lowering.py
@@ -1,4 +1,8 @@
-"""Stratified Lakeflow/SDP lowering of the temporal chain pipes.
+"""Stratified Lakeflow lowering of the temporal chain pipes.
+
+Lakeflow execution is a capability of THIS (databricks) extension; the
+temporal extension stays engine-agnostic. kindling-ext-temporal is a soft
+dependency, imported only when an app registered chain pipes.
 
 Lakeflow gives a dataset no access to its own prior state — evaluation-time
 reads of pipeline datasets are rejected (REFERENCE_DLT_DATASET_OUTSIDE_
@@ -43,8 +47,7 @@ from functools import reduce
 from typing import Any, Dict, List, Optional
 
 from kindling.injection import GlobalInjector
-
-from .translation import TemporalPipeTranslator
+from kindling_ext_temporal.translation import TemporalPipeTranslator
 
 STRATUM_SUFFIX = "__g"
 DETERMINATIONS_SUFFIX = "__determinations"
@@ -65,7 +68,10 @@ def _spark():
 
 
 def _temporal_registries():
-    from .registry import TemporalEpisodeRegistry, TemporalEventRegistry
+    from kindling_ext_temporal.registry import (
+        TemporalEpisodeRegistry,
+        TemporalEventRegistry,
+    )
 
     event_registry = GlobalInjector.get(TemporalEventRegistry)
     episode_registry = GlobalInjector.get(TemporalEpisodeRegistry)
@@ -103,8 +109,10 @@ def _read_rules(spark, conditions_entity):
     max_rule_generation).
     """
     from kindling.data_entities import scd_config_from_tags
-
-    from .validation import ActiveSparkSqlExpressionParser, TemporalConditionValidator
+    from kindling_ext_temporal.validation import (
+        ActiveSparkSqlExpressionParser,
+        TemporalConditionValidator,
+    )
 
     try:
         table_name = _physical_table_name(conditions_entity)
@@ -205,10 +213,9 @@ def declare_stratified_temporal(
     single-part dataset names of the chain pipes' outputs (episodes may be
     None when no episodes are declared).
     """
+    from kindling_ext_temporal.engine import ConditionEngineRunner, EpisodeRunner
+    from kindling_ext_temporal.entities import TemporalEntityResolver
     from pyspark.sql import functions as F
-
-    from .engine import ConditionEngineRunner, EpisodeRunner
-    from .entities import TemporalEntityResolver
 
     spark = _spark()
     base_defs, episode_defs = _temporal_registries()

--- a/packages/extensions/kindling_ext_databricks/kindling_ext_databricks/temporal_lowering.py
+++ b/packages/extensions/kindling_ext_databricks/kindling_ext_databricks/temporal_lowering.py
@@ -7,7 +7,7 @@ dependency, imported only when an app registered chain pipes.
 Lakeflow gives a dataset no access to its own prior state — evaluation-time
 reads of pipeline datasets are rejected (REFERENCE_DLT_DATASET_OUTSIDE_
 QUERY_DEFINITION) and in-view self-target reads fail at runtime (both
-probed on a real workspace, 2026-07-22). The chain pipes therefore lower to
+probed on a real workspace). The chain pipes therefore lower to
 a stratified dataset graph in which every dependency is a real edge between
 distinct datasets and all cross-update state lives in platform-owned
 primitives:

--- a/packages/extensions/kindling_ext_databricks/pyproject.toml
+++ b/packages/extensions/kindling_ext_databricks/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "spark-kindling-ext-databricks"
-version = "0.1.8"
+version = "0.1.9"
 description = "Databricks Lakeflow adapter for Kindling's SDP declaration engine"
 authors = ["SEP Engineering <engineering@sep.com>"]
 license = "MIT"

--- a/packages/extensions/kindling_ext_temporal/pyproject.toml
+++ b/packages/extensions/kindling_ext_temporal/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "kindling-ext-temporal"
-version = "0.2.3"
+version = "0.2.4"
 description = "Temporal event, condition, and episode primitives for Kindling"
 authors = ["SEP Engineering <engineering@sep.com>"]
 license = "MIT"

--- a/tests/data-apps/temporal-test-app/settings.yaml
+++ b/tests/data-apps/temporal-test-app/settings.yaml
@@ -1,3 +1,3 @@
 kindling:
   extensions:
-    - kindling-ext-temporal==0.2.3
+    - kindling-ext-temporal==0.2.4

--- a/tests/system/extensions/databricks/test_lakeflow_scd_platform.py
+++ b/tests/system/extensions/databricks/test_lakeflow_scd_platform.py
@@ -21,7 +21,7 @@ serverless environments cache installed wheels by requirement set):
     packages/ path (scripts/deploy_extensions.py convention).
 
 Usage:
-    poe test-extension --extension sdp --platform databricks
+    poe test-extension --extension databricks --platform databricks
 """
 
 import base64

--- a/tests/system/extensions/databricks/test_temporal_lakeflow.py
+++ b/tests/system/extensions/databricks/test_temporal_lakeflow.py
@@ -33,7 +33,7 @@ have fixed names in the target schema, so this test must not run
 concurrently with itself.
 
 Usage:
-    poe test-extension --extension temporal --platform databricks
+    poe test-extension --extension databricks --platform databricks
 """
 
 import base64

--- a/tests/system/extensions/temporal/test_temporal_platform.py
+++ b/tests/system/extensions/temporal/test_temporal_platform.py
@@ -68,7 +68,7 @@ EXPECTED_RUN2_TESTS = [
     "run2_gold_aggregation",
 ]
 
-TEMPORAL_EXTENSION_SPEC = "kindling-ext-temporal==0.2.3"
+TEMPORAL_EXTENSION_SPEC = "kindling-ext-temporal==0.2.4"
 
 
 def _run_scenario(

--- a/tests/unit/test_temporal_sdp_lowering.py
+++ b/tests/unit/test_temporal_sdp_lowering.py
@@ -70,6 +70,7 @@ def test_stratified_lowering_emits_the_full_dataset_graph(monkeypatch):
         EntityNameMapper,
     )
     from kindling.data_pipes import DataPipesManager, DataPipesRegistry
+    from kindling_ext_databricks import temporal_lowering
     from kindling_ext_temporal import (
         DataEpisodes,
         DataEvents,
@@ -80,7 +81,6 @@ def test_stratified_lowering_emits_the_full_dataset_graph(monkeypatch):
         TemporalEventRegistry,
         TemporalEventRegistryManager,
         declare_temporal_chain,
-        sdp_lowering,
     )
 
     DataEvents.reset()
@@ -133,10 +133,10 @@ def test_stratified_lowering_emits_the_full_dataset_graph(monkeypatch):
         declare_temporal_chain()
 
         # Rules are unreadable in this hermetic test (first-run path).
-        monkeypatch.setattr(sdp_lowering, "_spark", lambda: MagicMock())
+        monkeypatch.setattr(temporal_lowering, "_spark", lambda: MagicMock())
 
         dp = FakeDp()
-        sdp_lowering.declare_stratified_temporal(
+        temporal_lowering.declare_stratified_temporal(
             dp, events_name="silver_events", episodes_name="silver_episodes", max_generations=2
         )
 


### PR DESCRIPTION
## What

Lakeflow execution is a capability of the **databricks extension**, not of temporal — this PR corrects the homing that #186 (and one test from #185) got wrong:

- The stratified lowering — pure Lakeflow vocabulary (streaming tables, append flows, AUTO CDC) — moves from `kindling_ext_temporal.sdp_lowering` to **`kindling_ext_databricks.temporal_lowering`**. The dependency direction is now explicit and one-way: the databricks extension soft-requires kindling-ext-temporal (imported only when an app registered chain pipes), and the temporal extension is engine-agnostic again — declarations, the chain (plain runner-executable pipes), the pure engine, ingestion.
- Both Lakeflow platform tests move to a dedicated **`tests/system/extensions/databricks`** suite (`poe test-extension --extension databricks --platform databricks`): the temporal-in-Lakeflow lifecycle test, and the SCD/AUTO CDC test that had been mis-homed under `extensions/sdp` since #185. `--extension temporal` now exercises only engine-agnostic and jobs-path behavior.
- Wheels bumped (temporal 0.2.4, databricks 0.1.9) and deployed.

No behavior change — module move + soft-import rewiring + test suite relocation.

## Verification

- Rehomed system test green against the real workspace from its new suite: `test_temporal_chain_runs_in_a_lakeflow_pipeline` — 1 passed in 5:06, full two-update lifecycle (closure, expiration, determinations, higher-order boundary, SCD2 revision with identity, determination history), self-cleaning.
- Full unit suite: 1817 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)