### PR TITLE
chore: devcontainer agent-state volume + AGENTS.md onboarding rewrite

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,7 +37,7 @@
 			}
 		}
 	},
-	"postCreateCommand": "poetry env remove --all 2>/dev/null; poetry install --with dev --sync && poetry run python -c \"import xdist\" && git config --unset-all core.hooksPath; pre-commit install && bash -lc 'grep -q \"# kindling .env auto-load\" ~/.bashrc || { echo \"# kindling .env auto-load\" >> ~/.bashrc; echo \"[ -f /workspaces/kindling/.env ] && set -a && source /workspaces/kindling/.env && set +a\" >> ~/.bashrc; }'",
+	"postCreateCommand": "sudo chown vscode:vscode /workspaces/kindling-city 2>/dev/null || true; poetry env remove --all 2>/dev/null; poetry install --with dev --sync && poetry run python -c \"import xdist\" && git config --unset-all core.hooksPath; pre-commit install && bash -lc 'grep -q \"# kindling .env auto-load\" ~/.bashrc || { echo \"# kindling .env auto-load\" >> ~/.bashrc; echo \"[ -f /workspaces/kindling/.env ] && set -a && source /workspaces/kindling/.env && set +a\" >> ~/.bashrc; }'",
 	"postStartCommand": "bash -c '[ -f \"/workspaces/kindling/.env\" ] && echo \"✅ .env will load in new terminals\" || echo \"⚠️  No .env file found\"'",
 	"initializeCommand": "echo '⚙️  Initializing devcontainer...'",
 	"mounts": [],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,7 +37,7 @@
 			}
 		}
 	},
-	"postCreateCommand": "sudo chown vscode:vscode /workspaces/kindling-city 2>/dev/null || true; poetry env remove --all 2>/dev/null; poetry install --with dev --sync && poetry run python -c \"import xdist\" && git config --unset-all core.hooksPath; pre-commit install && bash -lc 'grep -q \"# kindling .env auto-load\" ~/.bashrc || { echo \"# kindling .env auto-load\" >> ~/.bashrc; echo \"[ -f /workspaces/kindling/.env ] && set -a && source /workspaces/kindling/.env && set +a\" >> ~/.bashrc; }'",
+	"postCreateCommand": "sudo chown -R vscode:vscode /workspaces/kindling-city 2>/dev/null || true; poetry env remove --all 2>/dev/null; poetry install --with dev --sync && poetry run python -c \"import xdist\" && git config --unset-all core.hooksPath; pre-commit install && bash -lc 'grep -q \"# kindling .env auto-load\" ~/.bashrc || { echo \"# kindling .env auto-load\" >> ~/.bashrc; echo \"[ -f /workspaces/kindling/.env ] && set -a && source /workspaces/kindling/.env && set +a\" >> ~/.bashrc; }'",
 	"postStartCommand": "bash -c '[ -f \"/workspaces/kindling/.env\" ] && echo \"✅ .env will load in new terminals\" || echo \"⚠️  No .env file found\"'",
 	"initializeCommand": "echo '⚙️  Initializing devcontainer...'",
 	"mounts": [],

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,7 +5,13 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ..:/workspaces/kindling:cached
+      # Optional persistent store for local agent tooling state (task
+      # ledgers, orchestration config). Harmless if unused.
+      - agent-state:/workspaces/kindling-city
     command: sleep infinity
     environment:
       - PYTHONPATH=/workspaces/kindling
       - SPARK_LOCAL_IP=127.0.0.1
+
+volumes:
+  agent-state:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,113 @@
-# Agent System
+# Agent Guide
 
-Kindling agents should work from the repository state, the project documentation,
-and the current git branch. Keep changes focused, verified, and easy for the
-next contributor to pick up.
+Onboarding for coding agents (and humans) working on spark-kindling-framework.
+Work from the repository state, the project documentation, and the current git
+branch. Keep changes focused, verified, and easy for the next contributor to
+pick up.
 
-## Workflow
+## What this is
 
-- Read the relevant source and documentation before making changes.
-- Use git status and diffs to understand the current branch state.
-- Preserve user changes you did not make.
-- Keep implementation changes scoped to the task at hand.
-- Run targeted tests, linters, or builds when code changes.
-- Document follow-up work in the appropriate project documentation or handoff
-  notes.
+`spark-kindling` is a unified framework for building data apps that run
+unchanged across **Databricks, Microsoft Fabric, Azure Synapse, and
+standalone Spark**. Core ideas: declaratively registered data entities and
+data pipes (transformations), a pluggable entity-provider storage
+abstraction, hierarchical Dynaconf configuration, watermarked/incremental and
+streaming pipes with SCD1/SCD2 merge sinks, schema convergence via
+`kindling migrate`, and packaging/deployment of apps as `.kda` archives.
 
-## Session Completion
+## Repository layout
+
+- `packages/kindling/` — core runtime framework (import name `kindling`).
+- `packages/kindling_cli/` — `spark-kindling-cli`: the `kindling` CLI,
+  scaffolding, test runner. Design-time only.
+- `packages/kindling_sdk/` — `spark-kindling-sdk`: programmatic platform APIs
+  for deploying and running jobs from a dev machine. Design-time only.
+- `packages/extensions/kindling_ext_<name>/` — extensions, published as
+  `spark-kindling-ext-<name>`.
+- `tests/` — `unit/`, `integration/`, `system/{core,extensions}/`,
+  `local-project/`; `docs/` — see documentation conventions below.
+
+## Architecture essentials
+
+- **Initialization**: `kindling.initialize(...)` wraps
+  `initialize_framework` in `packages/kindling/bootstrap.py`. Idempotent;
+  platform is auto-detected (databricks/fabric/synapse/standalone).
+- **Platform services**: each platform module self-registers via
+  `@PlatformServices.register(...)` and is discovered through the
+  `spark_kindling.platforms` entry-point group. Platform differences stay
+  behind this service layer plus runtime feature flags — never leak
+  platform conditionals into shared code.
+- **Entity providers**: storage backends implementing the interfaces in
+  `packages/kindling/entity_provider.py`, registered in
+  `entity_provider_registry.py`. An entity picks its provider via the
+  `provider_type` tag (default `delta`). Built-ins include delta, csv,
+  parquet, memory, eventhub, sql, current_view, adx-api.
+- **Configuration**: dotted `kindling.*` keys via Dynaconf; layered YAML
+  overlays (base → platform → workspace → environment → per-app);
+  `KINDLING_`-prefixed env vars override; `spark.kindling.*` SparkConf keys
+  merge in at init; secrets via the `@secret` loader. Execution options
+  belong in `kindling.*` config — parameters are just-in-time overrides.
+- **Extensions**: import-time registration (no entry points). Provider
+  extensions call `register_provider()` at module scope; engine extensions
+  expose `engine_extension()` resolved by `kindling.initialize(engine=...)`.
+- **JVM boundary**: never touch `spark._jvm` / `spark._jsc` (enforced by
+  `tests/unit/test_architecture_jvm_boundary.py`).
+- **SDK note**: the SDK submits Synapse (and inspects Fabric) Spark jobs via
+  the platforms' Livy batch APIs. Livy is a design-time submission
+  transport, not part of the on-cluster runtime.
+
+## Commands
+
+Always use `poe` tasks (never call pytest directly):
+
+- `poe test-unit` — unit suite (`tests/unit`).
+- `poe test-integration` — integration suite (local Spark, plus Azure
+  storage access from environment config).
+- `poe test-system --platform <fabric|synapse|databricks>` — system tests
+  against real platforms; slow and costly, run only what your change
+  impacts. `--test <pattern>` narrows further.
+- `poe test-quick` — unit + integration.
+- `poe test-extension --extension <name>` — extension system tests.
+- `poe format` — black; `poe lint` — pylint; `poe check` — format + lint +
+  full tests.
+- `poe cleanup [--platform ...]` — tear down cloud test resources.
+
+Pre-commit hooks run black, isort, flake8, and private-key detection. A
+reformat aborts the commit silently — if files change, re-stage and commit
+again, and confirm HEAD actually moved before pushing.
+
+Integration and system tests read Azure credentials and endpoints from the
+environment; without them, run unit tests only.
+
+## Documentation conventions
+
+- `docs/proposals/` is the decision record: one proposal doc per design
+  decision, moved to `docs/proposals/obsolete/` when superseded. Durable
+  design decisions go here (or the matching `docs/contributing/` doc), not
+  in commit messages alone. Migration-style features follow desired-state
+  convergence (declare the target; the framework converges) — never
+  versioned migration scripts.
+- `CHANGELOG.md` is Keep-a-Changelog style: add entries under
+  `## Unreleased` (`### Added/Changed/Fixed`) with each user-visible change.
+- Release notes live in `docs/releases/vX.Y.Z.md`.
+
+## Contribution expectations
+
+- Conventional commits with scopes (`feat(streaming): ...`,
+  `fix(bootstrap): ...`, `docs(proposals): ...`).
+- Branch from `main` using `<type>/<slug>` (e.g. `feat/123-short-slug` when
+  addressing issue #123). Never commit directly to `main`; open a PR. PR
+  bodies reference the issue (`Closes #123`).
+- Tests and formatting are required for code changes: run targeted suites
+  for what you touched plus `poe format` before pushing. CI gates on black,
+  unit, integration, KDA packaging, and bandit (pylint/mypy are
+  report-only).
+- Type hints and docstrings per `CONTRIBUTING.md`; PEP 8; Spark 3.x
+  compatibility across all supported platforms.
+- Preserve user changes you did not make; keep implementation changes
+  scoped to the task at hand.
+
+## Session completion
 
 When ending a work session:
 
@@ -29,5 +122,6 @@ When ending a work session:
    git status
    ```
 
-5. Verify the branch is clean or clearly note any intentional uncommitted work.
+5. Verify the branch is clean or clearly note any intentional uncommitted
+   work.
 6. Hand off enough context for the next session.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,9 @@ streaming pipes with SCD1/SCD2 merge sinks, schema convergence via
   `packages/kindling/entity_provider.py`, registered in
   `entity_provider_registry.py`. An entity picks its provider via the
   `provider_type` tag (default `delta`). Built-ins include delta, csv,
-  parquet, memory, eventhub, sql, current_view, adx-api.
+  parquet, memory, eventhub, current_view, adx-api. SQL entities use a
+  separate declaration path (`@DataEntities.sql_entity(...)`), not a
+  `provider_type` tag.
 - **Configuration**: dotted `kindling.*` keys via Dynaconf; layered YAML
   overlays (base → platform → workspace → environment → per-app);
   `KINDLING_`-prefixed env vars override; `spark.kindling.*` SparkConf keys


### PR DESCRIPTION
## What

Two pieces of groundwork for local agent tooling, both generic and inert for developers who don't use it:

- **devcontainer**: adds an optional named Docker volume `agent-state` mounted at `/workspaces/kindling-city` so local agent tooling state (task ledgers, orchestration config) survives devcontainer rebuilds. A `postCreateCommand` chown makes it writable for the `vscode` user. No behavior change otherwise.
- **AGENTS.md**: rewrites the thin process notes into a concise, provider-neutral onboarding guide — framework purpose and supported platforms, package layout, architecture essentials (platform services, entity providers, configuration model, extensions, JVM boundary), day-to-day `poe` commands, documentation conventions, and contribution expectations. The existing session-completion guidance is preserved verbatim.

## Notes

- `CLAUDE.md` already points at `AGENTS.md`, so no change needed there.
- Docs-only + devcontainer classification: no wheel builds or system tests triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)