### PR TITLE
feat(delta): schema.drift policy — declared handling of write-time schema drift

### DIFF
--- a/docs/guide/derived_datasets.md
+++ b/docs/guide/derived_datasets.md
@@ -106,6 +106,23 @@ Sugar form: `@DataEntities.insert_only_entity(...)` sets the
 - Works identically in batch and streaming (each micro-batch runs the
   same insert-only merge through the stream-merge sink).
 
+## Schema drift policy (`schema.drift`)
+
+State-dataset writes evolve schemas additively by default. The
+`schema.drift` tag makes that a declared policy:
+
+- `evolve` (default) — additive evolution, no preflight; today's behavior.
+- `warn` — before a merge/append, log any drift (columns the table lacks,
+  or same-named columns with different types) and proceed.
+- `fail` — refuse a drifting write with `SchemaDriftError` naming the
+  columns, *before* the write starts. Use on bronze tables whose producers
+  you don't own — silent schema unioning is how tables grow accidental
+  envelope branches.
+
+Columns the table has but the incoming DataFrame lacks are not drift:
+Delta null-fills them, and SCD2 bookkeeping columns are added by the
+merge strategy after the check.
+
 ## Choosing a write shape
 
 | You want | Declare |

--- a/packages/kindling/data_entities.py
+++ b/packages/kindling/data_entities.py
@@ -400,6 +400,21 @@ def _validate_derived_config(entity: EntityMetadata) -> None:
             )
 
 
+def _validate_schema_drift_tag(entity: EntityMetadata) -> None:
+    """Validate the static ``schema.drift`` policy tag at registration time.
+
+    ``evolve`` (default): additive schema evolution, today's behavior.
+    ``warn``: log drift (new columns / type conflicts) before writing.
+    ``fail``: refuse drifting writes with a SchemaDriftError.
+    """
+    policy = str((entity.tags or {}).get("schema.drift") or "").strip().lower()
+    if policy not in ("", "evolve", "warn", "fail"):
+        raise ValueError(
+            f"Entity '{entity.entityid}': invalid schema.drift "
+            f"'{policy}' (expected 'evolve', 'warn' or 'fail')"
+        )
+
+
 def _validate_write_mode_tag(entity: EntityMetadata) -> None:
     """Validate the static ``write.mode`` tag at registration time.
 
@@ -710,6 +725,7 @@ class DataEntityManager(DataEntityRegistry, SignalEmitter):
         _validate_derived_config(entity)
         _validate_scd_config(entity)
         _validate_write_mode_tag(entity)
+        _validate_schema_drift_tag(entity)
 
         self.registry[entityid] = entity
         self.emit(

--- a/packages/kindling/entity_provider_delta.py
+++ b/packages/kindling/entity_provider_delta.py
@@ -489,6 +489,29 @@ class ReadOnlyEntityError(Exception):
         )
 
 
+class SchemaDriftError(Exception):
+    """Raised when a write drifts from the target table's schema and the
+    entity declares ``schema.drift: fail``."""
+
+    def __init__(self, entityid: str, new_columns, type_conflicts):
+        details = []
+        if new_columns:
+            details.append(f"new columns not in the table: {sorted(new_columns)}")
+        if type_conflicts:
+            details.append(
+                "type conflicts (column: table type != incoming type): "
+                + ", ".join(f"{name}: {t} != {d}" for name, t, d in sorted(type_conflicts))
+            )
+        super().__init__(
+            f"Entity '{entityid}' declares schema.drift='fail' and the incoming "
+            f"DataFrame drifts from the table schema — {'; '.join(details)}. "
+            "Fix the producer, update the declared schema, or relax the policy "
+            "to 'warn'/'evolve'."
+        )
+        self.new_columns = sorted(new_columns)
+        self.type_conflicts = sorted(type_conflicts)
+
+
 class EntityPathConflictError(Exception):
     """Raised when a read_only entity's catalog registration points at a different
     path than its configured provider.path."""
@@ -1508,6 +1531,7 @@ class DeltaEntityProvider(
 
     def _merge_to_delta_table(self, df: DataFrame, entity, table_ref: DeltaTableReference):
         """Merge DataFrame to existing Delta table"""
+        self._enforce_schema_drift_policy(df, entity, table_ref)
         scd_config = scd_config_from_tags(entity)
         write_mode = str((entity.tags or {}).get("write.mode") or "").strip().lower()
         if scd_config.enabled:
@@ -1541,6 +1565,7 @@ class DeltaEntityProvider(
 
     def _append_to_delta_table(self, df: DataFrame, entity, table_ref: DeltaTableReference):
         """Append DataFrame to existing Delta table"""
+        self._enforce_schema_drift_policy(df, entity, table_ref)
         writer = df.write.format("delta").mode("append").option("mergeSchema", "true")
 
         if self._should_partition_files(entity):
@@ -1556,6 +1581,46 @@ class DeltaEntityProvider(
             raise ValueError(
                 f"Cannot append entity '{entity.entityid}' without table path in access mode '{table_ref.access_mode}'"
             )
+
+    def _enforce_schema_drift_policy(self, df: DataFrame, entity, table_ref) -> None:
+        """Apply the entity's declared drift policy before touching the table.
+
+        ``schema.drift`` values: ``evolve`` (default — additive evolution,
+        no preflight, today's behavior), ``warn`` (log drift, proceed) and
+        ``fail`` (raise SchemaDriftError before the write starts).
+
+        Drift means columns the table does not have, or same-named columns
+        whose types differ. Columns the table has but the DataFrame lacks
+        are NOT drift: Delta fills them with NULL, and merge strategies add
+        their own bookkeeping columns (SCD2 temporal columns) after this
+        check runs.
+        """
+        policy = str((entity.tags or {}).get("schema.drift") or "evolve").strip().lower()
+        if policy == "evolve":
+            return
+
+        table_fields = {
+            field.name: field.dataType.simpleString()
+            for field in table_ref.get_delta_table().toDF().schema.fields
+        }
+        new_columns = []
+        type_conflicts = []
+        for field in df.schema.fields:
+            table_type = table_fields.get(field.name)
+            if table_type is None:
+                new_columns.append(field.name)
+            elif table_type != field.dataType.simpleString():
+                type_conflicts.append((field.name, table_type, field.dataType.simpleString()))
+
+        if not new_columns and not type_conflicts:
+            return
+        if policy == "fail":
+            raise SchemaDriftError(entity.entityid, new_columns, type_conflicts)
+        self.logger.warning(
+            f"Schema drift writing entity '{entity.entityid}' "
+            f"(schema.drift=warn): new columns {sorted(new_columns)}, type "
+            f"conflicts {sorted(type_conflicts)}; proceeding with evolution"
+        )
 
     def _get_table_version(self, table_ref: DeltaTableReference) -> int:
         """Get current version of Delta table"""

--- a/packages/kindling/entity_provider_delta.py
+++ b/packages/kindling/entity_provider_delta.py
@@ -1595,7 +1595,7 @@ class DeltaEntityProvider(
         their own bookkeeping columns (SCD2 temporal columns) after this
         check runs.
         """
-        policy = str((entity.tags or {}).get("schema.drift") or "evolve").strip().lower()
+        policy = str((entity.tags or {}).get("schema.drift") or "").strip().lower() or "evolve"
         if policy == "evolve":
             return
 

--- a/tests/unit/test_schema_drift_policy.py
+++ b/tests/unit/test_schema_drift_policy.py
@@ -1,0 +1,146 @@
+"""
+Unit tests for the ``schema.drift`` policy: ``evolve`` (default, no
+preflight), ``warn`` (log and proceed), ``fail`` (SchemaDriftError before
+the write starts).
+
+Drift = columns the table lacks, or same-named columns with different
+types. Columns the table has but the DataFrame lacks are NOT drift —
+Delta null-fills them and SCD2 strategies add bookkeeping columns after
+the check.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from kindling.data_entities import (
+    DataEntityManager,
+    EntityMetadata,
+    EntityNameMapper,
+    EntityPathLocator,
+)
+from kindling.entity_provider_delta import DeltaEntityProvider, SchemaDriftError
+from kindling.signaling import SignalProvider
+from kindling.spark_config import ConfigService
+from kindling.spark_log_provider import PythonLoggerProvider
+from pyspark.sql.types import LongType, StringType, StructField, StructType
+
+
+@pytest.fixture(autouse=True)
+def mock_spark_session(monkeypatch):
+    spark = MagicMock()
+    monkeypatch.setattr("kindling.entity_provider_delta.get_or_create_spark_session", lambda: spark)
+    return spark
+
+
+@pytest.fixture
+def provider():
+    config = MagicMock(spec=ConfigService)
+    config.get.side_effect = lambda key, default=None: (
+        "catalog" if key == "kindling.delta.access_mode" else default
+    )
+    logger_provider = MagicMock(spec=PythonLoggerProvider)
+    logger_provider.get_logger.return_value = MagicMock()
+    return DeltaEntityProvider(
+        config=config,
+        entity_name_mapper=MagicMock(spec=EntityNameMapper),
+        path_locator=MagicMock(spec=EntityPathLocator),
+        tp=logger_provider,
+        signal_provider=MagicMock(spec=SignalProvider),
+    )
+
+
+def _entity(policy=None):
+    tags = {"schema.drift": policy} if policy else {}
+    return EntityMetadata(
+        entityid="silver.orders",
+        name="orders",
+        merge_columns=["order_id"],
+        tags=tags,
+        schema=None,
+    )
+
+
+def _table_ref(fields):
+    table_ref = MagicMock()
+    table_ref.get_delta_table.return_value.toDF.return_value.schema = StructType(fields)
+    return table_ref
+
+
+def _df(fields):
+    df = MagicMock()
+    df.schema = StructType(fields)
+    return df
+
+
+_TABLE = [StructField("order_id", StringType()), StructField("amount", LongType())]
+
+
+class TestDriftPolicyEnforcement:
+    def test_evolve_default_skips_preflight_entirely(self, provider):
+        table_ref = MagicMock()
+        provider._enforce_schema_drift_policy(_df(_TABLE), _entity(), table_ref)
+        table_ref.get_delta_table.assert_not_called()
+
+    def test_fail_raises_on_new_column(self, provider):
+        df = _df(_TABLE + [StructField("discount", LongType())])
+        with pytest.raises(SchemaDriftError, match="discount"):
+            provider._enforce_schema_drift_policy(df, _entity("fail"), _table_ref(_TABLE))
+
+    def test_fail_raises_on_type_conflict(self, provider):
+        df = _df([StructField("order_id", StringType()), StructField("amount", StringType())])
+        with pytest.raises(SchemaDriftError, match="amount: bigint != string"):
+            provider._enforce_schema_drift_policy(df, _entity("fail"), _table_ref(_TABLE))
+
+    def test_missing_columns_are_not_drift(self, provider):
+        # Table has 'amount', df doesn't: Delta null-fills, SCD strategies
+        # add their own columns later — must pass under 'fail'.
+        df = _df([StructField("order_id", StringType())])
+        provider._enforce_schema_drift_policy(df, _entity("fail"), _table_ref(_TABLE))
+
+    def test_matching_schema_passes_fail_policy(self, provider):
+        provider._enforce_schema_drift_policy(_df(_TABLE), _entity("fail"), _table_ref(_TABLE))
+
+    def test_warn_logs_and_proceeds(self, provider):
+        df = _df(_TABLE + [StructField("discount", LongType())])
+        provider._enforce_schema_drift_policy(df, _entity("warn"), _table_ref(_TABLE))
+        provider.logger.warning.assert_called_once()
+        assert "discount" in provider.logger.warning.call_args.args[0]
+
+    def test_merge_path_runs_preflight(self, provider):
+        entity = _entity("fail")
+        df = _df(_TABLE + [StructField("discount", LongType())])
+        table_ref = _table_ref(_TABLE)
+        with pytest.raises(SchemaDriftError):
+            provider._merge_to_delta_table(df, entity, table_ref)
+
+    def test_append_path_runs_preflight(self, provider):
+        entity = _entity("fail")
+        df = _df(_TABLE + [StructField("discount", LongType())])
+        table_ref = _table_ref(_TABLE)
+        table_ref.access_mode = "catalog"
+        with pytest.raises(SchemaDriftError):
+            provider._append_to_delta_table(df, entity, table_ref)
+
+
+class TestDriftTagRegistration:
+    @pytest.mark.parametrize("policy", ["evolve", "warn", "fail", "FAIL "])
+    def test_valid_policies_register(self, policy):
+        manager = DataEntityManager()
+        manager.register_entity(
+            "silver.orders",
+            name="orders",
+            merge_columns=["order_id"],
+            tags={"schema.drift": policy},
+            schema=None,
+        )
+        assert "silver.orders" in manager.registry
+
+    def test_invalid_policy_rejected(self):
+        with pytest.raises(ValueError, match="invalid schema.drift"):
+            DataEntityManager().register_entity(
+                "silver.orders",
+                name="orders",
+                merge_columns=["order_id"],
+                tags={"schema.drift": "strict"},
+                schema=None,
+            )

--- a/tests/unit/test_schema_drift_policy.py
+++ b/tests/unit/test_schema_drift_policy.py
@@ -9,7 +9,7 @@ Delta null-fills them and SCD2 strategies add bookkeeping columns after
 the check.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from kindling.data_entities import (
@@ -76,6 +76,11 @@ _TABLE = [StructField("order_id", StringType()), StructField("amount", LongType(
 
 
 class TestDriftPolicyEnforcement:
+    def test_whitespace_policy_defaults_to_evolve(self, provider):
+        table_ref = MagicMock()
+        provider._enforce_schema_drift_policy(_df(_TABLE), _entity(" "), table_ref)
+        table_ref.get_delta_table.assert_not_called()
+
     def test_evolve_default_skips_preflight_entirely(self, provider):
         table_ref = MagicMock()
         provider._enforce_schema_drift_policy(_df(_TABLE), _entity(), table_ref)


### PR DESCRIPTION
## What

Companion to #191 (the validation half of the ensure-on-write audit): a declared, tags-first policy for how state-dataset writes treat schema drift.

- **`schema.drift: "evolve"`** (default) — additive evolution exactly as today; no preflight, zero added cost.
- **`schema.drift: "warn"`** — before a merge/append into an existing table, diff the incoming DataFrame schema against the table schema and log any drift, then proceed with evolution.
- **`schema.drift: "fail"`** — refuse a drifting write with a `SchemaDriftError` that names the new columns and type conflicts (`column: table_type != incoming_type`), *before* the write starts — instead of a deep Delta `AnalysisException` mid-write, or worse, silent unioning. Intended for bronze tables whose producers you don't own: silent schema unioning is exactly how a table grows accidental envelope branches (`Body` + `data.Body`).

**What counts as drift**: columns the table lacks, or same-named columns with different types. Columns the table has but the DataFrame lacks are deliberately *not* drift — Delta null-fills them, and SCD2 merge strategies add their bookkeeping columns after the check, so `fail` stays usable on SCD entities.

Tag validated at registration (`evolve|warn|fail`) in the existing named-validation style; documented in the derived-datasets guide alongside the other write-shape tags.

## Verification

Full unit suite: **1880 passed** (13 new tests: evolve skips the preflight entirely — no table read; fail on new column / type conflict; missing-columns-not-drift; warn logs and proceeds; both merge and append paths enforce; registration accepts the three policies case-insensitively and rejects unknown values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)