### PR TITLE
feat(entities): derived datasets and replacement writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Spark Kindling Framework is a comprehensive solution for building robust data pi
 - [Introduction](./docs/intro.md) - Framework overview and architecture
 - [Data Entities](./docs/guide/data_entities.md) - Data entity management system
 - [Data Pipes](./docs/guide/data_pipes.md) - Transformation pipeline system
+- [Derived Datasets](./docs/guide/derived_datasets.md) - Replacement writes: derived datasets, slice replace, insert-only
 - [Entity Providers](./docs/contributing/entity_providers.md) - Storage abstraction system
 - [Setup Guide](./docs/guide/setup_guide.md) - Installation and configuration
 - [Migrating from runMultiple](./docs/guide/migrating_from_runmultiple.md) - Move Synapse/Fabric notebook DAGs to Kindling pipes

--- a/docs/guide/derived_datasets.md
+++ b/docs/guide/derived_datasets.md
@@ -1,0 +1,101 @@
+# Derived Datasets and Replacement Writes
+
+Kindling distinguishes two kinds of dataset:
+
+- **State datasets** have identity and memory. Writes describe how state
+  *evolves*: append rows, upsert by key (`write.mode: merge`), keep
+  history (`scd.type: "2"`), or insert-if-absent (`write.mode: insert`).
+- **Derived datasets** have no independent state. Their contents are a
+  pure function of their inputs, so a write *replaces* rather than
+  evolves. Declared with `dataset.kind: derived`.
+
+The declaration is engine-agnostic. Each execution style materializes it
+however it natively can:
+
+| Engine | Materialization |
+| --- | --- |
+| Runner (batch) | Atomic Delta overwrite swap — full table, or only the batch's slices with `derived.replace_keys` |
+| Streaming | Rejected at query start — a continuous sink has no "recompute" moment |
+| Declarative (SDP / Databricks Lakeflow) | A materialized view; the platform owns refresh |
+
+## Declaring a derived dataset
+
+```python
+@data_entity(
+    entityid="gold.run_summary",
+    tags={
+        "dataset.kind": "derived",
+        "derived.replace_keys": "run_id",   # optional: slice scope
+    },
+)
+```
+
+- Without `derived.replace_keys`, every write atomically replaces the
+  whole table (`mode("overwrite")`). Right for reference data and
+  recomputed summaries where the full recompute is proportional to the
+  output anyway.
+- With `derived.replace_keys`, each write replaces exactly the slices
+  present in the incoming DataFrame — the distinct values of the key
+  columns become a Delta `replaceWhere` predicate. Right for bounded-run
+  reprocessing ("re-analyze run X"): rerunning converges to the identical
+  table, and rows the recomputation no longer produces disappear — which
+  a merge can never do. Keys should scope coarse slices (runs, days,
+  sites), not high-cardinality business keys.
+
+Both forms are one transaction-log commit: old files are dereferenced,
+not rewritten, so readers see the previous version until the swap lands
+and the write costs only the new data. Every swap is a Delta version, so
+"what did this say before the rules changed" is a `VERSION AS OF` query.
+
+### What a derived dataset excludes
+
+The derived and state vocabularies are mutually exclusive and validated
+at entity registration:
+
+- `write.mode` and `scd.*` tags are rejected — replacement has no
+  evolution semantics.
+- `derived.replace_keys` requires `dataset.kind: derived`, and its
+  columns must exist in the declared schema (when one is declared).
+- A derived entity cannot be a streaming sink.
+- On SDP engines, `dataset.kind: derived` lowers to a materialized view;
+  a conflicting `sdp.dataset_type: streaming_table` is a validation
+  error (`invalid_dataset_type`).
+
+### Change-data-feed caveat
+
+A replacement write emits CDF churn for every row it touches. Do not use
+a derived dataset as the watermarked driving source of a downstream
+incremental pipe — downstream consumers should read it fully (it is
+cheap to read: it is exactly its latest recomputation).
+
+## Insert-only writes (`write.mode: insert`)
+
+For **state** tables whose rows are immutable once landed (event logs,
+readings with deterministic IDs), `write.mode: insert` merges with
+insert-if-absent semantics: rows whose `merge_columns` keys already
+exist are left untouched, new keys are inserted. Replays of
+already-landed batches rewrite nothing, so idempotent re-delivery is
+near-free.
+
+```python
+@data_entity(
+    entityid="silver.readings",
+    merge_columns=["reading_id"],
+    tags={"write.mode": "insert"},
+)
+```
+
+- Requires `merge_columns` (the dedup keys); contradicts `scd.type`.
+- Works identically in batch and streaming (each micro-batch runs the
+  same insert-only merge through the stream-merge sink).
+
+## Choosing a write shape
+
+| You want | Declare |
+| --- | --- |
+| Rows accumulate, never change | `write.mode: append` |
+| Upsert by key, latest wins | `write.mode: merge` (default with `merge_columns`) |
+| Upsert by key, keep history | `scd.type: "2"` |
+| Immutable rows, dedup on replay | `write.mode: insert` |
+| Recomputed from inputs, replace all | `dataset.kind: derived` |
+| Recomputed per run/day/slice | `dataset.kind: derived` + `derived.replace_keys` |

--- a/packages/extensions/kindling_ext_sdp/kindling_ext_sdp/declaration_engine.py
+++ b/packages/extensions/kindling_ext_sdp/kindling_ext_sdp/declaration_engine.py
@@ -503,6 +503,18 @@ class DeclarationEngine(ABC):
         )
         if entity is not None:
             tag_value = str((entity.tags or {}).get(DATASET_TYPE_TAG, "")).strip()
+            # A derived dataset (core tag dataset.kind='derived') IS a
+            # materialized view — that is precisely what the declaration
+            # means on a declarative engine. An explicit conflicting
+            # sdp.dataset_type is a contradiction, not an override.
+            if str((entity.tags or {}).get("dataset.kind", "")).strip().lower() == "derived":
+                if tag_value and tag_value.lower() != DatasetType.MATERIALIZED_VIEW.value:
+                    raise ValueError(
+                        f"Entity '{entity.entityid}': dataset.kind='derived' "
+                        f"lowers to a materialized view; conflicting "
+                        f"{DATASET_TYPE_TAG}='{tag_value}'"
+                    )
+                return DatasetType.MATERIALIZED_VIEW
             if tag_value:
                 raw, source = tag_value, f"entity tag '{DATASET_TYPE_TAG}'"
 

--- a/packages/kindling/data_entities.py
+++ b/packages/kindling/data_entities.py
@@ -365,6 +365,12 @@ def _validate_derived_config(entity: EntityMetadata) -> None:
         )
 
     cfg = derived_config_from_tags(entity)
+    replace_raw = str(tags.get("derived.replace_keys") or "").strip()
+    if replace_raw and not cfg.replace_keys:
+        raise ValueError(
+            f"Entity '{entity.entityid}': derived.replace_keys is set but "
+            f"contains no usable column names: '{replace_raw}'"
+        )
     if not cfg.enabled:
         if cfg.replace_keys:
             raise ValueError(
@@ -630,9 +636,12 @@ class DataEntityManager(DataEntityRegistry, SignalEmitter):
 
     def register_entity(self, entityid, **decorator_params):
         entity = EntityMetadata(entityid, **decorator_params)
+        # Derived-vs-state exclusivity first: a derived entity carrying
+        # state tags should fail with "does not apply to a derived
+        # dataset", not with a downstream state-vocabulary complaint.
+        _validate_derived_config(entity)
         _validate_scd_config(entity)
         _validate_write_mode_tag(entity)
-        _validate_derived_config(entity)
 
         self.registry[entityid] = entity
         self.emit(

--- a/packages/kindling/data_entities.py
+++ b/packages/kindling/data_entities.py
@@ -313,6 +313,87 @@ def scd_config_from_tags(entity: EntityMetadata) -> SCDConfig:
     )
 
 
+@dataclass(frozen=True)
+class DerivedConfig:
+    """Parsed derived-dataset configuration from an entity's tags.
+
+    A derived dataset has no independent state: its contents are a pure
+    function of its inputs. Engines materialize the declaration however
+    they natively can — the runner as an atomic overwrite swap (full
+    table, or per-slice via ``replace_keys``), declarative engines as a
+    materialized view.
+    """
+
+    enabled: bool
+    replace_keys: Optional[List[str]] = None
+
+
+def derived_config_from_tags(entity: EntityMetadata) -> DerivedConfig:
+    """Extract derived-dataset configuration from an entity's tags.
+
+    Tags:
+    - ``dataset.kind``: ``"derived"`` opts in; absent/empty means a state
+      dataset (the default — today's append/merge/SCD behavior).
+    - ``derived.replace_keys``: comma-separated scoping columns. When set,
+      each write atomically replaces only the slices present in the batch
+      (the distinct values of these columns) instead of the whole table.
+    """
+    tags = entity.tags or {}
+    kind = str(tags.get("dataset.kind") or "").strip().lower()
+    replace_raw = str(tags.get("derived.replace_keys") or "").strip()
+    replace_keys = (
+        [column.strip() for column in replace_raw.split(",") if column.strip()]
+        if replace_raw
+        else None
+    )
+    return DerivedConfig(enabled=kind == "derived", replace_keys=replace_keys)
+
+
+def _validate_derived_config(entity: EntityMetadata) -> None:
+    """Validate derived-dataset tags at registration time.
+
+    Derived and state vocabularies are mutually exclusive: a derived
+    dataset is recomputed, so evolution semantics (``write.mode``,
+    ``scd.*``) cannot apply to it.
+    """
+    tags = entity.tags or {}
+    kind = str(tags.get("dataset.kind") or "").strip().lower()
+    if kind not in ("", "derived"):
+        raise ValueError(
+            f"Entity '{entity.entityid}': invalid dataset.kind "
+            f"'{kind}' (expected 'derived' or unset)"
+        )
+
+    cfg = derived_config_from_tags(entity)
+    if not cfg.enabled:
+        if cfg.replace_keys:
+            raise ValueError(
+                f"Entity '{entity.entityid}': derived.replace_keys requires "
+                "dataset.kind='derived'"
+            )
+        return
+
+    if str(tags.get("write.mode") or "").strip():
+        raise ValueError(
+            f"Entity '{entity.entityid}': write.mode does not apply to a "
+            "derived dataset — its contents are replaced, not evolved"
+        )
+    if str(tags.get("scd.type") or "").strip():
+        raise ValueError(
+            f"Entity '{entity.entityid}': scd.type does not apply to a "
+            "derived dataset — history semantics require a state dataset"
+        )
+
+    if cfg.replace_keys and entity.schema is not None:
+        schema_names = {field.name for field in entity.schema.fields}
+        missing = [column for column in cfg.replace_keys if column not in schema_names]
+        if missing:
+            raise ValueError(
+                f"Entity '{entity.entityid}': derived.replace_keys columns "
+                f"not in entity schema: {missing}"
+            )
+
+
 def _validate_write_mode_tag(entity: EntityMetadata) -> None:
     """Validate the static ``write.mode`` tag at registration time.
 
@@ -321,12 +402,24 @@ def _validate_write_mode_tag(entity: EntityMetadata) -> None:
     surfaces typos when the entity is registered instead of mid-persist,
     where a raise would sit awkwardly inside the persist lifecycle.
     """
-    write_mode = str((entity.tags or {}).get("write.mode") or "").strip().lower()
-    if write_mode not in ("", "append", "merge"):
+    tags = entity.tags or {}
+    write_mode = str(tags.get("write.mode") or "").strip().lower()
+    if write_mode not in ("", "append", "merge", "insert"):
         raise ValueError(
             f"Entity '{entity.entityid}': invalid write.mode "
-            f"'{write_mode}' (expected 'append' or 'merge')"
+            f"'{write_mode}' (expected 'append', 'merge' or 'insert')"
         )
+    if write_mode == "insert":
+        if not entity.merge_columns:
+            raise ValueError(
+                f"Entity '{entity.entityid}': write.mode 'insert' requires "
+                "merge_columns (dedup keys) to be defined"
+            )
+        if str(tags.get("scd.type") or "").strip():
+            raise ValueError(
+                f"Entity '{entity.entityid}': write.mode 'insert' contradicts "
+                "scd.type — SCD entities update history on change"
+            )
 
 
 def _validate_scd_config(entity: EntityMetadata) -> None:
@@ -539,6 +632,7 @@ class DataEntityManager(DataEntityRegistry, SignalEmitter):
         entity = EntityMetadata(entityid, **decorator_params)
         _validate_scd_config(entity)
         _validate_write_mode_tag(entity)
+        _validate_derived_config(entity)
 
         self.registry[entityid] = entity
         self.emit(

--- a/packages/kindling/entity_provider.py
+++ b/packages/kindling/entity_provider.py
@@ -258,6 +258,36 @@ class StreamMergeableEntityProvider(ABC):
         pass
 
 
+class ReplaceWritableEntityProvider(ABC):
+    """
+    Optional interface for providers that can atomically replace an entity's
+    contents.
+
+    This is the materialization contract for derived datasets
+    (``dataset.kind: derived``): the entity's contents are a pure function
+    of its inputs, so a write replaces rather than evolves. The replacement
+    must be atomic — readers see the old contents until the swap commits —
+    and idempotent: replaying the same batch converges to the same table.
+
+    The replacement scope comes from the entity's own declaration
+    (``derived.replace_keys``): unset means the whole table; set means only
+    the slices present in the incoming DataFrame (its distinct values of
+    those columns) are swapped.
+    """
+
+    @abstractmethod
+    def replace_entity(self, df: DataFrame, entity_metadata: EntityMetadata) -> None:
+        """
+        Atomically replace entity contents (full table or declared slices).
+
+        Args:
+            df: DataFrame holding the new contents
+            entity_metadata: Metadata describing the destination entity;
+                its tags declare the replacement scope
+        """
+        pass
+
+
 class DestinationEnsuringProvider(ABC):
     """
     Optional interface for providers that can ensure a write destination exists.
@@ -330,6 +360,11 @@ def is_stream_writable(provider: BaseEntityProvider) -> bool:
 def is_stream_mergeable(provider: BaseEntityProvider) -> bool:
     """Check if provider supports streaming merges."""
     return isinstance(provider, StreamMergeableEntityProvider)
+
+
+def is_replace_writable(provider: BaseEntityProvider) -> bool:
+    """Check if provider supports atomic replace writes (derived datasets)."""
+    return isinstance(provider, ReplaceWritableEntityProvider)
 
 
 def can_ensure_destination(provider: BaseEntityProvider) -> bool:

--- a/packages/kindling/entity_provider_delta.py
+++ b/packages/kindling/entity_provider_delta.py
@@ -34,6 +34,7 @@ from .entity_provider import (
     BaseEntityProvider,
     DestinationEnsuringProvider,
     IncrementalReadableEntityProvider,
+    ReplaceWritableEntityProvider,
     StreamableEntityProvider,
     StreamMergeableEntityProvider,
     StreamWritableEntityProvider,
@@ -132,6 +133,44 @@ class SCD1MergeStrategy(DeltaMergeStrategy):
         spark.conf.set(conf_key, "true")
         try:
             (builder.whenMatchedUpdateAll().whenNotMatchedInsertAll().execute())
+        finally:
+            if previous is None:
+                spark.conf.unset(conf_key)
+            else:
+                spark.conf.set(conf_key, previous)
+
+
+@DeltaMergeStrategies.register(name="insert_only")
+class InsertOnlyMergeStrategy(DeltaMergeStrategy):
+    """Insert-if-absent merge for immutable state tables.
+
+    Selected by ``write.mode: insert``: rows whose business keys already
+    exist in the target are left untouched (no matched clause, so replays
+    of already-landed batches rewrite nothing), new keys are inserted.
+    Schema evolution follows the same additive policy as SCD1 — see
+    ``SCD1MergeStrategy.apply`` for the Delta-version fallback rationale.
+    """
+
+    def apply(
+        self,
+        delta_table,
+        df: DataFrame,
+        entity,
+        merge_condition: str,
+    ) -> None:
+        builder = delta_table.alias("old").merge(source=df.alias("new"), condition=merge_condition)
+
+        if hasattr(builder, "withSchemaEvolution"):
+            builder.withSchemaEvolution().whenNotMatchedInsertAll().execute()
+            return
+
+        # Delta < 3.2 compatibility path.
+        spark = df.sparkSession
+        conf_key = "spark.databricks.delta.schema.autoMerge.enabled"
+        previous = spark.conf.get(conf_key, None)
+        spark.conf.set(conf_key, "true")
+        try:
+            builder.whenNotMatchedInsertAll().execute()
         finally:
             if previous is None:
                 spark.conf.unset(conf_key)
@@ -545,6 +584,7 @@ class DeltaEntityProvider(
     IncrementalReadableEntityProvider,
     StreamableEntityProvider,
     WritableEntityProvider,
+    ReplaceWritableEntityProvider,
     StreamWritableEntityProvider,
     StreamMergeableEntityProvider,
     SignalEmitter,
@@ -1490,7 +1530,13 @@ class DeltaEntityProvider(
     def _merge_to_delta_table(self, df: DataFrame, entity, table_ref: DeltaTableReference):
         """Merge DataFrame to existing Delta table"""
         scd_config = scd_config_from_tags(entity)
-        strategy_name = "scd2" if scd_config.enabled else "scd1"
+        write_mode = str((entity.tags or {}).get("write.mode") or "").strip().lower()
+        if scd_config.enabled:
+            strategy_name = "scd2"
+        elif write_mode == "insert":
+            strategy_name = "insert_only"
+        else:
+            strategy_name = "scd1"
         strategy = DeltaMergeStrategies.get(strategy_name)
         merge_condition = self._build_merge_condition("old", "new", entity.merge_columns)
         strategy.apply(table_ref.get_delta_table(), df, entity, merge_condition)
@@ -1941,6 +1987,134 @@ class DeltaEntityProvider(
                 duration_seconds=duration,
             )
             raise
+
+    def replace_entity(self, df: DataFrame, entity):
+        """Atomically replace entity contents (derived-dataset materialization).
+
+        Full replace (no ``derived.replace_keys``) is a Delta overwrite —
+        one transaction-log commit dereferences the old files, so readers
+        see the previous version until the swap lands and the cost is only
+        the write of the new data. Keyed replace swaps exactly the slices
+        present in the batch via ``replaceWhere`` computed from the batch's
+        distinct key values: idempotent by construction, and rows the
+        recomputation no longer produces disappear (which merge cannot do).
+        """
+        if self._is_read_only(entity):
+            raise ReadOnlyEntityError(entity.entityid)
+
+        start_time = time.time()
+        table_ref = self._get_table_reference(entity)
+
+        self.emit("entity.before_replace", entity_id=entity.entityid, entity_name=entity.name)
+
+        try:
+            if self._check_table_exists(table_ref):
+                self._replace_delta_table(df, entity, table_ref)
+            else:
+                # First materialization: plain create — every slice is new.
+                self._ensure_destination_for_write(entity, table_ref)
+                self._write_to_delta_table(df, entity, table_ref)
+
+            duration = time.time() - start_time
+            self.emit(
+                "entity.after_replace",
+                entity_id=entity.entityid,
+                entity_name=entity.name,
+                duration_seconds=duration,
+            )
+        except Exception as e:
+            duration = time.time() - start_time
+            self.emit(
+                "entity.replace_failed",
+                entity_id=entity.entityid,
+                error=str(e),
+                error_type=type(e).__name__,
+                duration_seconds=duration,
+            )
+            raise
+
+    def _replace_delta_table(self, df: DataFrame, entity, table_ref: DeltaTableReference):
+        """Overwrite the table, scoped by replaceWhere when keys are declared."""
+        derived_config = derived_config_from_tags(entity)
+
+        if derived_config.replace_keys:
+            predicate = self._build_replace_predicate(df, derived_config.replace_keys)
+            if predicate is None:
+                self.logger.info(
+                    f"Keyed replace of entity '{entity.entityid}': batch holds no "
+                    "slices — nothing to swap"
+                )
+                return
+            # overwriteSchema cannot combine with replaceWhere; keyed
+            # replaces keep the additive mergeSchema policy instead.
+            writer = (
+                df.write.format("delta")
+                .mode("overwrite")
+                .option("replaceWhere", predicate)
+                .option("mergeSchema", "true")
+            )
+        else:
+            writer = df.write.format("delta").mode("overwrite").option("overwriteSchema", "true")
+
+        if self._should_partition_files(entity):
+            writer = writer.partitionBy(*entity.partition_columns)
+
+        if self._is_for_name_mode(table_ref.access_mode) and table_ref.table_name:
+            self._ensure_configured_table_schema_exists()
+            writer.saveAsTable(table_ref.table_name)
+            table_ref.table_path = self._resolve_catalog_table_location(table_ref.table_name)
+        elif table_ref.table_path:
+            writer.save(table_ref.table_path)
+        else:
+            raise ValueError(
+                f"Cannot replace entity '{entity.entityid}' without table path "
+                f"in access mode '{table_ref.access_mode}'"
+            )
+
+    def _build_replace_predicate(self, df: DataFrame, replace_keys: list[str]) -> Optional[str]:
+        """Build a replaceWhere predicate covering the batch's distinct slices.
+
+        Returns None for an empty batch — a keyed replace with no slices is
+        a no-op, unlike a full replace where empty input means an empty
+        table. Every incoming row matches the predicate by construction,
+        which is exactly what Delta's replaceWhere requires.
+        """
+        slices = df.select(*replace_keys).distinct().collect()
+        if not slices:
+            return None
+        if len(slices) > 100:
+            self.logger.warning(
+                f"Keyed replace covers {len(slices)} slices in one batch; "
+                "derived.replace_keys should scope coarse slices (runs, days), "
+                "not high-cardinality keys"
+            )
+        clauses = []
+        for row in slices:
+            parts = []
+            for key in replace_keys:
+                value = row[key]
+                if value is None:
+                    parts.append(f"`{key}` IS NULL")
+                else:
+                    parts.append(f"`{key}` = {self._sql_literal(value)}")
+            clauses.append("(" + " AND ".join(parts) + ")")
+        return " OR ".join(clauses)
+
+    @staticmethod
+    def _sql_literal(value) -> str:
+        """Render a collected Python value as a SQL literal for replaceWhere."""
+        from datetime import date, datetime
+
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, (int, float)):
+            return str(value)
+        if isinstance(value, datetime):
+            return f"TIMESTAMP '{value.isoformat(sep=' ')}'"
+        if isinstance(value, date):
+            return f"DATE '{value.isoformat()}'"
+        escaped = str(value).replace("'", "''")
+        return f"'{escaped}'"
 
     def get_entity_version(self, entity) -> int:
         """Get current version of entity table"""

--- a/packages/kindling/entity_provider_delta.py
+++ b/packages/kindling/entity_provider_delta.py
@@ -2104,10 +2104,11 @@ class DeltaEntityProvider(
     def _sql_literal(value) -> str:
         """Render a collected Python value as a SQL literal for replaceWhere."""
         from datetime import date, datetime
+        from decimal import Decimal
 
         if isinstance(value, bool):
             return "true" if value else "false"
-        if isinstance(value, (int, float)):
+        if isinstance(value, (int, float, Decimal)):
             return str(value)
         if isinstance(value, datetime):
             return f"TIMESTAMP '{value.isoformat(sep=' ')}'"

--- a/packages/kindling/pipe_streaming.py
+++ b/packages/kindling/pipe_streaming.py
@@ -98,19 +98,30 @@ class SimplePipeStreamStarter(PipeStreamStarter):
                 "Missing streaming checkpoint root. "
                 "Set kindling.storage.checkpoint_root or pass streaming_options['base_checkpoint_path']."
             )
+        # Derived datasets are recomputed wholesale from their inputs; a
+        # continuous sink has no "recompute" moment, so a derived entity
+        # cannot be a streaming target. Materialize it with a batch pipe
+        # or a declarative engine (where it lowers to a materialized view).
+        if derived_config_from_tags(output_entity).enabled:
+            raise TypeError(
+                f"Entity '{output_entity.entityid}' is a derived dataset "
+                "(dataset.kind='derived') and cannot be a streaming sink"
+            )
+
         # Sink write mode: merge (per micro-batch upsert honoring the
-        # entity's SCD1/SCD2 semantics) vs append. Mirrors the batch persist
+        # entity's SCD1/SCD2 semantics), insert (per micro-batch
+        # insert-if-absent) vs append. Mirrors the batch persist
         # strategy, which merges whenever the provider supports it: entities
         # that declare merge/business keys default to merge when the sink
         # provider can stream-merge. The `write.mode` entity tag (shared
-        # with the batch persist path) forces either mode.
+        # with the batch persist path) forces the mode.
         write_mode = str(output_entity.tags.get("write.mode") or "").strip().lower()
-        if write_mode not in ("", "append", "merge"):
+        if write_mode not in ("", "append", "merge", "insert"):
             raise ValueError(
                 f"Entity '{output_entity.entityid}': invalid write.mode "
-                f"'{write_mode}' (expected 'append' or 'merge')"
+                f"'{write_mode}' (expected 'append', 'merge' or 'insert')"
             )
-        if write_mode == "merge" and not is_stream_mergeable(output_provider):
+        if write_mode in ("merge", "insert") and not is_stream_mergeable(output_provider):
             raise TypeError(
                 f"Output provider for entity '{output_entity.entityid}' "
                 f"(type={output_entity.tags.get('provider_type')}) "
@@ -157,9 +168,12 @@ class SimplePipeStreamStarter(PipeStreamStarter):
             if callable(ensure_output_table):
                 ensure_output_table(output_entity)
 
-        if write_mode == "merge":
+        if write_mode in ("merge", "insert"):
             # merge_as_stream starts the query itself (foreachBatch resolves
             # the target table internally), so no toTable()/start() step.
+            # "insert" rides the same sink: each micro-batch runs the batch
+            # merge, and the provider picks the insert-only strategy from
+            # the entity's write.mode tag.
             # Recognized streaming options are forwarded so callers can set
             # the trigger and query name on merged sinks too.
             merge_options = {

--- a/packages/kindling/simple_read_persist_strategy.py
+++ b/packages/kindling/simple_read_persist_strategy.py
@@ -196,6 +196,40 @@ class SimpleReadPersistStrategy(EntityReadPersistStrategy, SignalEmitter):
                 df = _apply_df_transforms(results, df)
 
                 try:
+                    # Derived datasets (dataset.kind='derived') are replaced,
+                    # not evolved: the provider swaps the whole table — or
+                    # only the batch's slices when derived.replace_keys is
+                    # declared — atomically. The state-dataset write.mode
+                    # machinery below never applies (the combination is
+                    # rejected at entity registration).
+                    derived_config = derived_config_from_tags(output_entity)
+                    if derived_config.enabled:
+                        if not hasattr(output_provider, "replace_entity"):
+                            provider_type = (output_entity.tags or {}).get(
+                                "provider_type", "unknown"
+                            )
+                            raise ValueError(
+                                f"Entity '{output_entity.entityid}' is a derived dataset "
+                                f"but provider '{provider_type}' does not support "
+                                "replace writes"
+                            )
+                        with strategy.tp.span(
+                            component="data_utils", operation="replace_entity_table"
+                        ):
+                            output_provider.replace_entity(df, output_entity)
+
+                        duration = time.time() - start_time
+                        strategy.emit(
+                            "persist.after_persist",
+                            df=df,
+                            pipe_id=pipe.pipeid,
+                            source_entity_id=src_input_entity_id,
+                            output_entity_id=pipe.output_entity_id,
+                            duration_seconds=duration,
+                            persist_id=persist_id,
+                        )
+                        return
+
                     # Sink write mode override, shared with the streaming path
                     # (SimplePipeStreamStarter): "append" skips the merge even
                     # when the provider supports it (e.g. append-only fact
@@ -209,16 +243,19 @@ class SimpleReadPersistStrategy(EntityReadPersistStrategy, SignalEmitter):
                     write_mode = (
                         str((output_entity.tags or {}).get("write.mode") or "").strip().lower()
                     )
-                    if write_mode not in ("", "append", "merge"):
+                    if write_mode not in ("", "append", "merge", "insert"):
                         raise ValueError(
                             f"Entity '{output_entity.entityid}': invalid write.mode "
-                            f"'{write_mode}' (expected 'append' or 'merge')"
+                            f"'{write_mode}' (expected 'append', 'merge' or 'insert')"
                         )
-                    if write_mode == "merge" and not hasattr(output_provider, "merge_to_entity"):
+                    if write_mode in ("merge", "insert") and not hasattr(
+                        output_provider, "merge_to_entity"
+                    ):
                         provider_type = (output_entity.tags or {}).get("provider_type", "unknown")
                         raise ValueError(
-                            f"Entity '{output_entity.entityid}': write.mode is 'merge' but "
-                            f"provider '{provider_type}' does not support merge operations"
+                            f"Entity '{output_entity.entityid}': write.mode is "
+                            f"'{write_mode}' but provider '{provider_type}' does not "
+                            "support merge operations"
                         )
 
                     with strategy.tp.span(

--- a/tests/unit/test_delta_replace.py
+++ b/tests/unit/test_delta_replace.py
@@ -204,3 +204,9 @@ class TestInsertOnlyStrategySelection:
         builder.whenNotMatchedInsertAll.assert_called_once()
         builder.whenMatchedUpdateAll.assert_not_called()
         builder.execute.assert_called_once()
+
+
+def test_sql_literal_decimal_is_unquoted():
+    from decimal import Decimal
+
+    assert DeltaEntityProvider._sql_literal(Decimal("12.50")) == "12.50"

--- a/tests/unit/test_delta_replace.py
+++ b/tests/unit/test_delta_replace.py
@@ -1,0 +1,206 @@
+"""
+Unit tests for DeltaEntityProvider.replace_entity — the derived-dataset
+materialization: an atomic overwrite swap of the full table, or of only
+the batch's slices when ``derived.replace_keys`` is declared (Delta
+``replaceWhere`` computed from the batch's distinct key values).
+"""
+
+from datetime import date, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from kindling.data_entities import EntityMetadata, EntityNameMapper, EntityPathLocator
+from kindling.entity_provider import ReplaceWritableEntityProvider, is_replace_writable
+from kindling.entity_provider_delta import DeltaEntityProvider, ReadOnlyEntityError
+from kindling.signaling import SignalProvider
+from kindling.spark_config import ConfigService
+from kindling.spark_log_provider import PythonLoggerProvider
+
+
+class TestDeltaReplaceEntity:
+    @pytest.fixture(autouse=True)
+    def mock_spark_session(self, monkeypatch):
+        spark = MagicMock()
+        monkeypatch.setattr(
+            "kindling.entity_provider_delta.get_or_create_spark_session", lambda: spark
+        )
+        return spark
+
+    @pytest.fixture
+    def provider(self):
+        config = MagicMock(spec=ConfigService)
+        config.get.side_effect = lambda key, default=None: (
+            "catalog" if key == "kindling.delta.access_mode" else default
+        )
+        entity_name_mapper = MagicMock(spec=EntityNameMapper)
+        path_locator = MagicMock(spec=EntityPathLocator)
+        logger_provider = MagicMock(spec=PythonLoggerProvider)
+        logger_provider.get_logger.return_value = MagicMock()
+        return DeltaEntityProvider(
+            config=config,
+            entity_name_mapper=entity_name_mapper,
+            path_locator=path_locator,
+            tp=logger_provider,
+            signal_provider=MagicMock(spec=SignalProvider),
+        )
+
+    def _make_entity(self, tags=None):
+        return EntityMetadata(
+            entityid="gold.summary",
+            name="summary",
+            tags={"dataset.kind": "derived", **(tags or {})},
+            merge_columns=None,
+            schema=None,
+        )
+
+    def _writer_chain(self):
+        """A df.write mock whose format/mode/option chain returns itself."""
+        writer = MagicMock()
+        writer.format.return_value = writer
+        writer.mode.return_value = writer
+        writer.option.return_value = writer
+        writer.partitionBy.return_value = writer
+        return writer
+
+    def test_provider_is_replace_writable(self, provider):
+        assert isinstance(provider, ReplaceWritableEntityProvider)
+        assert is_replace_writable(provider)
+
+    def test_read_only_entity_raises(self, provider):
+        entity = self._make_entity(tags={"read_only": "true"})
+        with pytest.raises(ReadOnlyEntityError):
+            provider.replace_entity(MagicMock(), entity)
+
+    def test_full_replace_overwrites_with_overwrite_schema(self, provider):
+        entity = self._make_entity()
+        df = MagicMock()
+        df.write = self._writer_chain()
+        table_ref = MagicMock(access_mode="catalog", table_name="gold_summary")
+
+        with (
+            patch.object(provider, "_get_table_reference", return_value=table_ref),
+            patch.object(provider, "_check_table_exists", return_value=True),
+            patch.object(provider, "_ensure_configured_table_schema_exists"),
+            patch.object(provider, "_resolve_catalog_table_location", return_value=None),
+        ):
+            provider.replace_entity(df, entity)
+
+        df.write.mode.assert_called_once_with("overwrite")
+        df.write.option.assert_called_once_with("overwriteSchema", "true")
+        df.write.saveAsTable.assert_called_once_with("gold_summary")
+
+    def test_keyed_replace_uses_replace_where_not_overwrite_schema(self, provider):
+        entity = self._make_entity(tags={"derived.replace_keys": "run_id"})
+        df = MagicMock()
+        df.write = self._writer_chain()
+        df.select.return_value.distinct.return_value.collect.return_value = [
+            {"run_id": "flight-1"},
+            {"run_id": "flight-2"},
+        ]
+        table_ref = MagicMock(access_mode="catalog", table_name="gold_summary")
+
+        with (
+            patch.object(provider, "_get_table_reference", return_value=table_ref),
+            patch.object(provider, "_check_table_exists", return_value=True),
+            patch.object(provider, "_ensure_configured_table_schema_exists"),
+            patch.object(provider, "_resolve_catalog_table_location", return_value=None),
+        ):
+            provider.replace_entity(df, entity)
+
+        option_calls = {call.args[0]: call.args[1] for call in df.write.option.call_args_list}
+        assert option_calls["replaceWhere"] == (
+            "(`run_id` = 'flight-1') OR (`run_id` = 'flight-2')"
+        )
+        assert option_calls.get("mergeSchema") == "true"
+        assert "overwriteSchema" not in option_calls
+        df.write.mode.assert_called_once_with("overwrite")
+
+    def test_keyed_replace_empty_batch_is_noop(self, provider):
+        entity = self._make_entity(tags={"derived.replace_keys": "run_id"})
+        df = MagicMock()
+        df.write = self._writer_chain()
+        df.select.return_value.distinct.return_value.collect.return_value = []
+        table_ref = MagicMock(access_mode="catalog", table_name="gold_summary")
+
+        with (
+            patch.object(provider, "_get_table_reference", return_value=table_ref),
+            patch.object(provider, "_check_table_exists", return_value=True),
+        ):
+            provider.replace_entity(df, entity)
+
+        df.write.mode.assert_not_called()
+        df.write.saveAsTable.assert_not_called()
+
+    def test_missing_table_takes_create_path(self, provider):
+        entity = self._make_entity()
+        df = MagicMock()
+        table_ref = MagicMock(access_mode="catalog", table_name="gold_summary")
+
+        with (
+            patch.object(provider, "_get_table_reference", return_value=table_ref),
+            patch.object(provider, "_check_table_exists", return_value=False),
+            patch.object(provider, "_ensure_destination_for_write") as ensure,
+            patch.object(provider, "_write_to_delta_table") as write,
+        ):
+            provider.replace_entity(df, entity)
+
+        ensure.assert_called_once()
+        write.assert_called_once_with(df, entity, table_ref)
+
+
+class TestReplacePredicate:
+    def _predicate(self, rows, keys):
+        df = MagicMock()
+        df.select.return_value.distinct.return_value.collect.return_value = rows
+        provider = MagicMock()
+        provider.logger = MagicMock()
+        provider._sql_literal = DeltaEntityProvider._sql_literal
+        return DeltaEntityProvider._build_replace_predicate(provider, df, keys)
+
+    def test_multi_key_slices_and_of_keys_or_of_slices(self):
+        predicate = self._predicate(
+            [{"run_id": "r1", "site": 7}, {"run_id": "r2", "site": None}],
+            ["run_id", "site"],
+        )
+        assert predicate == (
+            "(`run_id` = 'r1' AND `site` = 7) OR (`run_id` = 'r2' AND `site` IS NULL)"
+        )
+
+    def test_string_values_escape_quotes(self):
+        predicate = self._predicate([{"run_id": "o'brien"}], ["run_id"])
+        assert predicate == "(`run_id` = 'o''brien')"
+
+    def test_temporal_and_bool_literals(self):
+        predicate = self._predicate(
+            [{"day": date(2026, 7, 1), "at": datetime(2026, 7, 1, 12, 30), "ok": True}],
+            ["day", "at", "ok"],
+        )
+        assert predicate == (
+            "(`day` = DATE '2026-07-01' AND `at` = TIMESTAMP '2026-07-01 12:30:00' "
+            "AND `ok` = true)"
+        )
+
+
+class TestInsertOnlyStrategySelection:
+    def test_registry_has_insert_only(self):
+        from kindling.entity_provider_delta import DeltaMergeStrategies
+
+        strategy = DeltaMergeStrategies.get("insert_only")
+        builder = MagicMock()
+        delta_table = MagicMock()
+        delta_table.alias.return_value.merge.return_value = builder
+        builder.withSchemaEvolution.return_value = builder
+        builder.whenNotMatchedInsertAll.return_value = builder
+
+        entity = EntityMetadata(
+            entityid="silver.events",
+            name="events",
+            merge_columns=["event_id"],
+            tags={"write.mode": "insert"},
+            schema=None,
+        )
+        strategy.apply(delta_table, MagicMock(), entity, "old.`event_id` = new.`event_id`")
+
+        builder.whenNotMatchedInsertAll.assert_called_once()
+        builder.whenMatchedUpdateAll.assert_not_called()
+        builder.execute.assert_called_once()

--- a/tests/unit/test_derived_dataset_config.py
+++ b/tests/unit/test_derived_dataset_config.py
@@ -1,0 +1,135 @@
+"""
+Unit tests for the derived-dataset declaration surface.
+
+A derived dataset (``dataset.kind: derived``) has no independent state —
+its contents are a pure function of its inputs, so writes replace rather
+than evolve. The derived and state vocabularies are mutually exclusive:
+``write.mode`` and ``scd.*`` are rejected on a derived entity at
+registration time, as is ``derived.replace_keys`` without the kind tag.
+"""
+
+import pytest
+from kindling.data_entities import (
+    DataEntityManager,
+    DerivedConfig,
+    EntityMetadata,
+    derived_config_from_tags,
+)
+from pyspark.sql.types import StringType, StructField, StructType
+
+
+def _entity(tags=None, schema=None, merge_columns=None):
+    return EntityMetadata(
+        "gold.summary",
+        name="Summary",
+        tags=tags or {},
+        schema=schema,
+        merge_columns=merge_columns,
+    )
+
+
+def _register(manager, tags=None, schema=None, merge_columns=None):
+    manager.register_entity(
+        "gold.summary",
+        name="Summary",
+        tags=tags or {},
+        schema=schema,
+        merge_columns=merge_columns,
+    )
+
+
+class TestDerivedConfigFromTags:
+    def test_absent_kind_is_disabled(self):
+        cfg = derived_config_from_tags(_entity())
+        assert cfg == DerivedConfig(enabled=False, replace_keys=None)
+
+    def test_derived_kind_enables(self):
+        cfg = derived_config_from_tags(_entity(tags={"dataset.kind": "derived"}))
+        assert cfg.enabled is True
+        assert cfg.replace_keys is None
+
+    def test_replace_keys_parse_and_strip(self):
+        cfg = derived_config_from_tags(
+            _entity(tags={"dataset.kind": "derived", "derived.replace_keys": " run_id , site "})
+        )
+        assert cfg.replace_keys == ["run_id", "site"]
+
+
+class TestDerivedRegistrationValidation:
+    def test_plain_derived_registers(self):
+        manager = DataEntityManager()
+        _register(manager, tags={"dataset.kind": "derived"})
+        assert "gold.summary" in manager.registry
+
+    def test_invalid_kind_rejected(self):
+        with pytest.raises(ValueError, match="invalid dataset.kind"):
+            _register(DataEntityManager(), tags={"dataset.kind": "materialized"})
+
+    def test_derived_rejects_write_mode(self):
+        with pytest.raises(ValueError, match="write.mode does not apply"):
+            _register(
+                DataEntityManager(),
+                tags={"dataset.kind": "derived", "write.mode": "merge"},
+            )
+
+    def test_derived_rejects_scd(self):
+        with pytest.raises(ValueError, match="scd.type does not apply"):
+            _register(
+                DataEntityManager(),
+                tags={"dataset.kind": "derived", "scd.type": "2"},
+                merge_columns=["id"],
+            )
+
+    def test_replace_keys_require_derived_kind(self):
+        with pytest.raises(ValueError, match="requires\\s+dataset.kind='derived'"):
+            _register(DataEntityManager(), tags={"derived.replace_keys": "run_id"})
+
+    def test_replace_keys_must_exist_in_declared_schema(self):
+        schema = StructType([StructField("value", StringType())])
+        with pytest.raises(ValueError, match="not in entity schema.*run_id"):
+            _register(
+                DataEntityManager(),
+                tags={"dataset.kind": "derived", "derived.replace_keys": "run_id"},
+                schema=schema,
+            )
+
+    def test_replace_keys_in_schema_register(self):
+        schema = StructType(
+            [StructField("run_id", StringType()), StructField("value", StringType())]
+        )
+        manager = DataEntityManager()
+        _register(
+            manager,
+            tags={"dataset.kind": "derived", "derived.replace_keys": "run_id"},
+            schema=schema,
+        )
+        assert "gold.summary" in manager.registry
+
+    def test_replace_keys_without_schema_register(self):
+        # Schema-less entities defer column checks to write time.
+        manager = DataEntityManager()
+        _register(manager, tags={"dataset.kind": "derived", "derived.replace_keys": "run_id"})
+        assert "gold.summary" in manager.registry
+
+
+class TestInsertWriteModeValidation:
+    def test_insert_requires_merge_columns(self):
+        with pytest.raises(ValueError, match="'insert' requires\\s+merge_columns"):
+            _register(DataEntityManager(), tags={"write.mode": "insert"})
+
+    def test_insert_with_merge_columns_registers(self):
+        manager = DataEntityManager()
+        _register(manager, tags={"write.mode": "insert"}, merge_columns=["event_id"])
+        assert "gold.summary" in manager.registry
+
+    def test_insert_contradicts_scd(self):
+        with pytest.raises(ValueError, match="'insert' contradicts\\s+scd.type"):
+            _register(
+                DataEntityManager(),
+                tags={"write.mode": "insert", "scd.type": "2"},
+                merge_columns=["event_id"],
+            )
+
+    def test_unknown_write_mode_still_rejected(self):
+        with pytest.raises(ValueError, match="invalid write.mode"):
+            _register(DataEntityManager(), tags={"write.mode": "overwrite"})

--- a/tests/unit/test_derived_dataset_config.py
+++ b/tests/unit/test_derived_dataset_config.py
@@ -133,3 +133,23 @@ class TestInsertWriteModeValidation:
     def test_unknown_write_mode_still_rejected(self):
         with pytest.raises(ValueError, match="invalid write.mode"):
             _register(DataEntityManager(), tags={"write.mode": "overwrite"})
+
+
+class TestCopilotReviewRegressions:
+    def test_empty_replace_keys_tag_rejected(self):
+        """A present-but-unusable replace_keys tag must not silently become
+        a full-table replace."""
+        with pytest.raises(ValueError, match="no usable column names"):
+            _register(
+                DataEntityManager(),
+                tags={"dataset.kind": "derived", "derived.replace_keys": ","},
+            )
+
+    def test_derived_error_wins_over_state_vocabulary_errors(self):
+        """Derived exclusivity validates first: a derived entity with a bad
+        state tag fails as 'does not apply', not with the state rule."""
+        with pytest.raises(ValueError, match="write.mode does not apply"):
+            _register(
+                DataEntityManager(),
+                tags={"dataset.kind": "derived", "write.mode": "insert"},
+            )

--- a/tests/unit/test_persist_write_mode.py
+++ b/tests/unit/test_persist_write_mode.py
@@ -171,3 +171,75 @@ def test_valid_write_mode_accepted_at_registration(mode):
     )
 
     assert "entity.ok" in manager.registry
+
+
+class _ReplaceCapableProvider(BaseEntityProvider, WritableEntityProvider):
+    """Spec class: batch-writable provider that also supports replace."""
+
+    def replace_entity(self, df, entity): ...
+
+
+def test_derived_dataset_routes_to_replace():
+    dst_entity = Mock(entityid="entity.dst", tags={"dataset.kind": "derived"})
+    out_provider = Mock(spec=_ReplaceCapableProvider)
+
+    persist, _ = _make_strategy(dst_entity, out_provider)
+    persist(Mock(name="df"))
+
+    out_provider.replace_entity.assert_called_once()
+    out_provider.write_to_entity.assert_not_called()
+    out_provider.append_to_entity.assert_not_called()
+
+
+def test_derived_dataset_emits_after_persist():
+    dst_entity = Mock(entityid="entity.dst", tags={"dataset.kind": "derived"})
+    out_provider = Mock(spec=_ReplaceCapableProvider)
+
+    persist, strategy = _make_strategy(dst_entity, out_provider)
+    emitted = _capture_emitted_signals(strategy)
+    persist(Mock(name="df"))
+
+    assert "persist.before_persist" in emitted
+    assert "persist.after_persist" in emitted
+
+
+def test_derived_dataset_requires_replace_capable_provider():
+    dst_entity = Mock(
+        entityid="entity.dst",
+        tags={"dataset.kind": "derived", "provider_type": "memory"},
+    )
+    out_provider = Mock(spec=_MergeWritableProvider)  # no replace_entity
+
+    persist, strategy = _make_strategy(dst_entity, out_provider)
+    emitted = _capture_emitted_signals(strategy)
+
+    with pytest.raises(ValueError, match="does not support\\s+replace"):
+        persist(Mock(name="df"))
+
+    assert "persist.persist_failed" in emitted
+
+
+def test_write_mode_insert_routes_to_merge_provider():
+    """insert rides the merge path; the provider picks the insert-only
+    strategy from the entity's write.mode tag."""
+    dst_entity = Mock(entityid="entity.dst", tags={"write.mode": "insert"})
+    out_provider = Mock(spec=_MergeWritableProvider)
+    out_provider.check_entity_exists.return_value = True
+
+    persist, _ = _make_strategy(dst_entity, out_provider)
+    persist(Mock(name="df"))
+
+    out_provider.merge_to_entity.assert_called_once()
+    out_provider.append_to_entity.assert_not_called()
+
+
+def test_write_mode_insert_requires_merge_capable_provider():
+    dst_entity = Mock(
+        entityid="entity.dst",
+        tags={"write.mode": "insert", "provider_type": "memory"},
+    )
+    out_provider = Mock(spec=WritableEntityProvider)
+
+    persist, _ = _make_strategy(dst_entity, out_provider)
+    with pytest.raises(ValueError, match="does not support merge"):
+        persist(Mock(name="df"))

--- a/tests/unit/test_pipe_streaming.py
+++ b/tests/unit/test_pipe_streaming.py
@@ -330,3 +330,56 @@ def test_invalid_write_mode_tag_raises():
     starter, _ = _make_starter(dst_entity, out_provider)
     with pytest.raises(ValueError, match="write.mode"):
         starter.start_pipe_stream("pipe1")
+
+
+def test_derived_dataset_rejected_as_streaming_sink():
+    dst_entity = Mock(
+        entityid="entity.dst",
+        tags={"provider_type": "delta", "dataset.kind": "derived"},
+        merge_columns=None,
+    )
+    out_provider = Mock(spec=_MergeCapableProvider)
+
+    starter, _ = _make_starter(dst_entity, out_provider)
+    with pytest.raises(TypeError, match="derived dataset"):
+        starter.start_pipe_stream("pipe1")
+
+    out_provider.merge_as_stream.assert_not_called()
+    out_provider.append_as_stream.assert_not_called()
+
+
+def test_write_mode_insert_routes_to_merge_as_stream():
+    dst_entity = Mock(
+        entityid="entity.dst",
+        tags={
+            "provider_type": "delta",
+            "provider.access_mode": "catalog",
+            "write.mode": "insert",
+        },
+        merge_columns=["event_id"],
+    )
+    out_provider = Mock(spec=_MergeCapableProvider)
+    query = Mock(id="q-insert")
+    out_provider.merge_as_stream.return_value = query
+
+    starter, pipe = _make_starter(dst_entity, out_provider)
+    result = starter.start_pipe_stream("pipe1")
+
+    assert result is query
+    out_provider.merge_as_stream.assert_called_once_with(
+        pipe.execute.return_value, dst_entity, "/checkpoints/pipe1", options={}
+    )
+    out_provider.append_as_stream.assert_not_called()
+
+
+def test_write_mode_insert_requires_merge_capable_provider():
+    dst_entity = Mock(
+        entityid="entity.dst",
+        tags={"provider_type": "delta", "write.mode": "insert"},
+        merge_columns=["event_id"],
+    )
+    out_provider = Mock(spec=StreamWritableEntityProvider)
+
+    starter, _ = _make_starter(dst_entity, out_provider)
+    with pytest.raises(TypeError, match="streaming merges"):
+        starter.start_pipe_stream("pipe1")

--- a/tests/unit/test_sdp_declaration_engine.py
+++ b/tests/unit/test_sdp_declaration_engine.py
@@ -9,6 +9,8 @@ session is needed.
 import sys
 
 import pytest
+from kindling.data_entities import EntityMetadata
+from kindling.data_pipes import PipeMetadata
 
 # The extension package root is added to sys.path by tests/conftest.py,
 # matching the other extension packages (kindling_ext_visualization, ...).
@@ -23,9 +25,6 @@ from kindling_ext_sdp import (
     supports_expectations,
     supports_incremental_mv_refresh,
 )
-
-from kindling.data_entities import EntityMetadata
-from kindling.data_pipes import PipeMetadata
 
 # --------------------------------------------------------------------- #
 # Fixtures: fake registries over a small bronze -> silver -> gold graph #
@@ -625,3 +624,74 @@ class TestBuildPlan:
                 pipe_registry=pipe_registry,
                 capabilities=OSS_SDP,
             )
+
+
+# --------------------------------------------------------------------- #
+# Derived datasets (core dataset.kind tag)                                #
+# --------------------------------------------------------------------- #
+
+
+class TestDerivedDatasetSelection:
+    def test_derived_kind_forces_materialized_view(self, entities, pipe_registry):
+        """dataset.kind='derived' IS the materialized-view declaration; it
+        wins over engine config asking for a streaming table."""
+        tagged = [
+            (
+                make_entity("bronze.orders", tags={"dataset.kind": "derived"})
+                if entity.entityid == "bronze.orders"
+                else entity
+            )
+            for entity in entities
+        ]
+        engine = make_engine(
+            FakeEntityRegistry(tagged),
+            pipe_registry,
+            engine_config={"ingest.orders": {"sdp": {"dataset_type": "streaming_table"}}},
+        )
+
+        plan = engine.build_plan()
+
+        assert plan.get_dataset("bronze.orders").dataset_type is DatasetType.MATERIALIZED_VIEW
+
+    def test_derived_kind_conflicting_sdp_tag_is_a_validation_error(self, entities, pipe_registry):
+        tagged = [
+            (
+                make_entity(
+                    "bronze.orders",
+                    tags={
+                        "dataset.kind": "derived",
+                        "sdp.dataset_type": "streaming_table",
+                    },
+                )
+                if entity.entityid == "bronze.orders"
+                else entity
+            )
+            for entity in entities
+        ]
+        engine = make_engine(FakeEntityRegistry(tagged), pipe_registry)
+
+        issues = engine.validate()
+
+        assert issue_codes(issues) == ["invalid_dataset_type"]
+        assert "derived" in issues[0].reason
+
+    def test_derived_kind_explicit_materialized_view_tag_is_fine(self, entities, pipe_registry):
+        tagged = [
+            (
+                make_entity(
+                    "bronze.orders",
+                    tags={
+                        "dataset.kind": "derived",
+                        "sdp.dataset_type": "materialized_view",
+                    },
+                )
+                if entity.entityid == "bronze.orders"
+                else entity
+            )
+            for entity in entities
+        ]
+        engine = make_engine(FakeEntityRegistry(tagged), pipe_registry)
+
+        plan = engine.build_plan()
+
+        assert plan.get_dataset("bronze.orders").dataset_type is DatasetType.MATERIALIZED_VIEW


### PR DESCRIPTION
## What

Closes the replacement-writes gap in the Delta write surface by making the state/derived distinction a first-class declaration, per the design discussion: overwrite isn't a write *mode*, it's a dataset *kind*.

**Derived datasets — `dataset.kind: "derived"`.** The entity's contents are a pure function of its inputs; writes replace rather than evolve. Each engine materializes the declaration natively:

- **Runner (batch)**: an atomic Delta overwrite swap — one transaction-log commit dereferences the old files, readers see the previous version until the swap lands, and the write costs only the new data. With **`derived.replace_keys: "run_id"`**, each write swaps exactly the slices present in the batch (`replaceWhere` computed from the batch's distinct key values): idempotent by construction, and rows the recomputation no longer produces disappear — which merge can never do. This is the primitive for bounded-run reprocessing ("re-analyze run X under the new rules").
- **SDP / Lakeflow**: lowers to a materialized view — the semantic the platform already owns. A conflicting `sdp.dataset_type: streaming_table` is an `invalid_dataset_type` validation issue.
- **Streaming**: rejected at query start — a continuous sink has no recompute moment.

**Insert-only writes — `write.mode: "insert"`.** For state tables whose rows are immutable once landed: `whenNotMatchedInsertAll`-only merge keyed on `merge_columns`, so replays rewrite nothing. Rides the existing merge paths unchanged in batch and streaming (the foreachBatch sink picks the strategy from the tag).

**Guardrails** (registration-time, in the existing named-validation style): derived rejects `write.mode`/`scd.*`; `derived.replace_keys` requires the kind tag and schema membership; `insert` requires `merge_columns` and contradicts `scd.type`. New `ReplaceWritableEntityProvider` capability interface gates providers, mirroring `StreamMergeableEntityProvider`.

Docs: new [derived_datasets.md](docs/guide/derived_datasets.md) guide including the CDF caveat (a replacement write emits change rows for everything it touches — don't watermark off a derived table) and a "choosing a write shape" table.

## Verification

- Full unit suite: **1853 passed** (34 new tests: registration validation, replace/predicate mechanics incl. quoting/NULL/temporal literals, persist routing, streaming rejection/insert routing, SDP dataset-type forcing and conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)