### PR TITLE
fix(features): discovery off-switch, SHOW CATALOGS short-circuit, DBR version regex

### DIFF
--- a/packages/kindling/features.py
+++ b/packages/kindling/features.py
@@ -69,17 +69,36 @@ def _detect_databricks_uc_enabled(spark) -> bool:
     except Exception:
         current_catalog = ""
 
+    # A non-legacy current catalog is conclusive on its own. Only fall back
+    # to SHOW CATALOGS when it is not: that statement enumerates every
+    # catalog the principal can see and is the slowest probe in startup
+    # feature discovery on large metastores.
+    if current_catalog and current_catalog != "spark_catalog":
+        return True
+
     try:
         catalog_rows = spark.sql("SHOW CATALOGS").collect()
         catalogs = [str(row[0]).strip().lower() for row in catalog_rows if row and row[0]]
     except Exception:
         catalogs = []
 
-    if current_catalog and current_catalog != "spark_catalog":
-        return True
-    if catalogs and any(catalog != "spark_catalog" for catalog in catalogs):
-        return True
-    return False
+    return bool(catalogs) and any(catalog != "spark_catalog" for catalog in catalogs)
+
+
+#: Runtime-feature values assumed when probing is disabled
+#: (``kindling.features.discovery: "false"``): a modern Databricks
+#: environment — Unity Catalog on, Volumes available, liquid clustering
+#: (including AUTO) understood by the engine. Every value remains
+#: overridable via static ``kindling.features.<key>`` config, which wins
+#: over these runtime defaults.
+MODERN_RUNTIME_DEFAULTS = {
+    "delta.cluster_by": True,
+    "delta.auto_clustering": True,
+    "databricks.uc_enabled": True,
+    "databricks.volumes_enabled": True,
+    "databricks.any_file_required_for_bootstrap": False,
+    "databricks.name_mode_catalog_qualified": True,
+}
 
 
 def discover_runtime_features(config_service, logger=None) -> None:
@@ -87,7 +106,23 @@ def discover_runtime_features(config_service, logger=None) -> None:
 
     This should run once during startup. All keys written here are optional and
     can be overridden by kindling.features.*.
+
+    Set ``kindling.features.discovery: "false"`` to skip every probe (no
+    Spark statements at startup); runtime features are then assumed to be
+    a modern Databricks environment (``MODERN_RUNTIME_DEFAULTS``). On
+    other platforms, pair the flag with static ``kindling.features.*``
+    overrides for anything the defaults get wrong.
     """
+    if get_feature_bool(config_service, "discovery", default=True) is False:
+        for key, value in MODERN_RUNTIME_DEFAULTS.items():
+            set_runtime_feature(config_service, key, value)
+        if logger:
+            logger.info(
+                "Runtime feature discovery disabled (kindling.features.discovery=false); "
+                "assuming modern Databricks defaults"
+            )
+        return
+
     try:
         spark = get_or_create_spark_session()
     except Exception as e:
@@ -126,7 +161,7 @@ def discover_runtime_features(config_service, logger=None) -> None:
 
     major_minor = None
     if isinstance(dbr_version_raw, str) and dbr_version_raw.strip():
-        match = re.search(r"(\\d+)\\.(\\d+)", dbr_version_raw)
+        match = re.search(r"(\d+)\.(\d+)", dbr_version_raw)
         if match:
             try:
                 major_minor = (int(match.group(1)), int(match.group(2)))

--- a/tests/unit/test_features.py
+++ b/tests/unit/test_features.py
@@ -122,7 +122,7 @@ def test_discovery_false_defaults_yield_to_static_overrides(monkeypatch):
     assert get_feature_bool(config, "databricks.uc_enabled") is False
 
 
-def test_uc_detection_short_circuits_show_catalogs(monkeypatch):
+def test_uc_detection_short_circuits_show_catalogs():
     """A conclusive current_catalog() must not trigger the expensive
     SHOW CATALOGS metastore enumeration."""
     from kindling.features import _detect_databricks_uc_enabled
@@ -140,7 +140,7 @@ def test_uc_detection_short_circuits_show_catalogs(monkeypatch):
     assert spark.sql.call_count == 1
 
 
-def test_uc_detection_falls_back_to_show_catalogs_on_legacy_current(monkeypatch):
+def test_uc_detection_falls_back_to_show_catalogs_on_legacy_current():
     from kindling.features import _detect_databricks_uc_enabled
 
     spark = MagicMock()

--- a/tests/unit/test_features.py
+++ b/tests/unit/test_features.py
@@ -84,3 +84,95 @@ def test_discover_runtime_features_sets_databricks_classic_flags(monkeypatch):
         config.get("kindling.runtime.features.databricks.any_file_required_for_bootstrap") is True
     )
     assert config.get("kindling.runtime.features.databricks.name_mode_catalog_qualified") is False
+
+
+def test_discovery_false_skips_probes_and_assumes_modern_databricks(monkeypatch):
+    config = _ConfigStub()
+    config.set("kindling.features.discovery", "false")
+
+    def _no_session():
+        raise AssertionError("discovery disabled must not touch Spark")
+
+    monkeypatch.setattr("kindling.features.get_or_create_spark_session", _no_session)
+
+    discover_runtime_features(config)
+
+    assert config.get("kindling.runtime.features.databricks.uc_enabled") is True
+    assert config.get("kindling.runtime.features.databricks.volumes_enabled") is True
+    assert (
+        config.get("kindling.runtime.features.databricks.any_file_required_for_bootstrap") is False
+    )
+    assert config.get("kindling.runtime.features.delta.cluster_by") is True
+    assert config.get("kindling.runtime.features.delta.auto_clustering") is True
+
+
+def test_discovery_false_defaults_yield_to_static_overrides(monkeypatch):
+    from kindling.features import get_feature_bool
+
+    config = _ConfigStub()
+    config.set("kindling.features.discovery", "false")
+    config.set("kindling.features.databricks.uc_enabled", "false")  # static wins
+
+    monkeypatch.setattr(
+        "kindling.features.get_or_create_spark_session",
+        lambda: (_ for _ in ()).throw(AssertionError("no spark")),
+    )
+    discover_runtime_features(config)
+
+    assert get_feature_bool(config, "databricks.uc_enabled") is False
+
+
+def test_uc_detection_short_circuits_show_catalogs(monkeypatch):
+    """A conclusive current_catalog() must not trigger the expensive
+    SHOW CATALOGS metastore enumeration."""
+    from kindling.features import _detect_databricks_uc_enabled
+
+    spark = MagicMock()
+
+    def _sql(query: str):
+        if query == "SELECT current_catalog() AS catalog":
+            return _Collectable([["main"]])
+        raise AssertionError(f"Unexpected SQL after short-circuit: {query}")
+
+    spark.sql.side_effect = _sql
+
+    assert _detect_databricks_uc_enabled(spark) is True
+    assert spark.sql.call_count == 1
+
+
+def test_uc_detection_falls_back_to_show_catalogs_on_legacy_current(monkeypatch):
+    from kindling.features import _detect_databricks_uc_enabled
+
+    spark = MagicMock()
+
+    def _sql(query: str):
+        if query == "SELECT current_catalog() AS catalog":
+            return _Collectable([["spark_catalog"]])
+        if query == "SHOW CATALOGS":
+            return _Collectable([["spark_catalog"], ["main"]])
+        raise AssertionError(f"Unexpected SQL: {query}")
+
+    spark.sql.side_effect = _sql
+
+    assert _detect_databricks_uc_enabled(spark) is True
+    assert spark.sql.call_count == 2
+
+
+def test_runtime_version_regex_parses_major_minor(monkeypatch):
+    """Regression: the version regex previously used escaped backslashes and
+    never matched, so runtime_major/minor were silently unset."""
+    config = _ConfigStub()
+    spark = _make_spark(
+        version="15.4.x-scala2.12",
+        current_catalog="main",
+        catalogs=["main"],
+    )
+    monkeypatch.setattr("kindling.features.get_or_create_spark_session", lambda: spark)
+    monkeypatch.setattr("kindling.features._supports_databricks_volumes", lambda spark: True)
+
+    discover_runtime_features(config)
+
+    assert config.get("kindling.runtime.features.databricks.runtime_major") == 15
+    assert config.get("kindling.runtime.features.databricks.runtime_minor") == 4
+    # >= 15.2 with a parsing engine: AUTO clustering now detectable
+    assert config.get("kindling.runtime.features.delta.auto_clustering") is True


### PR DESCRIPTION
## What

Three init-time fixes prompted by slow `kindling.initialize()` on a real workspace:

1. **`kindling.features.discovery: "false"`** — skips every startup Spark probe. Runtime features are then assumed to be a modern Databricks environment (`MODERN_RUNTIME_DEFAULTS`: UC enabled, Volumes available, liquid clustering incl. AUTO understood). Static `kindling.features.*` overrides still win over the assumed defaults, and other platforms can pair the flag with overrides.
2. **`SHOW CATALOGS` short-circuit** — UC detection no longer enumerates the metastore when `SELECT current_catalog()` is already conclusive (any non-`spark_catalog` answer). On large workspaces that enumeration dominated init time; it now runs only for legacy-looking sessions.
3. **DBR version regex fix** — `r"(\\d+)\\.(\\d+)"` matched literal backslashes, never `"15.4.x"`, so `databricks.runtime_major/minor` were silently never populated and AUTO-clustering detection could never trigger. Now `r"(\d+)\.(\d+)"`.

## Verification

Full unit suite: **1872 passed** (5 new tests: discovery-off assumes modern defaults without touching Spark, static override beats assumed default, short-circuit executes exactly one statement, legacy fallback still runs SHOW CATALOGS, version regex regression pinning major/minor + AUTO detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)