### PR TITLE
feat(config): add wildcard config pattern engine (ConfigPatternMatcher)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ All notable changes to spark-kindling are documented here.
 
 ### Added
 
+- **Wildcard config pattern engine**: new `kindling.config_patterns` module
+  with `ConfigPatternMatcher` — glob patterns (`*`, `?`, `**`) over
+  dot-segmented pipe/entity ids, tiered specificity (exact > single
+  wildcard > multi wildcard, last-declared wins ties), and copy-on-merge
+  override resolution. Groundwork for wildcard `datapipes:`/`dataentities:`
+  config overrides (gh#31); no behavior change until consumers wire it in.
 - **Public `kindling.reset()`**: clears in-process framework state (DI
   container, config service, declaration registries, signal handlers, active
   engine reference) for notebook recovery and tests after a failed or repeated

--- a/docs/proposals/package_config_architecture.md
+++ b/docs/proposals/package_config_architecture.md
@@ -662,6 +662,39 @@ This keeps registration behavior unchanged and adds one small, testable post-pro
 
 ### Phase 1: Wildcard Pattern Matcher
 
+> **Implementation note (2026-07-28):** Phase 1 shipped as
+> `packages/kindling/config_patterns.py` (gh#31). The module follows the
+> reference sketch below except for three deliberate corrections — the
+> sketch is kept unchanged for history; the shipped semantics are:
+>
+> 1. **Specificity is tiered, not per-segment-summed.** The sketch scores
+>    wildcard patterns by summing per-segment values (exact segment
+>    +1000), so `bronze.*` (1100) would outrank the *exact* pattern
+>    `bronze.ingest_orders` (1000), violating the precedence rule above
+>    and Resolved Decision #3 (which makes `bronze.*` and `*.orders`
+>    EQUAL). Shipped: `EXACT_MATCH`/`SINGLE_WILDCARD`/`MULTI_WILDCARD`
+>    are tier ranks — exact (no wildcards) > single (`*`/`?` only) >
+>    multi (contains `**`).
+> 2. **One ascending sort, declaration order preserved within a tier.**
+>    The sketch sorts descending and then iterates `reversed(...)`, which
+>    also flips declaration order within equal scores, making the
+>    first-declared pattern win ties instead of the last (contradicting
+>    Resolved Decision #3). Shipped: compiled patterns sort once,
+>    ascending by `(tier, declaration_index)`, and apply in that order.
+> 3. **Copy-on-merge; `base` is never mutated.** The sketch's
+>    `_merge_override` can alias and mutate the caller's nested dicts
+>    (e.g. `result['tags'].pop(...)`). Shipped: `resolve_overrides`
+>    copies nested containers on write and returns plain dicts.
+>
+> Additionally, underscore keys (`_enabled`, `_remove_tags`,
+> `_remove_all_tags`) get no special handling in the matcher — they merge
+> like any other key (upsert model, Resolved Decision #2) and are
+> interpreted by Phase 3 tag management. The matcher operates on the
+> already-Dynaconf-merged section, so per-layer sequential application
+> (resolution-trace steps 6–7) collapses per pattern key before the
+> matcher runs; a pattern re-declared in a later layer keeps its
+> first-seen position in the merged mapping.
+
 ```python
 # packages/kindling/config_patterns.py
 
@@ -1107,11 +1140,11 @@ dataentities:
 ### Phase 1: Core Pattern Matching (Week 1-2)
 
 ```
-- [ ] Create config_patterns.py module
-- [ ] Implement ConfigPatternMatcher with glob support
-- [ ] Implement pattern scoring/precedence
-- [ ] Write comprehensive pattern matching tests
-- [ ] Test edge cases (overlapping patterns, escaping)
+- [x] Create config_patterns.py module
+- [x] Implement ConfigPatternMatcher with glob support
+- [x] Implement pattern scoring/precedence
+- [x] Write comprehensive pattern matching tests
+- [x] Test edge cases (overlapping patterns, escaping)
 ```
 
 ### Phase 2: Config Overlay (Week 3-4)

--- a/packages/kindling/config_patterns.py
+++ b/packages/kindling/config_patterns.py
@@ -136,13 +136,16 @@ class ConfigPatternMatcher:
         ]
 
     def resolve_overrides(self, item_id: str, base: Mapping) -> Dict[str, Any]:
-        """Return ``dict(base)`` with every matching override merged in order.
+        """Return a plain-dict deep copy of ``base`` with every matching
+        override merged in order.
 
         Mapping values deep-merge recursively; scalars and lists replace.
-        ``base`` is never mutated. Underscore keys (``_enabled``,
-        ``_remove_tags``, ...) merge like any other key.
+        ``base`` is never mutated — the result shares no nested containers
+        with it (non-dict Mappings such as Dynaconf boxes are converted to
+        plain dicts). Underscore keys (``_enabled``, ``_remove_tags``, ...)
+        merge like any other key.
         """
-        result: Dict[str, Any] = dict(base)
+        result: Dict[str, Any] = _clone(base)
         for compiled in self._patterns:
             if compiled.regex.match(item_id):
                 result = _merge(result, compiled.overrides)
@@ -186,7 +189,9 @@ class ConfigPatternMatcher:
                 _LOGGER.warning("Config pattern %r has an empty segment — skipping", pattern)
                 return None
             if segment == "**":
-                segment_sources.append(".+")  # one or more whole segments
+                # One or more whole (non-empty, dot-free) segments — ids with
+                # empty segments like "a..b" or "a." must not match.
+                segment_sources.append(r"[^.]+(?:\.[^.]+)*")
                 continue
             if "**" in segment:
                 _LOGGER.warning(

--- a/packages/kindling/config_patterns.py
+++ b/packages/kindling/config_patterns.py
@@ -1,0 +1,206 @@
+"""Wildcard pattern matching for per-item configuration override sections.
+
+Config sections such as ``datapipes:`` / ``dataentities:`` (and existing
+per-item maps like ``kindling.execution.pipes``) key overrides by pipe or
+entity id. This module provides the pattern engine that lets those keys be
+glob patterns over dot-segmented ids, so one entry can target a family of
+items (``bronze.*``) instead of every id individually. It is pure stdlib —
+no framework imports, no Spark, no Dynaconf dependency. Any ``Mapping``
+(including a Dynaconf ``DynaBox``) works as the config section; it is
+indexed by literal pattern string, never dotted-key traversal, because ids
+routinely contain dots (same rationale as ``kindling.execution.pipes``).
+
+Pattern language (full-string anchored ``^...$``, case-sensitive, over
+dot-segmented ids):
+
+- ``*`` — one non-empty run of characters within a segment; may be
+  embedded (``ingest_*``). Never crosses a ``.``, so ``bronze.*`` matches
+  ``bronze.orders`` but not ``bronze.orders.raw``.
+- ``?`` — exactly one non-dot character.
+- ``**`` — one or more whole segments; only special as a complete segment
+  (``bronze.**`` matches ``bronze.x`` and ``bronze.x.y`` but not bare
+  ``bronze``; bare ``**`` matches every id). A ``**`` embedded mid-segment
+  (``ingest_**``), an empty pattern, or an empty segment is malformed: a
+  warning is logged and the pattern is skipped.
+- Every other character is literal (ids containing ``_``, ``-``, ``+``
+  need no escaping).
+
+Specificity is tiered — :data:`ConfigPatternMatcher.EXACT_MATCH` (no
+wildcard characters) beats :data:`ConfigPatternMatcher.SINGLE_WILDCARD`
+(only ``*``/``?``), which beats :data:`ConfigPatternMatcher.MULTI_WILDCARD`
+(contains ``**``). Overrides resolve least→most specific; within a tier the
+mapping's declaration order is kept and the later-declared pattern is
+applied later, so last-in wins ties (Resolved Decision #3 of
+``docs/proposals/package_config_architecture.md``).
+
+Merge semantics (:meth:`ConfigPatternMatcher.resolve_overrides`): mapping
+values deep-merge recursively (``tags``, ``delta_properties``,
+``spark_config``, ``retry`` all behave uniformly); scalars and lists
+replace. The input ``base`` is never mutated — nested containers are
+copied on write. Underscore keys (``_enabled``, ``_remove_tags``,
+``_remove_all_tags``) get no special handling here: they merge like any
+other key (upsert model) and are interpreted downstream by tag management.
+
+Layering: the matcher sees the ALREADY-MERGED section — Dynaconf
+``MERGE_ENABLED_FOR_DYNACONF`` collapses the settings → platform →
+workspace → environment overlays per pattern key before resolution, so
+same-pattern overrides across layers behave as expected and cross-pattern
+conflicts resolve by tier then declaration order. Caveat: a pattern
+re-declared in a later layer keeps its first-seen position in the merged
+mapping (dict-merge semantics), so "last-in wins" ties follow the merged
+mapping order, not file order across layers — keep tie-sensitive override
+patterns declared later within the same mapping.
+"""
+
+import logging
+import re
+from collections.abc import Mapping
+from typing import Any, Dict, List, NamedTuple, Optional
+
+_LOGGER = logging.getLogger("kindling.config")
+
+
+class _CompiledPattern(NamedTuple):
+    pattern: str
+    regex: re.Pattern
+    tier: int
+    index: int
+    overrides: Dict[str, Any]
+
+
+def _clone(value: Any) -> Any:
+    """Deep-copy mappings and lists into plain dicts/lists; scalars pass through."""
+    if isinstance(value, Mapping):
+        return {key: _clone(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_clone(item) for item in value]
+    return value
+
+
+def _merge(base: Mapping, override: Mapping) -> Dict[str, Any]:
+    """Merge ``override`` into a copy of ``base``; neither input is mutated."""
+    result: Dict[str, Any] = dict(base)
+    for key, value in override.items():
+        existing = result.get(key)
+        if isinstance(value, Mapping) and isinstance(existing, Mapping):
+            result[key] = _merge(existing, value)
+        else:
+            result[key] = _clone(value)
+    return result
+
+
+class ConfigPatternMatcher:
+    """Matches glob config patterns against pipe/entity ids with precedence."""
+
+    # Specificity tiers (ranks, not per-segment sums): exact > single > multi.
+    EXACT_MATCH = 1000
+    SINGLE_WILDCARD = 100
+    MULTI_WILDCARD = 10
+
+    def __init__(self, config_section: Optional[Mapping] = None):
+        """Compile and order a ``{pattern: overrides}`` section once.
+
+        Args:
+            config_section: Mapping keyed by literal pattern string (plain
+                dict or Dynaconf ``DynaBox``). ``None``/empty means no
+                patterns. Keys are coerced via ``str()``; non-mapping
+                override values and malformed patterns log a warning and
+                are skipped.
+        """
+        self._patterns = self._compile(config_section)
+
+    @staticmethod
+    def specificity(pattern: str) -> int:
+        """Return the specificity tier for ``pattern``.
+
+        ``EXACT_MATCH`` when it has no wildcard characters,
+        ``SINGLE_WILDCARD`` when it uses only ``*``/``?``, and
+        ``MULTI_WILDCARD`` when it contains ``**``.
+        """
+        if "**" in pattern:
+            return ConfigPatternMatcher.MULTI_WILDCARD
+        if "*" in pattern or "?" in pattern:
+            return ConfigPatternMatcher.SINGLE_WILDCARD
+        return ConfigPatternMatcher.EXACT_MATCH
+
+    def get_matching_overrides(self, item_id: str) -> List[Dict[str, Any]]:
+        """Return all override dicts matching ``item_id``, least→most specific.
+
+        Declaration order is stable within a tier. The returned dicts are
+        copies; apply them in list order to get correct precedence.
+        """
+        return [
+            _clone(compiled.overrides)
+            for compiled in self._patterns
+            if compiled.regex.match(item_id)
+        ]
+
+    def resolve_overrides(self, item_id: str, base: Mapping) -> Dict[str, Any]:
+        """Return ``dict(base)`` with every matching override merged in order.
+
+        Mapping values deep-merge recursively; scalars and lists replace.
+        ``base`` is never mutated. Underscore keys (``_enabled``,
+        ``_remove_tags``, ...) merge like any other key.
+        """
+        result: Dict[str, Any] = dict(base)
+        for compiled in self._patterns:
+            if compiled.regex.match(item_id):
+                result = _merge(result, compiled.overrides)
+        return result
+
+    def _compile(self, config_section: Optional[Mapping]) -> List[_CompiledPattern]:
+        compiled: List[_CompiledPattern] = []
+        if not config_section:
+            return compiled
+        for index, (key, overrides) in enumerate(config_section.items()):
+            pattern = str(key)
+            if not isinstance(overrides, Mapping):
+                _LOGGER.warning(
+                    "Config pattern %r: override value %r is not a mapping — skipping",
+                    pattern,
+                    overrides,
+                )
+                continue
+            regex = self._pattern_to_regex(pattern)
+            if regex is None:
+                continue
+            compiled.append(
+                _CompiledPattern(
+                    pattern, regex, self.specificity(pattern), index, _clone(overrides)
+                )
+            )
+        # Least specific first; within a tier keep declaration order so the
+        # later-declared pattern is applied later (last-in wins ties).
+        compiled.sort(key=lambda entry: (entry.tier, entry.index))
+        return compiled
+
+    @staticmethod
+    def _pattern_to_regex(pattern: str) -> Optional[re.Pattern]:
+        """Translate a glob pattern to an anchored regex; ``None`` if malformed."""
+        if not pattern:
+            _LOGGER.warning("Config pattern is empty — skipping")
+            return None
+        segment_sources: List[str] = []
+        for segment in pattern.split("."):
+            if not segment:
+                _LOGGER.warning("Config pattern %r has an empty segment — skipping", pattern)
+                return None
+            if segment == "**":
+                segment_sources.append(".+")  # one or more whole segments
+                continue
+            if "**" in segment:
+                _LOGGER.warning(
+                    "Config pattern %r: '**' must stand alone as a segment — skipping",
+                    pattern,
+                )
+                return None
+            source = ""
+            for char in segment:
+                if char == "*":
+                    source += "[^.]+"
+                elif char == "?":
+                    source += "[^.]"
+                else:
+                    source += re.escape(char)
+            segment_sources.append(source)
+        return re.compile("^" + r"\.".join(segment_sources) + "$")

--- a/tests/unit/test_config_patterns.py
+++ b/tests/unit/test_config_patterns.py
@@ -1,0 +1,429 @@
+"""
+Unit tests for kindling.config_patterns (gh#31 Wildcard Config Patterns).
+
+Covers the pattern language (* / ? / ** over dot-segmented ids), tiered
+specificity, least→most-specific ordering with declaration-order ties,
+copy-on-merge override resolution, the issue's and the proposal's
+end-to-end vectors, and quoted wildcard keys loaded through real Dynaconf
+exactly as DynaconfConfig.initialize loads config files.
+"""
+
+import copy
+import logging
+import textwrap
+from collections.abc import Mapping
+
+import pytest
+from dynaconf import Dynaconf
+from kindling.config_patterns import ConfigPatternMatcher
+
+
+def _matches(pattern: str, item_id: str) -> bool:
+    matcher = ConfigPatternMatcher({pattern: {"src": pattern}})
+    return bool(matcher.get_matching_overrides(item_id))
+
+
+def _match_order(section, item_id):
+    """Return the ``src`` labels of matching overrides in application order."""
+    matcher = ConfigPatternMatcher(section)
+    return [overrides["src"] for overrides in matcher.get_matching_overrides(item_id)]
+
+
+class TestPatternTranslation:
+    @pytest.mark.parametrize(
+        ("pattern", "item_id", "expected"),
+        [
+            # Exact patterns match only themselves
+            ("bronze.ingest_orders", "bronze.ingest_orders", True),
+            ("bronze.ingest_orders", "bronze.ingest_orders_v2", False),
+            ("bronze.ingest_orders", "bronze.ingest", False),
+            ("Bronze.ingest_orders", "bronze.ingest_orders", False),  # case-sensitive
+            # * matches one non-empty span within a segment
+            ("bronze.*", "bronze.orders", True),
+            ("bronze.*", "bronze.customers", True),
+            ("bronze.*", "bronze.orders.raw", False),
+            ("bronze.*", "silver.orders", False),
+            ("bronze.*", "bronze", False),
+            # * may be embedded; still never crosses dots and needs 1+ chars
+            ("*.ingest_*", "bronze.ingest_orders", True),
+            ("*.ingest_*", "ingest_orders", False),
+            ("*.ingest_*", "a.b.ingest_x", False),
+            ("*.ingest_*", "bronze.ingest_", False),
+            ("bronze*", "bronze.orders", False),
+            ("bronze*x", "bronzeYx", True),
+            # ? matches exactly one non-dot character
+            ("bronze.order?", "bronze.orders", True),
+            ("bronze.order?", "bronze.order1", True),
+            ("bronze.order?", "bronze.order", False),
+            ("bronze.order?", "bronze.order12", False),
+            ("bronze?orders", "bronze.orders", False),
+            # ** matches one or more whole segments
+            ("**", "a", True),
+            ("**", "a.b", True),
+            ("**", "a.b.c", True),
+            ("bronze.**", "bronze.x", True),
+            ("bronze.**", "bronze.x.y", True),
+            ("bronze.**", "bronze", False),
+            ("**.ingest", "bronze.ingest", True),
+            ("**.ingest", "silver.etl.ingest", True),
+            ("**.ingest", "ingest", False),
+            # Regex metacharacters in ids are literal
+            ("raw.a+b", "raw.a+b", True),
+            ("raw.a+b", "raw.aab", False),
+            ("etl-v1.load", "etl-v1.load", True),
+        ],
+    )
+    def test_match(self, pattern, item_id, expected):
+        assert _matches(pattern, item_id) is expected
+
+    @pytest.mark.parametrize(
+        "malformed",
+        ["ingest_**", "**x", "bronze.**suffix", "", "bronze..orders", ".bronze", "bronze."],
+    )
+    def test_malformed_patterns_warn_and_are_skipped(self, caplog, malformed):
+        section = {malformed: {"src": "bad"}, "bronze.*": {"src": "good"}}
+        with caplog.at_level(logging.WARNING, logger="kindling.config"):
+            matcher = ConfigPatternMatcher(section)
+        assert any("skipping" in record.message.lower() for record in caplog.records)
+        # The malformed pattern contributes nothing; valid siblings still work.
+        assert matcher.get_matching_overrides("bronze.x") == [{"src": "good"}]
+        assert matcher.get_matching_overrides("ingest_x") == []
+
+    def test_keys_are_coerced_via_str(self):
+        matcher = ConfigPatternMatcher({123: {"src": "numeric"}})
+        assert matcher.get_matching_overrides("123") == [{"src": "numeric"}]
+
+
+class TestSpecificity:
+    def test_tier_constants_keep_proposal_values(self):
+        assert ConfigPatternMatcher.EXACT_MATCH == 1000
+        assert ConfigPatternMatcher.SINGLE_WILDCARD == 100
+        assert ConfigPatternMatcher.MULTI_WILDCARD == 10
+
+    @pytest.mark.parametrize(
+        ("pattern", "tier"),
+        [
+            ("bronze.ingest_orders", 1000),
+            ("etl-v1.load+x", 1000),
+            ("bronze.*", 100),
+            ("*.ingest_*", 100),
+            ("bronze.order?", 100),
+            ("**", 10),
+            ("bronze.**", 10),
+            ("**.ingest", 10),
+            ("*.x.**", 10),
+        ],
+    )
+    def test_tiers(self, pattern, tier):
+        assert ConfigPatternMatcher.specificity(pattern) == tier
+
+    def test_single_wildcard_patterns_tie(self):
+        # Resolved Decision #3: bronze.* and *.orders are EQUAL specificity.
+        assert ConfigPatternMatcher.specificity("bronze.*") == ConfigPatternMatcher.specificity(
+            "*.orders"
+        )
+
+
+class TestOrdering:
+    def test_least_to_most_specific(self):
+        section = {
+            "bronze.ingest_orders": {"src": "exact"},
+            "**": {"src": "multi"},
+            "bronze.*": {"src": "single"},
+        }
+        assert _match_order(section, "bronze.ingest_orders") == [
+            "multi",
+            "single",
+            "exact",
+        ]
+
+    def test_declaration_order_preserved_within_tier(self):
+        forward = {"bronze.*": {"src": "first"}, "*.ingest_*": {"src": "second"}}
+        reversed_section = {"*.ingest_*": {"src": "first"}, "bronze.*": {"src": "second"}}
+        assert _match_order(forward, "bronze.ingest_x") == ["first", "second"]
+        assert _match_order(reversed_section, "bronze.ingest_x") == ["first", "second"]
+
+    def test_later_declared_wins_tied_scalar_conflicts(self):
+        forward = {"bronze.*": {"retry_count": 3}, "*.ingest_*": {"retry_count": 5}}
+        reversed_section = {
+            "*.ingest_*": {"retry_count": 5},
+            "bronze.*": {"retry_count": 3},
+        }
+        assert (
+            ConfigPatternMatcher(forward).resolve_overrides("bronze.ingest_x", {})["retry_count"]
+            == 5
+        )
+        assert (
+            ConfigPatternMatcher(reversed_section).resolve_overrides("bronze.ingest_x", {})[
+                "retry_count"
+            ]
+            == 3
+        )
+
+
+class TestMergeSemantics:
+    def test_tags_accumulate_across_all_matching_tiers(self):
+        section = {
+            "**": {"tags": {"framework": "kindling"}},
+            "bronze.*": {"tags": {"layer": "bronze"}},
+            "bronze.orders": {"tags": {"priority": "critical"}},
+        }
+        result = ConfigPatternMatcher(section).resolve_overrides(
+            "bronze.orders", {"tags": {"domain": "sales"}}
+        )
+        assert result["tags"] == {
+            "domain": "sales",
+            "framework": "kindling",
+            "layer": "bronze",
+            "priority": "critical",
+        }
+
+    def test_scalar_most_specific_wins(self):
+        section = {
+            "bronze.*": {"timeout_seconds": 300},
+            "bronze.orders": {"timeout_seconds": 600},
+        }
+        result = ConfigPatternMatcher(section).resolve_overrides("bronze.orders", {})
+        assert result["timeout_seconds"] == 600
+
+    def test_nested_dicts_deep_merge_recursively(self):
+        base = {"spark_config": {"spark": {"sql": {"shuffle.partitions": "200"}}}}
+        section = {
+            "bronze.*": {"spark_config": {"spark": {"sql": {"ansi.enabled": "true"}}}},
+            "bronze.orders": {"spark_config": {"spark": {"sql": {"shuffle.partitions": "8"}}}},
+        }
+        result = ConfigPatternMatcher(section).resolve_overrides("bronze.orders", base)
+        assert result["spark_config"] == {
+            "spark": {"sql": {"shuffle.partitions": "8", "ansi.enabled": "true"}}
+        }
+
+    def test_lists_replace(self):
+        section = {"bronze.*": {"partition_columns": ["c"]}}
+        result = ConfigPatternMatcher(section).resolve_overrides(
+            "bronze.orders", {"partition_columns": ["a", "b"]}
+        )
+        assert result["partition_columns"] == ["c"]
+
+    def test_base_is_never_mutated(self):
+        base = {
+            "tags": {"domain": "sales"},
+            "retry": {"attempts": 1},
+            "partition_columns": ["a"],
+        }
+        snapshot = copy.deepcopy(base)
+        section = {
+            "**": {"tags": {"framework": "kindling"}},
+            "bronze.*": {
+                "tags": {"layer": "bronze"},
+                "retry": {"attempts": 3},
+                "partition_columns": ["b"],
+            },
+        }
+        ConfigPatternMatcher(section).resolve_overrides("bronze.orders", base)
+        assert base == snapshot
+
+    def test_results_are_isolated_from_matcher_state(self):
+        section = {"bronze.*": {"tags": {"layer": "bronze"}, "cols": ["a"]}}
+        matcher = ConfigPatternMatcher(section)
+        first = matcher.resolve_overrides("bronze.orders", {})
+        first["tags"]["injected"] = "x"
+        first["cols"].append("b")
+        assert matcher.resolve_overrides("bronze.orders", {}) == {
+            "tags": {"layer": "bronze"},
+            "cols": ["a"],
+        }
+
+    def test_non_mapping_override_value_warns_and_is_skipped(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="kindling.config"):
+            matcher = ConfigPatternMatcher(
+                {"bronze.*": "oops", "bronze.orders": {"tags": {"a": "1"}}}
+            )
+        assert any("not a mapping" in record.message for record in caplog.records)
+        assert matcher.resolve_overrides("bronze.orders", {}) == {"tags": {"a": "1"}}
+
+    @pytest.mark.parametrize("section", [None, {}])
+    def test_none_or_empty_section_returns_base_copy(self, section):
+        base = {"tags": {"a": "1"}}
+        result = ConfigPatternMatcher(section).resolve_overrides("any.id", base)
+        assert result == base
+        assert result is not base
+
+    def test_underscore_keys_pass_through_untouched(self):
+        # Interpreting _enabled/_remove_tags/_remove_all_tags is tag
+        # management's job (upsert model) — the matcher just merges them.
+        section = {
+            "**": {"tags": {"debug": "true"}},
+            "bronze.*": {
+                "_remove_tags": ["debug"],
+                "_remove_all_tags": True,
+                "_enabled": False,
+            },
+        }
+        result = ConfigPatternMatcher(section).resolve_overrides("bronze.orders", {})
+        assert result["_remove_tags"] == ["debug"]
+        assert result["_remove_all_tags"] is True
+        assert result["_enabled"] is False
+        assert result["tags"] == {"debug": "true"}
+
+
+class TestEndToEndVectors:
+    def test_issue_31_four_pattern_example(self):
+        section = {
+            "**": {"tags": {"framework": "kindling"}},
+            "bronze.*": {"tags": {"layer": "bronze"}},
+            "*.ingest_*": {"tags": {"type": "ingestion"}},
+            "bronze.ingest_orders": {"tags": {"priority": "critical"}},
+        }
+        result = ConfigPatternMatcher(section).resolve_overrides("bronze.ingest_orders", {})
+        assert result == {
+            "tags": {
+                "framework": "kindling",
+                "layer": "bronze",
+                "type": "ingestion",
+                "priority": "critical",
+            }
+        }
+
+    # The proposal's resolution-trace config with settings + env_prod already
+    # collapsed per pattern key, as Dynaconf MERGE_ENABLED delivers it.
+    TRACE_SECTION = {
+        "**": {
+            "tags": {"framework": "kindling", "managed": "true"},
+            "_remove_tags": ["debug", "test"],
+        },
+        "bronze.*": {
+            "tags": {"layer": "bronze", "sla": "4h"},
+            "timeout_seconds": 300,
+            "retry_count": 3,
+        },
+        "*.ingest_*": {"tags": {"type": "ingestion"}, "retry_count": 5},
+        "bronze.ingest_orders": {
+            "tags": {
+                "priority": "critical",
+                "owner": "team-a",
+                "environment": "production",
+                "alert_channel": "#orders-alerts",
+            },
+            "timeout_seconds": 600,
+            "retry_count": 10,
+        },
+    }
+
+    def test_proposal_resolution_trace(self):
+        base = {"name": "Ingest Orders", "tags": {"domain": "sales"}}
+        result = ConfigPatternMatcher(self.TRACE_SECTION).resolve_overrides(
+            "bronze.ingest_orders", base
+        )
+        assert result["name"] == "Ingest Orders"
+        assert result["timeout_seconds"] == 600
+        assert result["retry_count"] == 10
+        assert result["tags"] == {
+            "domain": "sales",
+            "framework": "kindling",
+            "managed": "true",
+            "layer": "bronze",
+            "sla": "4h",
+            "type": "ingestion",
+            "priority": "critical",
+            "owner": "team-a",
+            "environment": "production",
+            "alert_channel": "#orders-alerts",
+        }
+        # Underscore keys survive as data for tag management to interpret.
+        assert result["_remove_tags"] == ["debug", "test"]
+
+    def test_proposal_trace_tie_between_single_wildcards(self):
+        # retry_count 5 from *.ingest_* must survive bronze.*'s 3 — the two
+        # patterns tie on specificity and *.ingest_* is declared later.
+        result = ConfigPatternMatcher(self.TRACE_SECTION).resolve_overrides(
+            "bronze.ingest_customers", {}
+        )
+        assert result["retry_count"] == 5
+        assert result["timeout_seconds"] == 300
+
+
+class TestRealPipeConfigIntegration:
+    """Quoted wildcard keys survive YAML→Dynaconf and DynaBox sections work as-is."""
+
+    SETTINGS_YAML = textwrap.dedent("""\
+        datapipes:
+          "**":
+            tags:
+              framework: "kindling"
+              managed: "true"
+          "bronze.*":
+            tags:
+              layer: "bronze"
+              sla: "4h"
+            timeout_seconds: 300
+            retry_count: 3
+          "*.ingest_*":
+            tags:
+              type: "ingestion"
+            retry_count: 5
+          "bronze.ingest_orders":
+            tags:
+              priority: "critical"
+              owner: "team-a"
+        """)
+
+    ENV_PROD_YAML = textwrap.dedent("""\
+        datapipes:
+          "**":
+            _remove_tags:
+              - debug
+              - test
+          "bronze.ingest_orders":
+            tags:
+              environment: "production"
+              alert_channel: "#orders-alerts"
+            timeout_seconds: 600
+            retry_count: 10
+        """)
+
+    def test_dynabox_section_resolves_like_plain_dict(self, tmp_path):
+        settings_path = tmp_path / "settings.yaml"
+        env_prod_path = tmp_path / "env_prod.yaml"
+        settings_path.write_text(self.SETTINGS_YAML, encoding="utf-8")
+        env_prod_path.write_text(self.ENV_PROD_YAML, encoding="utf-8")
+
+        # Load exactly as DynaconfConfig.initialize does (spark_config.py).
+        settings = Dynaconf(
+            settings_files=[str(settings_path), str(env_prod_path)],
+            environments=False,
+            MERGE_ENABLED_FOR_DYNACONF=True,
+            envvar_prefix="KINDLING",
+        )
+        section = settings.get("datapipes")
+
+        # The section is fed to the matcher as the DynaBox Dynaconf returns,
+        # not converted to a plain dict first.
+        assert isinstance(section, Mapping)
+        assert type(section) is not dict
+
+        matcher = ConfigPatternMatcher(section)
+        base = {"name": "Ingest Orders", "tags": {"domain": "sales"}}
+        result = matcher.resolve_overrides("bronze.ingest_orders", base)
+
+        assert result["timeout_seconds"] == 600
+        assert result["retry_count"] == 10
+        assert result["tags"] == {
+            "domain": "sales",
+            "framework": "kindling",
+            "managed": "true",
+            "layer": "bronze",
+            "sla": "4h",
+            "type": "ingestion",
+            "priority": "critical",
+            "owner": "team-a",
+            "environment": "production",
+            "alert_channel": "#orders-alerts",
+        }
+        assert result["_remove_tags"] == ["debug", "test"]
+
+        # An id the exact/env overrides don't target resolves from the
+        # wildcard tiers of the same DynaBox section.
+        other = matcher.resolve_overrides("bronze.ingest_customers", {"tags": {}})
+        assert other["retry_count"] == 5
+        assert other["timeout_seconds"] == 300
+        assert other["tags"]["layer"] == "bronze"

--- a/tests/unit/test_config_patterns.py
+++ b/tests/unit/test_config_patterns.py
@@ -67,6 +67,12 @@ class TestPatternTranslation:
             ("**.ingest", "bronze.ingest", True),
             ("**.ingest", "silver.etl.ingest", True),
             ("**.ingest", "ingest", False),
+            # ** never accepts ids with empty segments (review finding)
+            ("**", "a..b", False),
+            ("**", "a.", False),
+            ("**", ".a", False),
+            ("bronze.**", "bronze..x", False),
+            ("bronze.**", "bronze.x.", False),
             # Regex metacharacters in ids are literal
             ("raw.a+b", "raw.a+b", True),
             ("raw.a+b", "raw.aab", False),
@@ -221,6 +227,28 @@ class TestMergeSemantics:
         }
         ConfigPatternMatcher(section).resolve_overrides("bronze.orders", base)
         assert base == snapshot
+
+    def test_result_shares_no_nested_containers_with_base(self):
+        # Review finding: dict(base) was a shallow copy — nested containers
+        # untouched by any override leaked through and mutating the result
+        # mutated base. The result must be a full plain-dict deep copy.
+        base = {"tags": {"domain": "sales"}, "cols": ["a"]}
+        snapshot = copy.deepcopy(base)
+        result = ConfigPatternMatcher({"silver.*": {"x": 1}}).resolve_overrides(
+            "bronze.orders", base  # no pattern matches; nested keys untouched
+        )
+        result["tags"]["injected"] = "x"
+        result["cols"].append("b")
+        assert base == snapshot
+
+    def test_result_converts_custom_mappings_to_plain_dicts(self):
+        class Box(dict):
+            pass
+
+        base = {"tags": Box({"domain": "sales"})}
+        result = ConfigPatternMatcher(None).resolve_overrides("any.id", base)
+        assert type(result["tags"]) is dict
+        assert result["tags"] == {"domain": "sales"}
 
     def test_results_are_isolated_from_matcher_state(self):
         section = {"bronze.*": {"tags": {"layer": "bronze"}, "cols": ["a"]}}


### PR DESCRIPTION
## Summary

Adds `packages/kindling/config_patterns.py` — the pattern-matching engine for wildcard config overrides (Phase 1 of `docs/proposals/package_config_architecture.md`). Engine only: no consumers are wired in this PR, so there is no behavior change anywhere.

- Pattern language over dot-segmented ids (anchored, case-sensitive): `*` = one span within a segment, `?` = one char, `**` = one-or-more whole segments (only as a complete segment; malformed embedded `**` warns and skips).
- Tiered specificity — exact (1000) > single-wildcard (100) > multi-wildcard (10); ties resolve by declaration order, last-in wins. Overrides apply least→most specific; mappings deep-merge, scalars/lists replace.
- `_enabled`/`_remove_tags`/`_remove_all_tags` pass through untouched — interpreting them belongs to the tag-management follow-up.
- Copy-on-merge: `resolve_overrides` never mutates the caller's base or the matcher's stored overrides.
- Deviations from the proposal's reference snippet (per-segment scoring, reversed tie-break, merge aliasing) are corrected and recorded in an implementation note in the proposal doc.

## Tests

`tests/unit/test_config_patterns.py` — translation vectors, specificity tiers, tie-break in both declaration orders, merge/non-mutation/isolation, the issue's pattern vector, the proposal's resolution-trace vector, and a real-YAML-through-Dynaconf DynaBox test. Full unit suite: 2118 passed; new module at 100% coverage.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)