### PR TITLE
feat(cli): artifact store abstraction — UC Volumes and local artifacts roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ All notable changes to spark-kindling are documented here.
 
 ### Added
 
+- **Artifact store abstraction — UC Volumes and local artifacts roots**
+  (gh#207, Phase 1): new `kindling_sdk.artifact_store` module. The CLI's
+  deploy commands (`workspace init`, `workspace deploy`, `package deploy`,
+  `runtime deploy`, plus `app run`'s version check) now write through a
+  store dispatched on the artifacts path's shape: `abfss://…` (existing
+  Azure behavior, unchanged), `/Volumes/<catalog>/<schema>/<volume>/…`
+  (Databricks Files API), or a local directory / `file://` (tests, local
+  dev). The destination resolves from one value — `--artifacts-path`, then
+  `KINDLING_ARTIFACTS_STORAGE_PATH` (the env spelling of the runtime's
+  existing `artifacts_storage_path` config key, so one variable configures
+  both sides), then the legacy `AZURE_STORAGE_ACCOUNT`/`AZURE_CONTAINER`/
+  `AZURE_BASE_PATH` triple (deprecated but fully supported, synthesized to
+  abfss). `runtime deploy --source/--dest` accept any store root, so
+  staging→prod promotion works across backends; `dbfs:/` roots are
+  rejected with a Unity Catalog volume hint. `package deploy --json` now
+  reports a scheme-neutral `artifacts_path` (legacy `storage_account`/
+  `container` fields kept for abfss for one minor release) and no longer
+  contaminates JSON stdout with per-wheel progress echoes. Requires
+  databricks-sdk >= 0.20.0 (Files API directory operations) for volume
+  roots.
 - **Wildcard config pattern engine**: new `kindling.config_patterns` module
   with `ConfigPatternMatcher` — glob patterns (`*`, `?`, `**`) over
   dot-segmented pipe/entity ids, tiered specificity (exact > single

--- a/packages/kindling_cli/kindling_cli/cli.py
+++ b/packages/kindling_cli/kindling_cli/cli.py
@@ -22,6 +22,15 @@ from urllib.parse import quote, urlparse
 import click
 import yaml
 from kindling_cli.test_runner import SUPPORTED_PLATFORMS
+from kindling_sdk.artifact_store import (
+    AbfssArtifactStore,
+    ArtifactStore,
+    artifact_store_for,
+    create_blob_service_client,
+    parse_abfss_uri,
+    resolve_artifacts_path,
+    resolve_blob_account_url,
+)
 from kindling_sdk.platform_provider import (
     azure_cloud_config,
     azure_synapse_dev_endpoint_suffix,
@@ -2016,10 +2025,20 @@ def workspace_group() -> None:
     help="Target platform. Auto-detected from environment if omitted.",
 )
 @click.option(
+    "--artifacts-path",
+    "artifacts_path",
+    default=None,
+    help=(
+        "Artifacts root (abfss://…, /Volumes/…, or a local directory). "
+        "Overrides KINDLING_ARTIFACTS_STORAGE_PATH. Legacy --storage-account/"
+        "--container/--base-path remain supported for abfss."
+    ),
+)
+@click.option(
     "--storage-account",
     "storage_account",
     default=None,
-    help="Storage account: name, name.domain, or full URL. Overrides AZURE_STORAGE_ACCOUNT.",
+    help="[legacy] Storage account: name, name.domain, or full URL. Overrides AZURE_STORAGE_ACCOUNT.",
 )
 @click.option(
     "--container",
@@ -2065,6 +2084,7 @@ def workspace_group() -> None:
 )
 def workspace_init(
     platform: Optional[str],
+    artifacts_path: Optional[str],
     storage_account: Optional[str],
     container: Optional[str],
     base_path: Optional[str],
@@ -2074,15 +2094,17 @@ def workspace_init(
     workspace: Optional[str],
     overwrite: bool,
 ) -> None:
-    """Initialize the platform workspace: deploy config to storage.
+    """Initialize the platform workspace: deploy config to artifact storage.
 
-    Deploys settings.yaml and overlay configs to {base}/config/ in storage.
-    With --notebook-bootstrap, also generates and imports notebook bootstrap
-    files into the platform workspace via platform APIs.
+    Deploys settings.yaml and overlay configs to config/ under the artifacts
+    root. With --notebook-bootstrap, also generates and imports notebook
+    bootstrap files into the platform workspace via platform APIs.
 
     \b
     Examples:
       kindling workspace init --platform fabric --storage-account myacct
+      kindling workspace init --platform databricks \\
+          --artifacts-path /Volumes/main/kindling/artifacts
       kindling workspace init --platform fabric --storage-account myacct \\
           --notebook-bootstrap --workspace <workspace-id>
     """
@@ -2091,17 +2113,10 @@ def workspace_init(
         raise click.ClickException(_PLATFORM_NOT_FOUND_MSG)
     resolved_environment = environment or os.getenv("KINDLING_ENV")
 
-    resolved_account, resolved_container, resolved_base = _resolve_storage_env(
-        storage_account, container, base_path
-    )
+    store = _open_store(_resolve_destination(artifacts_path, storage_account, container, base_path))
 
-    click.echo(
-        f"Initializing workspace on {resolved_platform} "
-        f"({resolved_account}/{resolved_container}/)"
-    )
+    click.echo(f"Initializing workspace on {resolved_platform} ({store.describe()})")
     click.echo()
-
-    blob_service_client = _get_blob_service_client(resolved_account)
 
     # -- Config ----------------------------------------------------------------
     resolved_config = config_path.expanduser()
@@ -2111,12 +2126,9 @@ def workspace_init(
             "Run `kindling config init` first to generate one."
         )
 
-    config_dest = f"{resolved_base}/config" if resolved_base else "config"
-    click.echo(f"Config → {config_dest}/")
+    click.echo("Config → config/")
     _deploy_config(
-        blob_service_client,
-        resolved_container,
-        resolved_base,
+        store,
         resolved_config,
         overwrite=overwrite,
         platform=resolved_platform,
@@ -2160,76 +2172,56 @@ def workspace_init(
 # workspace deploy
 # =============================================================================
 
-_DEPLOY_ENV_VARS = ("AZURE_STORAGE_ACCOUNT", "AZURE_CONTAINER", "AZURE_BASE_PATH")
-
-
-def _resolve_storage_env(
-    storage_account_override: Optional[str] = None,
-    container_override: Optional[str] = None,
-    base_path_override: Optional[str] = None,
-) -> Tuple[str, str, str]:
-    """Return (storage_account, container, base_path) from overrides or environment."""
-    account = storage_account_override or os.getenv("AZURE_STORAGE_ACCOUNT", "")
-    container = container_override or os.getenv("AZURE_CONTAINER", "artifacts")
-    base_path = (
-        base_path_override if base_path_override is not None else os.getenv("AZURE_BASE_PATH", "")
-    )
-    if not account:
-        raise click.ClickException(
-            "Storage account is required. Use --storage-account or set AZURE_STORAGE_ACCOUNT."
-        )
-    return account, container, base_path
-
-
-def _storage_account_name(storage_account: str) -> str:
-    raw = (storage_account or "").strip()
-    if not raw:
-        return raw
-    parsed = urlparse(raw if "://" in raw else f"//{raw}")
-    host = parsed.hostname or raw.split("/", 1)[0]
-    return host.split(".", 1)[0]
-
 
 def _resolve_account_url(storage_account: str) -> str:
-    """Resolve a storage account name or URL to a full blob endpoint URL.
-
-    Accepts:
-      - Just the account name: "mystorageacct" -> configured cloud blob endpoint
-      - Name with custom domain: "mystorageacct.blob.core.usgovcloudapi.net" → "https://..."
-      - Full URL: "https://mystorageacct.blob.core.usgovcloudapi.net" → passed through
-    """
-    if storage_account.startswith("https://"):
-        return storage_account
-    if "." in storage_account:
-        return f"https://{storage_account}"
-    endpoint_suffix = os.getenv("AZURE_STORAGE_BLOB_ENDPOINT_SUFFIX")
-    if endpoint_suffix:
-        endpoint_suffix = endpoint_suffix.strip().rstrip("/").lstrip(".")
-        return f"https://{storage_account}.{endpoint_suffix.lstrip('.')}"
-    endpoint_suffix = azure_cloud_config()["storage_suffix"]
-    return f"https://{storage_account}.blob.{endpoint_suffix.lstrip('.')}"
+    """Thin alias for the moved implementation (kindling_sdk.artifact_store)."""
+    return resolve_blob_account_url(storage_account)
 
 
 def _get_blob_service_client(storage_account: str):
-    """Create a BlobServiceClient using DefaultAzureCredential."""
+    """Create a BlobServiceClient. Kept in the CLI as the seam tests patch."""
     try:
-        from azure.storage.blob import BlobServiceClient
+        return create_blob_service_client(storage_account)
     except ImportError as exc:
-        raise click.ClickException(
-            "azure-identity and azure-storage-blob are required for deploy.\n"
-            "Install with: pip install 'spark-kindling-cli[deploy]'"
-        ) from exc
-
-    account_url = _resolve_account_url(storage_account)
-    credential = create_azure_credential(additionally_allowed_tenants=["*"])
-    return BlobServiceClient(account_url=account_url, credential=credential)
+        raise click.ClickException(str(exc)) from exc
 
 
-def _warn_if_runtime_outdated(
-    blob_service_client,
-    container: str,
-    packages_path: str,
-) -> None:
+def _resolve_destination(
+    artifacts_path: Optional[str] = None,
+    storage_account: Optional[str] = None,
+    container: Optional[str] = None,
+    base_path: Optional[str] = None,
+) -> str:
+    """Resolve the artifacts destination path (see resolve_artifacts_path)."""
+    try:
+        return resolve_artifacts_path(
+            artifacts_path,
+            storage_account=storage_account,
+            container=container,
+            base_path=base_path,
+        )
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+def _open_store(path: str) -> ArtifactStore:
+    """Open the artifact store declared by ``path``'s shape.
+
+    abfss:// stores get their blob client through _get_blob_service_client so
+    existing test seams (and any credential overrides) keep working.
+    """
+    try:
+        if path.strip().startswith("abfss://"):
+            _, account, _ = parse_abfss_uri(path.strip())
+            return AbfssArtifactStore(
+                path.strip(), blob_service_client=_get_blob_service_client(account)
+            )
+        return artifact_store_for(path)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+def _warn_if_runtime_outdated(store: ArtifactStore) -> None:
     """Emit a warning if the deployed runtime wheel is older than the CLI."""
     try:
         from packaging.version import Version
@@ -2237,15 +2229,13 @@ def _warn_if_runtime_outdated(
         return
 
     try:
-        container_client = blob_service_client.get_container_client(container)
-        prefix = f"{packages_path}/" if packages_path else "packages/"
-        blobs = list(container_client.list_blobs(name_starts_with=prefix))
+        files = store.list_files("packages")
     except Exception:
         return
 
     deployed_version = None
-    for blob in blobs:
-        name = blob.name.split("/")[-1]
+    for file_path in files:
+        name = file_path.split("/")[-1]
         if name.startswith("spark_kindling-") and name.endswith(".whl"):
             parts = name.split("-")
             if len(parts) >= 2:
@@ -2272,25 +2262,6 @@ def _warn_if_runtime_outdated(
         )
 
 
-def _upload_blob(
-    blob_service_client,
-    container: str,
-    blob_path: str,
-    data: bytes,
-    overwrite: bool = True,
-) -> bool:
-    """Upload a blob. Returns True if uploaded, False if skipped."""
-    blob_client = blob_service_client.get_blob_client(container=container, blob=blob_path)
-    if not overwrite:
-        try:
-            blob_client.get_blob_properties()
-            return False  # exists, skip
-        except Exception:
-            pass  # doesn't exist, proceed
-    blob_client.upload_blob(data, overwrite=True)
-    return True
-
-
 def _find_wheels(dist_dir: Path, platform: Optional[str] = None) -> List[Path]:
     """Find runtime wheels, preferring the combined spark-kindling artifact."""
     combined_wheels = sorted(dist_dir.glob("spark_kindling-*.whl"))
@@ -2306,18 +2277,16 @@ def _find_wheels(dist_dir: Path, platform: Optional[str] = None) -> List[Path]:
     return sorted(legacy_wheels)
 
 
-def _deploy_wheels(
-    blob_service_client,
-    container: str,
-    packages_path: str,
-    wheels: List[Path],
-) -> int:
-    """Upload wheel files. Always overwrites (wheels are versioned)."""
+def _deploy_wheels(store: ArtifactStore, wheels: List[Path], quiet: bool = False) -> int:
+    """Upload wheel files to packages/. Always overwrites (wheels are versioned).
+
+    ``quiet`` suppresses the per-wheel echo so --json stdout stays parseable.
+    """
     count = 0
     for wheel in wheels:
-        dest = f"{packages_path}/{wheel.name}" if packages_path else wheel.name
-        click.echo(f"  {wheel.name}")
-        _upload_blob(blob_service_client, container, dest, wheel.read_bytes(), overwrite=True)
+        if not quiet:
+            click.echo(f"  {wheel.name}")
+        store.upload_file(f"packages/{wheel.name}", wheel.read_bytes(), overwrite=True)
         count += 1
     return count
 
@@ -2409,19 +2378,16 @@ def _build_package_wheel(package_root: Path, dist_dir: Path) -> Path:
 
 
 def _deploy_bootstrap_script(
-    blob_service_client,
-    container: str,
-    scripts_path: str,
+    store: ArtifactStore,
     repo_root: Path,
     overwrite: bool = True,
 ) -> bool:
-    """Upload kindling_bootstrap.py. Returns True if found and uploaded."""
+    """Upload kindling_bootstrap.py to scripts/. Returns True if found and uploaded."""
     bootstrap = repo_root / "runtime" / "scripts" / "kindling_bootstrap.py"
     if not bootstrap.exists():
         return False
-    dest = f"{scripts_path}/kindling_bootstrap.py" if scripts_path else "kindling_bootstrap.py"
-    if _upload_blob(
-        blob_service_client, container, dest, bootstrap.read_bytes(), overwrite=overwrite
+    if store.upload_file(
+        "scripts/kindling_bootstrap.py", bootstrap.read_bytes(), overwrite=overwrite
     ):
         click.echo("  kindling_bootstrap.py")
     else:
@@ -2594,15 +2560,13 @@ print(f"Framework initialized for {{BOOTSTRAP_CONFIG['app_name']}}")
 
 
 def _deploy_config(
-    blob_service_client,
-    container: str,
-    base_path: str,
+    store: ArtifactStore,
     config_path: Path,
     overwrite: bool = True,
     platform: Optional[str] = None,
     environment: Optional[str] = None,
 ) -> None:
-    """Upload settings.yaml and selected dot-style settings overlays to storage."""
+    """Upload settings.yaml and selected dot-style settings overlays to config/."""
     config_dir = config_path.parent
     config_files = [config_path]
     if platform:
@@ -2628,10 +2592,8 @@ def _deploy_config(
             seen.add(resolved)
             unique.append(f)
 
-    config_dest = f"{base_path}/config" if base_path else "config"
     for f in unique:
-        dest = f"{config_dest}/{f.name}"
-        if _upload_blob(blob_service_client, container, dest, f.read_bytes(), overwrite=overwrite):
+        if store.upload_file(f"config/{f.name}", f.read_bytes(), overwrite=overwrite):
             click.echo(f"  {f.name}")
         else:
             click.echo(f"  {f.name} (exists, skipped)")
@@ -2979,10 +2941,20 @@ def notebook_push(
     help="Environment settings overlay to deploy. Defaults to KINDLING_ENV when set.",
 )
 @click.option(
+    "--artifacts-path",
+    "artifacts_path",
+    default=None,
+    help=(
+        "Artifacts root (abfss://…, /Volumes/…, or a local directory). "
+        "Overrides KINDLING_ARTIFACTS_STORAGE_PATH. Legacy --storage-account/"
+        "--container/--base-path remain supported for abfss."
+    ),
+)
+@click.option(
     "--storage-account",
     "storage_account",
     default=None,
-    help="Storage account: name, name.domain, or full URL. Overrides AZURE_STORAGE_ACCOUNT.",
+    help="[legacy] Storage account: name, name.domain, or full URL. Overrides AZURE_STORAGE_ACCOUNT.",
 )
 @click.option(
     "--container",
@@ -3015,6 +2987,7 @@ def workspace_deploy(
     platform: Optional[str],
     config_path: Path,
     environment: Optional[str],
+    artifacts_path: Optional[str],
     storage_account: Optional[str],
     container: Optional[str],
     base_path: Optional[str],
@@ -3022,11 +2995,11 @@ def workspace_deploy(
     overwrite: bool,
     allow_missing_config: bool,
 ) -> None:
-    """Re-deploy config to Azure Storage after settings.yaml changes.
+    """Re-deploy config to artifact storage after settings.yaml changes.
 
     \b
-    Deploys settings.yaml and overlay configs to {base}/config/ in storage.
-    Use this to push config updates after initial workspace setup.
+    Deploys settings.yaml and overlay configs to config/ under the artifacts
+    root. Use this to push config updates after initial workspace setup.
 
     \b
     For first-time setup (including notebook bootstrap), use:
@@ -3038,7 +3011,8 @@ def workspace_deploy(
     \b
     Examples:
       kindling workspace deploy --platform synapse --storage-account mystorageacct
-      kindling workspace deploy --platform fabric --storage-account mystorageacct --overwrite
+      kindling workspace deploy --platform databricks \\
+          --artifacts-path /Volumes/main/kindling/artifacts --overwrite
     """
     resolved_platform = platform or _detect_platform_from_environment()
     if not resolved_platform:
@@ -3048,18 +3022,10 @@ def workspace_deploy(
         )
     resolved_environment = environment or os.getenv("KINDLING_ENV")
 
-    resolved_account, resolved_container, resolved_base = _resolve_storage_env(
-        storage_account,
-        container,
-        base_path,
-    )
+    store = _open_store(_resolve_destination(artifacts_path, storage_account, container, base_path))
 
-    click.echo(
-        f"Deploying config to {resolved_account}/{resolved_container}/ (platform: {resolved_platform})"
-    )
+    click.echo(f"Deploying config to {store.describe()} (platform: {resolved_platform})")
     click.echo()
-
-    blob_service_client = _get_blob_service_client(resolved_account)
 
     # -- Config ----------------------------------------------------------------
     if not skip_config:
@@ -3073,12 +3039,9 @@ def workspace_deploy(
                     f"{message} Use --skip-config or --allow-missing-config."
                 )
         else:
-            config_dest = f"{resolved_base}/config" if resolved_base else "config"
-            click.echo(f"Config → {config_dest}/")
+            click.echo("Config → config/")
             _deploy_config(
-                blob_service_client,
-                resolved_container,
-                resolved_base,
+                store,
                 resolved_config,
                 overwrite=overwrite,
                 platform=resolved_platform,
@@ -3483,9 +3446,7 @@ def _run_remote_app(
         _set_nested_key(parameters, key, _coerce_value(value))
 
     try:
-        _account, _container, _base = _resolve_storage_env()
-        _packages_path = f"{_base}/packages" if _base else "packages"
-        _warn_if_runtime_outdated(_get_blob_service_client(_account), _container, _packages_path)
+        _warn_if_runtime_outdated(_open_store(_resolve_destination()))
     except Exception:
         pass
 
@@ -5790,10 +5751,20 @@ def package_init(
     ),
 )
 @click.option(
+    "--artifacts-path",
+    "artifacts_path",
+    default=None,
+    help=(
+        "Artifacts root (abfss://…, /Volumes/…, or a local directory). "
+        "Overrides KINDLING_ARTIFACTS_STORAGE_PATH. Legacy --storage-account/"
+        "--container/--base-path remain supported for abfss."
+    ),
+)
+@click.option(
     "--storage-account",
     "storage_account",
     default=None,
-    help="Storage account: name, name.domain, or full URL. Overrides AZURE_STORAGE_ACCOUNT.",
+    help="[legacy] Storage account: name, name.domain, or full URL. Overrides AZURE_STORAGE_ACCOUNT.",
 )
 @click.option(
     "--container",
@@ -5812,6 +5783,7 @@ def package_deploy(
     package_name: str,
     local_folder: Optional[Path],
     dist_dir: Path,
+    artifacts_path: Optional[str],
     storage_account: Optional[str],
     container: Optional[str],
     base_path: Optional[str],
@@ -5822,8 +5794,8 @@ def package_deploy(
     \b
     PACKAGE_NAME is used to locate packages/<package_name>/ by convention.
     Use --local-folder to override for non-standard layouts.
-    The wheel is uploaded to {base}/packages/ so apps can reference it from
-    lake-reqs.txt.
+    The wheel is uploaded to packages/ under the artifacts root so apps can
+    reference it from lake-reqs.txt.
     """
     if local_folder:
         package_root = local_folder.expanduser().resolve()
@@ -5831,31 +5803,28 @@ def package_deploy(
         package_root = _resolve_by_convention(package_name, "packages", "package")
     wheel = _build_package_wheel(package_root, dist_dir)
 
-    resolved_account, resolved_container, resolved_base = _resolve_storage_env(
-        storage_account,
-        container,
-        base_path,
-    )
-    packages_path = f"{resolved_base}/packages" if resolved_base else "packages"
+    store = _open_store(_resolve_destination(artifacts_path, storage_account, container, base_path))
 
     if not json_output:
-        click.echo(f"Packages → {packages_path}/")
-    blob_service_client = _get_blob_service_client(resolved_account)
-    count = _deploy_wheels(blob_service_client, resolved_container, packages_path, [wheel])
+        click.echo("Packages → packages/")
+    count = _deploy_wheels(store, [wheel], quiet=json_output)
 
     payload = {
         "package_path": str(package_root),
         "wheel": str(wheel),
-        "storage_account": resolved_account,
-        "container": resolved_container,
-        "packages_path": packages_path,
+        "artifacts_path": store.root,
+        "packages_path": "packages",
         "uploaded_count": count,
     }
+    if isinstance(store, AbfssArtifactStore):
+        # Deprecated fields, kept for one minor release for abfss consumers.
+        payload["storage_account"] = store.account
+        payload["container"] = store.container
+        payload["packages_path"] = f"{store.base_path}/packages" if store.base_path else "packages"
     _emit_result(
         payload,
         json_output,
-        f"Deployed `{wheel.name}` to "
-        f"`{resolved_account}/{resolved_container}/{packages_path}/`.",
+        f"Deployed `{wheel.name}` to `{store.describe()}/packages/`.",
     )
 
 
@@ -5865,45 +5834,15 @@ def package_deploy(
 
 
 def _parse_abfss_uri(uri: str) -> Tuple[str, str, str]:
-    """Parse an abfss:// URI into (container, account, path).
+    """Thin alias for the moved implementation (kindling_sdk.artifact_store).
 
-    Expected format: abfss://container@account.dfs.core.windows.net/path
-    The storage account name is the part before '.dfs.' in the host.
-
-    Returns (container, storage_account_name, blob_path_prefix).
-    Raises click.ClickException on malformed URIs.
+    Returns (container, storage_account_name, blob_path_prefix); raises
+    click.ClickException with the same messages as before on malformed URIs.
     """
-    if not uri.startswith("abfss://"):
-        raise click.ClickException(
-            f"Invalid destination URI `{uri}`. Expected abfss://container@account.dfs.core.windows.net/path"
-        )
-    rest = uri[len("abfss://") :]
-    if "@" not in rest:
-        raise click.ClickException(
-            f"Invalid abfss URI `{uri}`. Missing '@' separator between container and account."
-        )
-    container, host_and_path = rest.split("@", 1)
-    if not container:
-        raise click.ClickException(f"Invalid abfss URI `{uri}`. Container name is empty.")
-
-    if "/" in host_and_path:
-        host, path = host_and_path.split("/", 1)
-    else:
-        host = host_and_path
-        path = ""
-
-    # Extract storage account name: part before the first '.'
-    if "." not in host:
-        raise click.ClickException(
-            f"Invalid abfss URI `{uri}`. Host `{host}` does not contain a domain suffix."
-        )
-    account_name = host.split(".", 1)[0]
-    if not account_name:
-        raise click.ClickException(f"Invalid abfss URI `{uri}`. Storage account name is empty.")
-
-    # Normalize path: strip leading slashes
-    blob_path = path.lstrip("/")
-    return container, account_name, blob_path
+    try:
+        return parse_abfss_uri(uri)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 def _github_api_json(path: str) -> Dict[str, Any]:
@@ -6015,38 +5954,27 @@ def _resolve_github_version(version: Optional[str], repo: str = KINDLING_GITHUB_
     return tag.lstrip("v")
 
 
-def _adls_copy_path(
-    src_blob_service_client,
-    src_container: str,
+def _copy_between_stores(
+    src_store: ArtifactStore,
     src_prefix: str,
-    dest_blob_service_client,
-    dest_container: str,
+    dest_store: ArtifactStore,
     dest_prefix: str,
     overwrite: bool = True,
 ) -> int:
-    """Copy blobs from an ADLS source prefix to a dest prefix.
+    """Copy files under a source prefix to a dest prefix, across any backends.
 
-    Returns the count of blobs copied.
+    Each file is buffered in memory (fine at wheel/config sizes). Returns the
+    count of files copied.
     """
-    src_container_client = src_blob_service_client.get_container_client(src_container)
-    list_prefix = f"{src_prefix}/" if src_prefix and not src_prefix.endswith("/") else src_prefix
-    blobs = list(src_container_client.list_blobs(name_starts_with=list_prefix))
     count = 0
-    for blob in blobs:
-        # Compute relative path from source prefix
-        rel = blob.name[len(list_prefix) :] if blob.name.startswith(list_prefix) else blob.name
-        dest_blob_path = f"{dest_prefix}/{rel}" if dest_prefix else rel
-
-        # Download
-        blob_client = src_blob_service_client.get_blob_client(
-            container=src_container, blob=blob.name
+    for file_path in src_store.list_files(src_prefix):
+        rel = (
+            file_path[len(src_prefix) + 1 :]
+            if src_prefix and file_path.startswith(f"{src_prefix}/")
+            else file_path
         )
-        data = blob_client.download_blob().readall()
-
-        # Upload
-        _upload_blob(
-            dest_blob_service_client, dest_container, dest_blob_path, data, overwrite=overwrite
-        )
+        dest_path = f"{dest_prefix}/{rel}" if dest_prefix else rel
+        dest_store.upload_file(dest_path, src_store.download_file(file_path), overwrite=overwrite)
         click.echo(f"  {rel}")
         count += 1
     return count
@@ -6066,14 +5994,18 @@ def runtime_group() -> None:
         "Source specifier. One of:\n\n"
         "  github:VERSION or github:latest — download from GitHub release\n\n"
         "  local:PATH — read wheels from a local directory\n\n"
-        "  abfss://container@account.dfs.core.windows.net/path — copy from ADLS"
+        "  an artifacts root (abfss://…, /Volumes/…, file://…) — copy from "
+        "another store (e.g. staging → prod)"
     ),
 )
 @click.option(
     "--dest",
     "dest",
     required=True,
-    help="Destination abfss:// URI (e.g. abfss://artifacts@myacct.dfs.core.windows.net/kindling).",
+    help=(
+        "Destination artifacts root: abfss://container@account.dfs.<suffix>/path, "
+        "/Volumes/<catalog>/<schema>/<volume>/path, or a local directory."
+    ),
 )
 @click.option(
     "--version",
@@ -6104,14 +6036,15 @@ def runtime_deploy(
     skip_bootstrap: bool,
     overwrite: bool,
 ) -> None:
-    """Deploy kindling runtime artifacts (wheels + bootstrap script) to Azure Data Lake Storage.
+    """Deploy kindling runtime artifacts (wheels + bootstrap script) to artifact storage.
 
     \b
     Source types:
       github:latest            — download from the latest GitHub release
       github:0.10.15           — download from a specific release
       local:./dist             — read wheels from a local directory
-      abfss://...              — copy from another ADLS path (e.g. staging → prod)
+      abfss:// | /Volumes/ | file://
+                               — copy from another artifacts root (e.g. staging → prod)
 
     \b
     Destination layout under --dest:
@@ -6121,17 +6054,19 @@ def runtime_deploy(
     \b
     Examples:
       kindling runtime deploy --source github:latest --dest abfss://artifacts@myprod.dfs.core.windows.net/kindling
-      kindling runtime deploy --source local:./dist --dest abfss://artifacts@mydev.dfs.core.windows.net/kindling
-      kindling runtime deploy --source abfss://artifacts@staging.dfs.core.windows.net/k --dest abfss://artifacts@prod.dfs.core.windows.net/k
+      kindling runtime deploy --source local:./dist --dest /Volumes/main/kindling/artifacts
+      kindling runtime deploy --source abfss://artifacts@staging.dfs.core.windows.net/k --dest /Volumes/main/kindling/artifacts
     """
     import tempfile
 
-    # ---- Validate and parse dest ------------------------------------------------
-    dest_container, dest_account, dest_base = _parse_abfss_uri(dest)
-    dest_packages_path = f"{dest_base}/packages" if dest_base else "packages"
-    dest_scripts_path = f"{dest_base}/scripts" if dest_base else "scripts"
-
-    dest_blob_client = _get_blob_service_client(dest_account)
+    # ---- Validate dest and open its store ----------------------------------------
+    try:
+        dest_store = _open_store(dest)
+    except click.ClickException as exc:
+        message = str(exc.message)
+        if not message.startswith("Invalid"):
+            message = f"Invalid destination URI `{dest}`. {message}"
+        raise click.ClickException(message) from exc
 
     # ---- Determine source type --------------------------------------------------
     if source.startswith("github:"):
@@ -6154,23 +6089,17 @@ def runtime_deploy(
                     "Expected spark_kindling-*.whl attachments."
                 )
 
-            click.echo(f"Packages → {dest_packages_path}/")
-            count = _deploy_wheels(dest_blob_client, dest_container, dest_packages_path, wheels)
+            click.echo("Packages → packages/")
+            count = _deploy_wheels(dest_store, wheels)
             click.echo(f"  ({count} wheel(s) uploaded)")
             click.echo()
 
             if not skip_bootstrap:
                 bootstrap_in_release = tmp_path / "kindling_bootstrap.py"
                 if bootstrap_in_release.exists():
-                    click.echo(f"Scripts → {dest_scripts_path}/")
-                    dest_blob_name = f"{dest_scripts_path}/kindling_bootstrap.py"
-                    script_overwrite = (
-                        overwrite or True
-                    )  # wheels always overwrite; scripts follow overwrite flag
-                    if _upload_blob(
-                        dest_blob_client,
-                        dest_container,
-                        dest_blob_name,
+                    click.echo("Scripts → scripts/")
+                    if dest_store.upload_file(
+                        "scripts/kindling_bootstrap.py",
                         bootstrap_in_release.read_bytes(),
                         overwrite=overwrite,
                     ):
@@ -6203,14 +6132,14 @@ def runtime_deploy(
                 "Expected spark_kindling-*.whl or kindling_<platform>-*.whl."
             )
 
-        click.echo(f"Packages → {dest_packages_path}/")
-        count = _deploy_wheels(dest_blob_client, dest_container, dest_packages_path, wheels)
+        click.echo("Packages → packages/")
+        count = _deploy_wheels(dest_store, wheels)
         click.echo(f"  ({count} wheel(s) uploaded)")
         click.echo()
 
         if not skip_bootstrap:
             # Look for bootstrap in runtime/scripts/ relative to local_dir or its parents
-            click.echo(f"Scripts → {dest_scripts_path}/")
+            click.echo("Scripts → scripts/")
             repo_root = local_dir
             bootstrap_found = False
             for candidate in (repo_root, repo_root.parent, repo_root.parent.parent):
@@ -6219,71 +6148,58 @@ def runtime_deploy(
                     bootstrap_found = True
                     break
             if bootstrap_found:
-                if _deploy_bootstrap_script(
-                    dest_blob_client,
-                    dest_container,
-                    dest_scripts_path,
-                    repo_root,
-                    overwrite=overwrite,
-                ):
+                if _deploy_bootstrap_script(dest_store, repo_root, overwrite=overwrite):
                     click.echo()
             else:
                 click.echo("  kindling_bootstrap.py not found in runtime/scripts/ — skipping.")
                 click.echo()
 
-    elif source.startswith("abfss://"):
-        # ADLS-to-ADLS copy
-        src_container, src_account, src_base = _parse_abfss_uri(source)
-        src_packages_prefix = f"{src_base}/packages" if src_base else "packages"
-        src_scripts_prefix = f"{src_base}/scripts" if src_base else "scripts"
+    else:
+        # Store-to-store copy (abfss://, /Volumes/, file://, local directory)
+        try:
+            src_store = _open_store(source)
+        except click.ClickException as exc:
+            raise click.ClickException(
+                f"Unrecognized source specifier: `{source}`.\n"
+                "Expected one of:\n"
+                "  github:VERSION or github:latest\n"
+                "  local:PATH\n"
+                "  an artifacts root (abfss://…, /Volumes/…, file://…)\n"
+                f"({exc.message})"
+            ) from exc
 
-        click.echo(f"Publishing from ADLS {source} → {dest}")
+        click.echo(f"Publishing from {src_store.describe()} → {dest_store.describe()}")
         click.echo()
 
-        src_blob_client = _get_blob_service_client(src_account)
-
         # Copy packages
-        click.echo(f"Packages → {dest_packages_path}/")
-        pkg_count = _adls_copy_path(
-            src_blob_client,
-            src_container,
-            src_packages_prefix,
-            dest_blob_client,
-            dest_container,
-            dest_packages_path,
+        click.echo("Packages → packages/")
+        pkg_count = _copy_between_stores(
+            src_store,
+            "packages",
+            dest_store,
+            "packages",
             overwrite=True,  # wheels always overwrite
         )
         if pkg_count == 0:
-            click.echo("  (no wheel blobs found at source packages path)")
+            click.echo("  (no wheel files found at source packages path)")
         else:
-            click.echo(f"  ({pkg_count} blob(s) copied)")
+            click.echo(f"  ({pkg_count} file(s) copied)")
         click.echo()
 
         if not skip_bootstrap:
-            click.echo(f"Scripts → {dest_scripts_path}/")
-            script_count = _adls_copy_path(
-                src_blob_client,
-                src_container,
-                src_scripts_prefix,
-                dest_blob_client,
-                dest_container,
-                dest_scripts_path,
+            click.echo("Scripts → scripts/")
+            script_count = _copy_between_stores(
+                src_store,
+                "scripts",
+                dest_store,
+                "scripts",
                 overwrite=overwrite,
             )
             if script_count == 0:
-                click.echo("  (no script blobs found at source scripts path)")
+                click.echo("  (no script files found at source scripts path)")
             else:
-                click.echo(f"  ({script_count} blob(s) copied)")
+                click.echo(f"  ({script_count} file(s) copied)")
             click.echo()
-
-    else:
-        raise click.ClickException(
-            f"Unrecognized source specifier: `{source}`.\n"
-            "Expected one of:\n"
-            "  github:VERSION or github:latest\n"
-            "  local:PATH\n"
-            "  abfss://container@account.dfs.core.windows.net/path"
-        )
 
     click.echo("Deploy complete.")
 

--- a/packages/kindling_sdk/kindling_sdk/artifact_store.py
+++ b/packages/kindling_sdk/kindling_sdk/artifact_store.py
@@ -35,7 +35,7 @@ import io
 import os
 import posixpath
 from abc import ABC, abstractmethod
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, List, Optional, Tuple
 
 from kindling_sdk.platform_provider import (
@@ -173,6 +173,23 @@ def create_databricks_workspace_client(host: Optional[str] = None):
     return WorkspaceClient(host=resolved_host, auth_type="azure-cli")
 
 
+def _validate_rel_path(rel_path: str) -> str:
+    """Reject paths that would escape the artifacts root.
+
+    Store paths are root-relative by contract, but they can originate
+    outside the caller (e.g. remote listings during store-to-store copies),
+    so absolute forms and ``..`` traversal are rejected rather than joined.
+    Both posix and Windows interpretations are checked so a path that is
+    merely odd on one platform cannot traverse on the other.
+    """
+    posix, windows = PurePosixPath(rel_path), PureWindowsPath(rel_path)
+    if posix.is_absolute() or windows.is_absolute() or windows.drive:
+        raise ValueError(f"Artifact path `{rel_path}` must be root-relative.")
+    if ".." in posix.parts or ".." in windows.parts:
+        raise ValueError(f"Artifact path `{rel_path}` must not contain `..`.")
+    return rel_path
+
+
 class ArtifactStore(ABC):
     """One artifacts root and the writes/reads the design-time tooling needs.
 
@@ -219,7 +236,7 @@ class LocalArtifactStore(ArtifactStore):
         self.root = str(self._root_path)
 
     def _full(self, rel_path: str) -> Path:
-        return self._root_path / rel_path
+        return self._root_path / _validate_rel_path(rel_path)
 
     def upload_file(self, rel_path: str, data: bytes, overwrite: bool = True) -> bool:
         target = self._full(rel_path)
@@ -278,6 +295,7 @@ class AbfssArtifactStore(ArtifactStore):
         return self._client
 
     def _blob(self, rel_path: str) -> str:
+        _validate_rel_path(rel_path)
         return f"{self.base_path}/{rel_path}" if self.base_path else rel_path
 
     def _rel(self, blob_name: str) -> str:
@@ -367,6 +385,7 @@ class VolumesArtifactStore(ArtifactStore):
         return self._workspace_client.files
 
     def _full(self, rel_path: str) -> str:
+        _validate_rel_path(rel_path)
         return posixpath.join(self.root, rel_path) if rel_path else self.root
 
     def _rel(self, full_path: str) -> str:

--- a/packages/kindling_sdk/kindling_sdk/artifact_store.py
+++ b/packages/kindling_sdk/kindling_sdk/artifact_store.py
@@ -1,0 +1,527 @@
+"""Design-time artifact store abstraction (gh#207).
+
+The artifacts contract ({root}/config, {root}/packages, {root}/scripts,
+{root}/data-apps/<app>) is read platform-agnostically at runtime — the
+cluster's storage utils interpret whatever string ``artifacts_storage_path``
+holds. This module gives the design-time side (CLI/SDK uploads from a dev
+machine) the same property: the path string declares the backend, and one
+store interface covers every write the tooling performs.
+
+Supported artifacts roots:
+
+- ``abfss://container@account.dfs.<suffix>/base`` — Azure Blob/ADLS Gen2,
+  authenticated via the shared Azure credential chain (service principal
+  env triple, then ``DefaultAzureCredential``). Sovereign-cloud endpoints
+  resolve exactly as before via ``AZURE_STORAGE_BLOB_ENDPOINT_SUFFIX`` /
+  ``AZURE_CLOUD``.
+- ``/Volumes/<catalog>/<schema>/<volume>[/base]`` — Unity Catalog volume,
+  written through the Databricks Files API. Auth follows the same chain as
+  the SDK's ``DatabricksAPI``: ``DATABRICKS_TOKEN``, then the
+  ``AZURE_TENANT_ID``/``AZURE_CLIENT_ID``/``AZURE_CLIENT_SECRET`` service
+  principal, then Azure CLI login (databricks-sdk natively reads ``ARM_*``,
+  not ``AZURE_*``, so the explicit mapping here is deliberate).
+- ``file:///path`` or a local directory — filesystem store for tests and
+  local development.
+
+``dbfs:/`` roots are rejected deliberately: DBFS root storage is deprecated
+by Databricks; use a Unity Catalog volume instead.
+
+All store methods take root-relative paths (``config/settings.yaml``,
+``packages/foo.whl``), matching the artifacts folder contract. Third-party
+imports are lazy with actionable install hints.
+"""
+
+import io
+import os
+import posixpath
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, List, Optional, Tuple
+
+from kindling_sdk.platform_provider import (
+    azure_abfss_uri,
+    azure_cloud_config,
+    create_azure_credential,
+)
+
+_SUPPORTED_ROOT_FORMS = (
+    "abfss://container@account.dfs.<endpoint-suffix>/path, "
+    "/Volumes/<catalog>/<schema>/<volume>[/path], "
+    "file:///path, or an existing local directory"
+)
+
+
+def parse_abfss_uri(uri: str) -> Tuple[str, str, str]:
+    """Parse an abfss:// URI into (container, account, path).
+
+    Expected format: abfss://container@account.dfs.core.windows.net/path
+    The storage account name is the part before the first '.' in the host.
+
+    Returns (container, storage_account_name, blob_path_prefix).
+    Raises ValueError on malformed URIs.
+    """
+    if not uri.startswith("abfss://"):
+        raise ValueError(
+            f"Invalid destination URI `{uri}`. "
+            "Expected abfss://container@account.dfs.core.windows.net/path"
+        )
+    rest = uri[len("abfss://") :]
+    if "@" not in rest:
+        raise ValueError(
+            f"Invalid abfss URI `{uri}`. Missing '@' separator between container and account."
+        )
+    container, host_and_path = rest.split("@", 1)
+    if not container:
+        raise ValueError(f"Invalid abfss URI `{uri}`. Container name is empty.")
+
+    if "/" in host_and_path:
+        host, path = host_and_path.split("/", 1)
+    else:
+        host = host_and_path
+        path = ""
+
+    if "." not in host:
+        raise ValueError(
+            f"Invalid abfss URI `{uri}`. Host `{host}` does not contain a domain suffix."
+        )
+    account_name = host.split(".", 1)[0]
+    if not account_name:
+        raise ValueError(f"Invalid abfss URI `{uri}`. Storage account name is empty.")
+
+    return container, account_name, path.lstrip("/")
+
+
+def resolve_blob_account_url(storage_account: str) -> str:
+    """Resolve a storage account name or URL to a full blob endpoint URL.
+
+    Accepts:
+      - Just the account name: "mystorageacct" -> configured cloud blob endpoint
+      - Name with custom domain: "mystorageacct.blob.core.usgovcloudapi.net" -> "https://..."
+      - Full URL: "https://mystorageacct.blob.core.usgovcloudapi.net" -> passed through
+    """
+    if storage_account.startswith("https://"):
+        return storage_account
+    if "." in storage_account:
+        return f"https://{storage_account}"
+    endpoint_suffix = os.getenv("AZURE_STORAGE_BLOB_ENDPOINT_SUFFIX")
+    if endpoint_suffix:
+        endpoint_suffix = endpoint_suffix.strip().rstrip("/").lstrip(".")
+        return f"https://{storage_account}.{endpoint_suffix.lstrip('.')}"
+    endpoint_suffix = azure_cloud_config()["storage_suffix"]
+    return f"https://{storage_account}.blob.{endpoint_suffix.lstrip('.')}"
+
+
+def create_blob_service_client(storage_account: str):
+    """Create a BlobServiceClient using the shared Azure credential chain."""
+    try:
+        from azure.storage.blob import BlobServiceClient
+    except ImportError as exc:
+        raise ImportError(
+            "azure-identity and azure-storage-blob are required for abfss:// "
+            "artifact stores.\n"
+            "Install with: pip install 'spark-kindling-cli[deploy]' "
+            "(or: pip install azure-identity azure-storage-blob)"
+        ) from exc
+
+    account_url = resolve_blob_account_url(storage_account)
+    credential = create_azure_credential(additionally_allowed_tenants=["*"])
+    return BlobServiceClient(account_url=account_url, credential=credential)
+
+
+def create_databricks_workspace_client(host: Optional[str] = None):
+    """Create a databricks-sdk WorkspaceClient with the SDK's auth chain.
+
+    Token first, then the AZURE_* service principal triple, then Azure CLI
+    login — the same order as DatabricksAPI. Kept as a module function so
+    stores, the CLI, and (Phase 2) the platform APIs resolve credentials
+    identically.
+    """
+    try:
+        from databricks.sdk import WorkspaceClient
+    except ImportError as exc:
+        raise ImportError(
+            "databricks-sdk is required for /Volumes artifact stores.\n"
+            "Install with: pip install databricks-sdk"
+        ) from exc
+
+    resolved_host = (host or os.getenv("DATABRICKS_HOST") or "").strip()
+    if not resolved_host:
+        raise ValueError(
+            "DATABRICKS_HOST is required for /Volumes artifact paths — volume "
+            "artifact roots are written through the Databricks Files API. Set "
+            "DATABRICKS_HOST plus DATABRICKS_TOKEN, the AZURE_TENANT_ID/"
+            "AZURE_CLIENT_ID/AZURE_CLIENT_SECRET service principal, or an "
+            "Azure CLI login."
+        )
+
+    token = (os.getenv("DATABRICKS_TOKEN") or "").strip()
+    if token:
+        return WorkspaceClient(host=resolved_host, token=token)
+
+    tenant_id = (os.getenv("AZURE_TENANT_ID") or "").strip()
+    client_id = (os.getenv("AZURE_CLIENT_ID") or "").strip()
+    client_secret = (os.getenv("AZURE_CLIENT_SECRET") or "").strip()
+    if tenant_id and client_id and client_secret:
+        return WorkspaceClient(
+            host=resolved_host,
+            azure_tenant_id=tenant_id,
+            azure_client_id=client_id,
+            azure_client_secret=client_secret,
+            auth_type="azure-client-secret",
+        )
+
+    return WorkspaceClient(host=resolved_host, auth_type="azure-cli")
+
+
+class ArtifactStore(ABC):
+    """One artifacts root and the writes/reads the design-time tooling needs.
+
+    All paths are root-relative and forward-slashed, matching the artifacts
+    folder contract (``config/``, ``packages/``, ``scripts/``,
+    ``data-apps/<app>/``).
+    """
+
+    root: str
+
+    def describe(self) -> str:
+        """Human-readable destination for CLI display lines."""
+        return self.root
+
+    @abstractmethod
+    def upload_file(self, rel_path: str, data: bytes, overwrite: bool = True) -> bool:
+        """Upload bytes to ``rel_path``. Returns False when the file already
+        exists and ``overwrite`` is False (skip semantics), True otherwise."""
+
+    @abstractmethod
+    def download_file(self, rel_path: str) -> bytes:
+        """Return the contents of ``rel_path``."""
+
+    @abstractmethod
+    def list_files(self, prefix: str = "") -> List[str]:
+        """Recursively list files under ``prefix``, as root-relative paths."""
+
+    @abstractmethod
+    def exists(self, rel_path: str) -> bool:
+        """True when ``rel_path`` exists as a file."""
+
+    @abstractmethod
+    def delete_prefix(self, prefix: str) -> int:
+        """Recursively delete everything under ``prefix``; returns the number
+        of files removed."""
+
+
+class LocalArtifactStore(ArtifactStore):
+    """Filesystem-backed store (tests and local development)."""
+
+    def __init__(self, root: str):
+        raw = root[len("file://") :] if root.startswith("file://") else root
+        self._root_path = Path(raw).expanduser()
+        self.root = str(self._root_path)
+
+    def _full(self, rel_path: str) -> Path:
+        return self._root_path / rel_path
+
+    def upload_file(self, rel_path: str, data: bytes, overwrite: bool = True) -> bool:
+        target = self._full(rel_path)
+        if not overwrite and target.exists():
+            return False
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+        return True
+
+    def download_file(self, rel_path: str) -> bytes:
+        return self._full(rel_path).read_bytes()
+
+    def list_files(self, prefix: str = "") -> List[str]:
+        base = self._full(prefix) if prefix else self._root_path
+        if not base.exists():
+            return []
+        return sorted(
+            str(path.relative_to(self._root_path)).replace(os.sep, "/")
+            for path in base.rglob("*")
+            if path.is_file()
+        )
+
+    def exists(self, rel_path: str) -> bool:
+        return self._full(rel_path).is_file()
+
+    def delete_prefix(self, prefix: str) -> int:
+        import shutil
+
+        base = self._full(prefix) if prefix else self._root_path
+        if not base.exists():
+            return 0
+        count = sum(1 for path in base.rglob("*") if path.is_file())
+        shutil.rmtree(base)
+        return count
+
+
+class AbfssArtifactStore(ArtifactStore):
+    """Azure Blob/ADLS Gen2 store for abfss:// artifact roots.
+
+    The blob endpoint is rebuilt from the account name via the configured
+    Azure environment (``AZURE_STORAGE_BLOB_ENDPOINT_SUFFIX`` /
+    ``AZURE_CLOUD``), exactly as the CLI resolved it before; the dfs host in
+    the URI only contributes the account name. A pre-built client may be
+    injected (Phase 2: the platform APIs pass their own).
+    """
+
+    def __init__(self, uri: str, *, blob_service_client: Any = None):
+        self.container, self.account, self.base_path = parse_abfss_uri(uri)
+        self.root = uri.rstrip("/")
+        self._client = blob_service_client
+
+    @property
+    def client(self) -> Any:
+        if self._client is None:
+            self._client = create_blob_service_client(self.account)
+        return self._client
+
+    def _blob(self, rel_path: str) -> str:
+        return f"{self.base_path}/{rel_path}" if self.base_path else rel_path
+
+    def _rel(self, blob_name: str) -> str:
+        if self.base_path and blob_name.startswith(f"{self.base_path}/"):
+            return blob_name[len(self.base_path) + 1 :]
+        return blob_name
+
+    def upload_file(self, rel_path: str, data: bytes, overwrite: bool = True) -> bool:
+        blob_client = self.client.get_blob_client(
+            container=self.container, blob=self._blob(rel_path)
+        )
+        if not overwrite:
+            try:
+                blob_client.get_blob_properties()
+                return False  # exists, skip
+            except Exception:
+                pass  # doesn't exist, proceed
+        blob_client.upload_blob(data, overwrite=True)
+        return True
+
+    def download_file(self, rel_path: str) -> bytes:
+        blob_client = self.client.get_blob_client(
+            container=self.container, blob=self._blob(rel_path)
+        )
+        return blob_client.download_blob().readall()
+
+    def list_files(self, prefix: str = "") -> List[str]:
+        full_prefix = self._blob(prefix) if prefix else self.base_path
+        list_prefix = (
+            f"{full_prefix}/"
+            if full_prefix and not full_prefix.endswith("/")
+            else (full_prefix or "")
+        )
+        container_client = self.client.get_container_client(self.container)
+        return sorted(
+            self._rel(blob.name)
+            for blob in container_client.list_blobs(name_starts_with=list_prefix)
+        )
+
+    def exists(self, rel_path: str) -> bool:
+        blob_client = self.client.get_blob_client(
+            container=self.container, blob=self._blob(rel_path)
+        )
+        try:
+            blob_client.get_blob_properties()
+            return True
+        except Exception:
+            return False
+
+    def delete_prefix(self, prefix: str) -> int:
+        count = 0
+        for rel_path in self.list_files(prefix):
+            blob_client = self.client.get_blob_client(
+                container=self.container, blob=self._blob(rel_path)
+            )
+            blob_client.delete_blob()
+            count += 1
+        return count
+
+
+class VolumesArtifactStore(ArtifactStore):
+    """Unity Catalog volume store, written through the Databricks Files API.
+
+    Requires Databricks credentials (see create_databricks_workspace_client);
+    the workspace client may be injected. Files API directory deletes are
+    non-recursive, so delete_prefix walks files first, then removes the
+    emptied directories deepest-first.
+    """
+
+    def __init__(self, root: str, *, workspace_client: Any = None):
+        segments = [segment for segment in root.strip("/").split("/") if segment]
+        if len(segments) < 4 or segments[0] != "Volumes":
+            raise ValueError(
+                f"Invalid volume artifacts path `{root}`. Expected "
+                "/Volumes/<catalog>/<schema>/<volume>[/path]."
+            )
+        self.root = "/" + "/".join(segments)
+        self._workspace_client = workspace_client
+        if self._workspace_client is None:
+            self._workspace_client = create_databricks_workspace_client()
+        from databricks.sdk.errors import NotFound
+
+        self._not_found = NotFound
+
+    @property
+    def _files(self) -> Any:
+        return self._workspace_client.files
+
+    def _full(self, rel_path: str) -> str:
+        return posixpath.join(self.root, rel_path) if rel_path else self.root
+
+    def _rel(self, full_path: str) -> str:
+        return (
+            full_path[len(self.root) + 1 :]
+            if full_path.startswith(f"{self.root}/")
+            else (full_path)
+        )
+
+    def upload_file(self, rel_path: str, data: bytes, overwrite: bool = True) -> bool:
+        full = self._full(rel_path)
+        if not overwrite and self.exists(rel_path):
+            return False
+        try:
+            self._files.upload(full, io.BytesIO(data), overwrite=True)
+        except self._not_found:
+            # Some workspace/API versions do not auto-create parent
+            # directories on upload.
+            self._files.create_directory(posixpath.dirname(full))
+            self._files.upload(full, io.BytesIO(data), overwrite=True)
+        return True
+
+    def download_file(self, rel_path: str) -> bytes:
+        response = self._files.download(self._full(rel_path))
+        return response.contents.read()
+
+    def list_files(self, prefix: str = "") -> List[str]:
+        base = self._full(prefix)
+        results: List[str] = []
+        stack = [base]
+        while stack:
+            directory = stack.pop()
+            try:
+                entries = list(self._files.list_directory_contents(directory))
+            except self._not_found:
+                continue
+            for entry in entries:
+                if entry.is_directory:
+                    stack.append(entry.path)
+                else:
+                    results.append(self._rel(entry.path))
+        return sorted(results)
+
+    def exists(self, rel_path: str) -> bool:
+        try:
+            self._files.get_metadata(self._full(rel_path))
+            return True
+        except self._not_found:
+            return False
+
+    def delete_prefix(self, prefix: str) -> int:
+        base = self._full(prefix)
+        files: List[str] = []
+        directories: List[str] = []
+        stack = [base]
+        while stack:
+            directory = stack.pop()
+            try:
+                entries = list(self._files.list_directory_contents(directory))
+            except self._not_found:
+                continue
+            directories.append(directory)
+            for entry in entries:
+                if entry.is_directory:
+                    stack.append(entry.path)
+                else:
+                    files.append(entry.path)
+        for file_path in files:
+            self._files.delete(file_path)
+        for directory in sorted(directories, key=lambda path: path.count("/"), reverse=True):
+            try:
+                self._files.delete_directory(directory)
+            except Exception:
+                pass  # base may be the volume root itself, which is not deletable
+        return len(files)
+
+
+def artifact_store_for(path: str, *, workspace_client: Any = None) -> ArtifactStore:
+    """Return the store implementation declared by ``path``'s shape.
+
+    The path string is the single source of truth — the same
+    ``artifacts_storage_path`` value the runtime interprets on-cluster.
+    """
+    candidate = (path or "").strip()
+    if not candidate:
+        raise ValueError(f"Artifacts path is empty. Expected {_SUPPORTED_ROOT_FORMS}.")
+    if candidate.startswith("abfss://"):
+        return AbfssArtifactStore(candidate)
+    if candidate == "/Volumes" or candidate.startswith("/Volumes/"):
+        return VolumesArtifactStore(candidate, workspace_client=workspace_client)
+    if candidate.startswith("dbfs:/"):
+        raise ValueError(
+            f"Unsupported artifacts path `{candidate}`: DBFS root storage is "
+            "deprecated by Databricks — use a Unity Catalog volume "
+            "(/Volumes/<catalog>/<schema>/<volume>/...) instead."
+        )
+    if candidate.startswith("file://"):
+        return LocalArtifactStore(candidate)
+    if "://" in candidate:
+        raise ValueError(
+            f"Unsupported artifacts path `{candidate}`. Expected {_SUPPORTED_ROOT_FORMS}."
+        )
+    local_candidate = Path(candidate).expanduser()
+    if not local_candidate.is_absolute() and not local_candidate.is_dir():
+        raise ValueError(
+            f"Unsupported artifacts path `{candidate}`. Expected {_SUPPORTED_ROOT_FORMS}."
+        )
+    return LocalArtifactStore(candidate)
+
+
+def resolve_artifacts_path(
+    explicit: Optional[str] = None,
+    *,
+    storage_account: Optional[str] = None,
+    container: Optional[str] = None,
+    base_path: Optional[str] = None,
+) -> str:
+    """Resolve the artifacts destination to a single path string.
+
+    Precedence: explicit path argument, then explicit legacy storage flags,
+    then the ``KINDLING_ARTIFACTS_STORAGE_PATH`` env var (the Dynaconf env
+    spelling of the runtime's ``artifacts_storage_path`` config key — one
+    value configures both sides), then the legacy ``AZURE_*`` env triple
+    synthesized to an abfss:// URI. Raises ValueError when nothing is
+    configured.
+    """
+    if explicit and explicit.strip():
+        return explicit.strip()
+
+    legacy_flags_given = bool(storage_account or container) or base_path is not None
+    if legacy_flags_given:
+        account = (storage_account or os.getenv("AZURE_STORAGE_ACCOUNT", "")).strip()
+        if not account:
+            raise ValueError(
+                "Storage account is required. Use --storage-account or set "
+                "AZURE_STORAGE_ACCOUNT."
+            )
+        resolved_container = container or os.getenv("AZURE_CONTAINER", "artifacts")
+        resolved_base = base_path if base_path is not None else os.getenv("AZURE_BASE_PATH", "")
+        return azure_abfss_uri(resolved_container, account, resolved_base)
+
+    env_path = os.getenv("KINDLING_ARTIFACTS_STORAGE_PATH", "").strip()
+    if env_path:
+        return env_path
+
+    account = os.getenv("AZURE_STORAGE_ACCOUNT", "").strip()
+    if account:
+        return azure_abfss_uri(
+            os.getenv("AZURE_CONTAINER", "artifacts"), account, os.getenv("AZURE_BASE_PATH", "")
+        )
+
+    raise ValueError(
+        "Artifacts location is not configured. Provide --artifacts-path, set "
+        "KINDLING_ARTIFACTS_STORAGE_PATH (e.g. "
+        "abfss://artifacts@acct.dfs.core.windows.net/kindling or "
+        "/Volumes/<catalog>/<schema>/<volume>/kindling), or set the legacy "
+        "AZURE_STORAGE_ACCOUNT (+ optional AZURE_CONTAINER, AZURE_BASE_PATH)."
+    )

--- a/packages/kindling_sdk/pyproject.toml
+++ b/packages/kindling_sdk/pyproject.toml
@@ -19,4 +19,6 @@ requests = ">=2.31.0"
 azure-identity = ">=1.15.0"
 azure-core = ">=1.30.0,<1.31.0"
 azure-storage-file-datalake = ">=12.14.0"
-databricks-sdk = ">=0.12.0"
+# >=0.20.0: Files API directory operations (files.list_directory_contents,
+# create_directory, delete_directory) used by the /Volumes artifact store.
+databricks-sdk = ">=0.20.0"

--- a/tests/unit/test_artifact_store.py
+++ b/tests/unit/test_artifact_store.py
@@ -1,0 +1,368 @@
+"""Unit tests for kindling_sdk.artifact_store (gh#207).
+
+Covers scheme dispatch, destination resolution precedence, and the three
+store backends: Local against a real tmp_path, Volumes against a stubbed
+Files API, and Abfss against a mocked BlobServiceClient.
+"""
+
+import io
+import posixpath
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from kindling_sdk.artifact_store import (
+    AbfssArtifactStore,
+    LocalArtifactStore,
+    VolumesArtifactStore,
+    artifact_store_for,
+    parse_abfss_uri,
+    resolve_artifacts_path,
+)
+
+_ENV_VARS = (
+    "KINDLING_ARTIFACTS_STORAGE_PATH",
+    "AZURE_STORAGE_ACCOUNT",
+    "AZURE_CONTAINER",
+    "AZURE_BASE_PATH",
+    "AZURE_STORAGE_DFS_ENDPOINT_SUFFIX",
+    "AZURE_STORAGE_BLOB_ENDPOINT_SUFFIX",
+    "AZURE_CLOUD",
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestDispatch:
+    def test_abfss_dispatches_to_abfss_store(self):
+        store = artifact_store_for("abfss://artifacts@acct.dfs.core.windows.net/kindling")
+        assert isinstance(store, AbfssArtifactStore)
+        assert store.container == "artifacts"
+        assert store.account == "acct"
+        assert store.base_path == "kindling"
+
+    def test_volumes_dispatches_to_volumes_store(self):
+        store = artifact_store_for("/Volumes/main/kindling/artifacts", workspace_client=MagicMock())
+        assert isinstance(store, VolumesArtifactStore)
+        assert store.root == "/Volumes/main/kindling/artifacts"
+
+    def test_file_uri_and_existing_dir_dispatch_to_local_store(self, tmp_path):
+        assert isinstance(artifact_store_for(f"file://{tmp_path}"), LocalArtifactStore)
+        assert isinstance(artifact_store_for(str(tmp_path)), LocalArtifactStore)
+
+    def test_dbfs_rejected_with_volume_hint(self):
+        with pytest.raises(ValueError, match="deprecated.*Unity Catalog volume"):
+            artifact_store_for("dbfs:/FileStore/kindling")
+
+    def test_unknown_scheme_rejected(self):
+        with pytest.raises(ValueError, match="Unsupported artifacts path"):
+            artifact_store_for("ftp://host/path")
+
+    def test_relative_nonexistent_path_rejected(self):
+        with pytest.raises(ValueError, match="Unsupported artifacts path"):
+            artifact_store_for("not-an-abfss-uri")
+
+    def test_empty_path_rejected(self):
+        with pytest.raises(ValueError, match="empty"):
+            artifact_store_for("")
+
+    def test_truncated_volume_path_rejected(self):
+        with pytest.raises(ValueError, match="/Volumes/<catalog>/<schema>/<volume>"):
+            artifact_store_for("/Volumes/main/kindling", workspace_client=MagicMock())
+
+
+class TestResolveArtifactsPath:
+    def test_explicit_path_wins(self, monkeypatch):
+        monkeypatch.setenv("KINDLING_ARTIFACTS_STORAGE_PATH", "/Volumes/a/b/c")
+        assert resolve_artifacts_path("/Volumes/x/y/z") == "/Volumes/x/y/z"
+
+    def test_legacy_flags_win_over_env_path(self, monkeypatch):
+        monkeypatch.setenv("KINDLING_ARTIFACTS_STORAGE_PATH", "/Volumes/a/b/c")
+        resolved = resolve_artifacts_path(None, storage_account="acct")
+        assert resolved == "abfss://artifacts@acct.dfs.core.windows.net"
+
+    def test_env_path_wins_over_legacy_env_triple(self, monkeypatch):
+        monkeypatch.setenv("KINDLING_ARTIFACTS_STORAGE_PATH", "/Volumes/a/b/c")
+        monkeypatch.setenv("AZURE_STORAGE_ACCOUNT", "acct")
+        assert resolve_artifacts_path() == "/Volumes/a/b/c"
+
+    def test_legacy_env_triple_synthesizes_abfss(self, monkeypatch):
+        monkeypatch.setenv("AZURE_STORAGE_ACCOUNT", "acct")
+        monkeypatch.setenv("AZURE_CONTAINER", "deploy")
+        monkeypatch.setenv("AZURE_BASE_PATH", "kindling")
+        assert resolve_artifacts_path() == "abfss://deploy@acct.dfs.core.windows.net/kindling"
+
+    def test_synthesis_honors_dfs_endpoint_suffix(self, monkeypatch):
+        monkeypatch.setenv("AZURE_STORAGE_ACCOUNT", "acct")
+        monkeypatch.setenv("AZURE_STORAGE_DFS_ENDPOINT_SUFFIX", "dfs.core.usgovcloudapi.net")
+        assert resolve_artifacts_path() == "abfss://artifacts@acct.dfs.core.usgovcloudapi.net"
+
+    def test_synthesis_honors_azure_cloud(self, monkeypatch):
+        monkeypatch.setenv("AZURE_STORAGE_ACCOUNT", "govacct")
+        monkeypatch.setenv("AZURE_CLOUD", "AzureUSGovernment")
+        assert resolve_artifacts_path() == "abfss://artifacts@govacct.dfs.core.usgovcloudapi.net"
+
+    def test_legacy_flags_without_account_raise_current_message(self):
+        with pytest.raises(ValueError, match="Storage account is required"):
+            resolve_artifacts_path(None, container="artifacts")
+
+    def test_nothing_configured_raises_actionable_error(self):
+        with pytest.raises(ValueError) as exc_info:
+            resolve_artifacts_path()
+        message = str(exc_info.value)
+        assert "KINDLING_ARTIFACTS_STORAGE_PATH" in message
+        assert "AZURE_STORAGE_ACCOUNT" in message
+        assert "--artifacts-path" in message
+
+
+class TestLocalArtifactStore:
+    def test_round_trip(self, tmp_path):
+        store = LocalArtifactStore(str(tmp_path))
+
+        assert store.upload_file("config/settings.yaml", b"kindling: {}") is True
+        assert store.upload_file("packages/a.whl", b"wheel") is True
+        assert store.download_file("config/settings.yaml") == b"kindling: {}"
+        assert store.exists("packages/a.whl") is True
+        assert store.exists("packages/missing.whl") is False
+        assert store.list_files() == ["config/settings.yaml", "packages/a.whl"]
+        assert store.list_files("packages") == ["packages/a.whl"]
+        assert store.delete_prefix("packages") == 1
+        assert store.list_files("packages") == []
+
+    def test_overwrite_false_skips_existing(self, tmp_path):
+        store = LocalArtifactStore(str(tmp_path))
+        store.upload_file("scripts/kindling_bootstrap.py", b"one")
+
+        assert store.upload_file("scripts/kindling_bootstrap.py", b"two", overwrite=False) is (
+            False
+        )
+        assert store.download_file("scripts/kindling_bootstrap.py") == b"one"
+
+    def test_file_uri_root(self, tmp_path):
+        store = LocalArtifactStore(f"file://{tmp_path}")
+        store.upload_file("a.txt", b"x")
+        assert (tmp_path / "a.txt").read_bytes() == b"x"
+
+
+def _make_fake_blob_service_client(existing=None):
+    """Fake BlobServiceClient with dict-backed blobs and prefix listing."""
+    blobs = dict(existing or {})
+
+    def get_blob_client(container, blob):
+        client = MagicMock()
+
+        def get_properties():
+            if blob not in blobs:
+                raise Exception("not found")
+            return {}
+
+        client.get_blob_properties.side_effect = get_properties
+        client.upload_blob.side_effect = lambda data, overwrite=True: blobs.__setitem__(blob, data)
+        client.download_blob.side_effect = lambda: SimpleNamespace(readall=lambda: blobs[blob])
+        client.delete_blob.side_effect = lambda: blobs.pop(blob)
+        return client
+
+    def get_container_client(container):
+        container_client = MagicMock()
+        container_client.list_blobs.side_effect = lambda name_starts_with="": [
+            SimpleNamespace(name=name)
+            for name in sorted(blobs)
+            if name.startswith(name_starts_with)
+        ]
+        return container_client
+
+    service_client = MagicMock()
+    service_client.get_blob_client.side_effect = get_blob_client
+    service_client.get_container_client.side_effect = get_container_client
+    service_client._blobs = blobs
+    return service_client
+
+
+class TestAbfssArtifactStore:
+    URI = "abfss://artifacts@acct.dfs.core.windows.net/kindling"
+
+    def _store(self, existing=None):
+        client = _make_fake_blob_service_client(existing)
+        return AbfssArtifactStore(self.URI, blob_service_client=client), client
+
+    def test_upload_prefixes_base_path(self):
+        store, client = self._store()
+        assert store.upload_file("packages/a.whl", b"wheel") is True
+        assert client._blobs == {"kindling/packages/a.whl": b"wheel"}
+
+    def test_overwrite_false_skips_existing_blob(self):
+        store, client = self._store(existing={"kindling/scripts/boot.py": b"one"})
+        assert store.upload_file("scripts/boot.py", b"two", overwrite=False) is False
+        assert client._blobs["kindling/scripts/boot.py"] == b"one"
+
+    def test_list_files_returns_root_relative_paths(self):
+        store, _ = self._store(
+            existing={
+                "kindling/packages/a.whl": b"1",
+                "kindling/packages/nested/b.whl": b"2",
+                "kindling/scripts/boot.py": b"3",
+                "unrelated/other.txt": b"4",
+            }
+        )
+        assert store.list_files("packages") == ["packages/a.whl", "packages/nested/b.whl"]
+        assert store.list_files() == [
+            "packages/a.whl",
+            "packages/nested/b.whl",
+            "scripts/boot.py",
+        ]
+
+    def test_download_exists_delete(self):
+        store, client = self._store(existing={"kindling/packages/a.whl": b"wheel"})
+        assert store.download_file("packages/a.whl") == b"wheel"
+        assert store.exists("packages/a.whl") is True
+        assert store.exists("packages/b.whl") is False
+        assert store.delete_prefix("packages") == 1
+        assert client._blobs == {}
+
+    def test_no_base_path_uses_container_root(self):
+        client = _make_fake_blob_service_client()
+        store = AbfssArtifactStore(
+            "abfss://artifacts@acct.dfs.core.windows.net", blob_service_client=client
+        )
+        store.upload_file("packages/a.whl", b"wheel")
+        assert client._blobs == {"packages/a.whl": b"wheel"}
+
+    @pytest.mark.parametrize(
+        ("uri", "match"),
+        [
+            ("https://acct.blob.core.windows.net/c", "Invalid destination URI"),
+            ("abfss://artifacts.dfs.core.windows.net/p", "Missing '@' separator"),
+            ("abfss://@acct.dfs.core.windows.net/p", "Container name is empty"),
+            ("abfss://c@accountnodot/p", "does not contain a domain suffix"),
+        ],
+    )
+    def test_malformed_uris_raise_current_messages(self, uri, match):
+        with pytest.raises(ValueError, match=match):
+            parse_abfss_uri(uri)
+
+
+class _FakeFilesAPI:
+    """Dict-backed stub of WorkspaceClient.files raising real NotFound."""
+
+    def __init__(self, require_parent_dirs=False):
+        from databricks.sdk.errors import NotFound
+
+        self._not_found = NotFound
+        self.require_parent_dirs = require_parent_dirs
+        self.files = {}
+        self.dirs = set()
+        self.deleted_directories = []
+
+    def upload(self, path, contents, overwrite=None):
+        if self.require_parent_dirs and posixpath.dirname(path) not in self.dirs:
+            raise self._not_found(f"parent of {path} does not exist")
+        self.files[path] = contents.read()
+
+    def download(self, path):
+        if path not in self.files:
+            raise self._not_found(path)
+        return SimpleNamespace(contents=io.BytesIO(self.files[path]))
+
+    def get_metadata(self, path):
+        if path not in self.files:
+            raise self._not_found(path)
+        return {}
+
+    def create_directory(self, path):
+        self.dirs.add(path)
+
+    def list_directory_contents(self, directory):
+        directory = directory.rstrip("/")
+        children = {}
+        for path in self.files:
+            if path.startswith(f"{directory}/"):
+                rest = path[len(directory) + 1 :]
+                head = rest.split("/", 1)[0]
+                children[f"{directory}/{head}"] = "/" in rest
+        if not children:
+            raise self._not_found(directory)
+        return [
+            SimpleNamespace(path=path, is_directory=is_dir) for path, is_dir in children.items()
+        ]
+
+    def delete(self, path):
+        del self.files[path]
+
+    def delete_directory(self, path):
+        self.deleted_directories.append(path)
+
+
+def _make_volumes_store(require_parent_dirs=False):
+    files_api = _FakeFilesAPI(require_parent_dirs=require_parent_dirs)
+    workspace_client = SimpleNamespace(files=files_api)
+    store = VolumesArtifactStore(
+        "/Volumes/main/kindling/artifacts", workspace_client=workspace_client
+    )
+    return store, files_api
+
+
+class TestVolumesArtifactStore:
+    def test_upload_maps_to_full_volume_path(self):
+        store, files_api = _make_volumes_store()
+        assert store.upload_file("packages/a.whl", b"wheel") is True
+        assert files_api.files == {"/Volumes/main/kindling/artifacts/packages/a.whl": b"wheel"}
+
+    def test_upload_ensures_parent_directory_on_not_found(self):
+        store, files_api = _make_volumes_store(require_parent_dirs=True)
+        assert store.upload_file("packages/a.whl", b"wheel") is True
+        assert "/Volumes/main/kindling/artifacts/packages" in files_api.dirs
+        assert files_api.files == {"/Volumes/main/kindling/artifacts/packages/a.whl": b"wheel"}
+
+    def test_overwrite_false_skips_existing_file(self):
+        store, files_api = _make_volumes_store()
+        store.upload_file("scripts/boot.py", b"one")
+        assert store.upload_file("scripts/boot.py", b"two", overwrite=False) is False
+        assert files_api.files["/Volumes/main/kindling/artifacts/scripts/boot.py"] == b"one"
+
+    def test_exists_via_get_metadata_not_found(self):
+        store, _ = _make_volumes_store()
+        store.upload_file("packages/a.whl", b"wheel")
+        assert store.exists("packages/a.whl") is True
+        assert store.exists("packages/missing.whl") is False
+
+    def test_list_files_walks_recursively(self):
+        store, _ = _make_volumes_store()
+        store.upload_file("packages/a.whl", b"1")
+        store.upload_file("packages/nested/b.whl", b"2")
+        store.upload_file("scripts/boot.py", b"3")
+        assert store.list_files() == [
+            "packages/a.whl",
+            "packages/nested/b.whl",
+            "scripts/boot.py",
+        ]
+        assert store.list_files("packages") == ["packages/a.whl", "packages/nested/b.whl"]
+        assert store.list_files("empty") == []
+
+    def test_download_round_trip(self):
+        store, _ = _make_volumes_store()
+        store.upload_file("config/settings.yaml", b"kindling: {}")
+        assert store.download_file("config/settings.yaml") == b"kindling: {}"
+
+    def test_delete_prefix_removes_files_then_directories(self):
+        store, files_api = _make_volumes_store()
+        store.upload_file("packages/a.whl", b"1")
+        store.upload_file("packages/nested/b.whl", b"2")
+        store.upload_file("scripts/boot.py", b"3")
+
+        assert store.delete_prefix("packages") == 2
+
+        assert list(files_api.files) == ["/Volumes/main/kindling/artifacts/scripts/boot.py"]
+        # Directories removed deepest-first, after their files.
+        assert files_api.deleted_directories == [
+            "/Volumes/main/kindling/artifacts/packages/nested",
+            "/Volumes/main/kindling/artifacts/packages",
+        ]
+
+    def test_missing_databricks_host_raises_credentials_hint(self, monkeypatch):
+        monkeypatch.delenv("DATABRICKS_HOST", raising=False)
+        with pytest.raises(ValueError, match="DATABRICKS_HOST.*Files API"):
+            VolumesArtifactStore("/Volumes/main/kindling/artifacts")

--- a/tests/unit/test_artifact_store.py
+++ b/tests/unit/test_artifact_store.py
@@ -366,3 +366,53 @@ class TestVolumesArtifactStore:
         monkeypatch.delenv("DATABRICKS_HOST", raising=False)
         with pytest.raises(ValueError, match="DATABRICKS_HOST.*Files API"):
             VolumesArtifactStore("/Volumes/main/kindling/artifacts")
+
+
+_ROOT_ESCAPING_PATHS = (
+    "/etc/passwd",  # posix absolute discards the joined root
+    "../outside.txt",
+    "packages/../../outside.txt",
+    "..",
+    "..\\outside.txt",  # Windows-style traversal
+    "C:\\outside.txt",  # Windows drive-absolute
+    "C:outside.txt",  # Windows drive-relative
+    "\\\\server\\share\\x",  # UNC
+)
+
+
+class TestRelPathValidation:
+    """Root-relative contract: paths from remote listings (store-to-store
+    copies) must not be able to address anything outside the artifacts root."""
+
+    @pytest.mark.parametrize("bad", _ROOT_ESCAPING_PATHS)
+    def test_local_store_rejects_root_escaping_paths(self, tmp_path, bad):
+        store = LocalArtifactStore(str(tmp_path / "root"))
+        with pytest.raises(ValueError, match="Artifact path"):
+            store.upload_file(bad, b"x")
+        with pytest.raises(ValueError, match="Artifact path"):
+            store.exists(bad)
+        with pytest.raises(ValueError, match="Artifact path"):
+            store.delete_prefix(bad)
+
+    @pytest.mark.parametrize("bad", _ROOT_ESCAPING_PATHS)
+    def test_abfss_store_rejects_root_escaping_paths(self, bad):
+        client = _make_fake_blob_service_client()
+        store = AbfssArtifactStore(
+            "abfss://artifacts@acct.dfs.core.windows.net/kindling",
+            blob_service_client=client,
+        )
+        with pytest.raises(ValueError, match="Artifact path"):
+            store.upload_file(bad, b"x")
+        assert client._blobs == {}
+
+    @pytest.mark.parametrize("bad", _ROOT_ESCAPING_PATHS)
+    def test_volumes_store_rejects_root_escaping_paths(self, bad):
+        store, files_api = _make_volumes_store()
+        with pytest.raises(ValueError, match="Artifact path"):
+            store.upload_file(bad, b"x")
+        assert files_api.files == {}
+
+    def test_nested_relative_paths_still_accepted(self, tmp_path):
+        store = LocalArtifactStore(str(tmp_path))
+        assert store.upload_file("data-apps/app/config/settings.yaml", b"x") is True
+        assert store.download_file("data-apps/app/config/settings.yaml") == b"x"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1039,10 +1039,8 @@ def test_package_deploy_builds_wheel_and_uploads_to_artifacts_packages(
         (dist / "domain_records-1.2.3-py3-none-any.whl").write_bytes(b"wheel")
         return types.SimpleNamespace(returncode=0, stdout="", stderr="")
 
-    def fake_deploy_wheels(blob_service_client, container, packages_path, wheels):
-        calls["blob_service_client"] = blob_service_client
-        calls["container"] = container
-        calls["packages_path"] = packages_path
+    def fake_deploy_wheels(store, wheels, quiet=False):
+        calls["store"] = store
         calls["wheels"] = wheels
         return len(wheels)
 
@@ -1093,8 +1091,8 @@ version = "1.2.3"
             str(package_dir.resolve() / "dist"),
         ]
         assert calls["build_cwd"] == package_dir.resolve()
-        assert calls["container"] == "artifacts"
-        assert calls["packages_path"] == "dev/packages"
+        assert calls["store"].container == "artifacts"
+        assert calls["store"].base_path == "dev"
         assert [wheel.name for wheel in calls["wheels"]] == [
             "domain_records-1.2.3-py3-none-any.whl"
         ]
@@ -1322,9 +1320,7 @@ class TestWorkspaceInit:
         deployed = []
         monkeypatch.setattr(
             "kindling_cli.cli._deploy_config",
-            lambda client, container, base, config, overwrite=False, **kwargs: deployed.append(
-                config
-            ),
+            lambda store, config, overwrite=False, **kwargs: deployed.append(config),
         )
         runner = CliRunner()
         with runner.isolated_filesystem():
@@ -1366,9 +1362,7 @@ class TestWorkspaceInit:
         calls = []
         monkeypatch.setattr(
             "kindling_cli.cli._deploy_config",
-            lambda client, container, base, config, overwrite=False, **kwargs: calls.append(
-                overwrite
-            ),
+            lambda store, config, overwrite=False, **kwargs: calls.append(overwrite),
         )
         runner = CliRunner()
         with runner.isolated_filesystem():
@@ -3366,6 +3360,7 @@ def test_deploy_config_uploads_only_selected_overlays(tmp_path):
     from unittest.mock import MagicMock
 
     from kindling_cli.cli import _deploy_config
+    from kindling_sdk.artifact_store import AbfssArtifactStore
 
     config_dir = tmp_path / "config"
     config_dir.mkdir()
@@ -3393,10 +3388,12 @@ def test_deploy_config_uploads_only_selected_overlays(tmp_path):
     blob_service_client = MagicMock()
     blob_service_client.get_blob_client.side_effect = get_blob_client
 
+    store = AbfssArtifactStore(
+        "abfss://artifacts@acct.dfs.core.windows.net/base",
+        blob_service_client=blob_service_client,
+    )
     _deploy_config(
-        blob_service_client,
-        "artifacts",
-        "base",
+        store,
         config_dir / "settings.yaml",
         platform="fabric",
         environment="prod",
@@ -3667,3 +3664,232 @@ class TestNotebookCommands:
         roundtripped = [(c["cell_type"], "".join(c["source"])) for c in nb["cells"]]
         original = [(c["cell_type"], "".join(c["source"])) for c in cells]
         assert roundtripped == original
+
+
+# ---------------------------------------------------------------------------
+# artifact store destinations (gh#207)
+# ---------------------------------------------------------------------------
+
+_ARTIFACTS_ENV_VARS = (
+    "KINDLING_ARTIFACTS_STORAGE_PATH",
+    "AZURE_STORAGE_ACCOUNT",
+    "AZURE_CONTAINER",
+    "AZURE_BASE_PATH",
+)
+
+
+def _clear_artifacts_env(monkeypatch):
+    for var in _ARTIFACTS_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestArtifactStoreDestinations:
+    """CLI deploy commands against non-Azure artifact roots — no Azure mocks."""
+
+    def test_workspace_init_deploys_config_to_local_store(self, tmp_path, monkeypatch):
+        _clear_artifacts_env(monkeypatch)
+        monkeypatch.setenv("KINDLING_ARTIFACTS_STORAGE_PATH", str(tmp_path))
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path("settings.yaml").write_text("kindling:\n  name: test\n")
+            result = runner.invoke(cli, ["workspace", "init", "--platform", "fabric"])
+
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "config" / "settings.yaml").read_text() == "kindling:\n  name: test\n"
+
+    def test_workspace_deploy_respects_overwrite_on_local_store(self, tmp_path, monkeypatch):
+        _clear_artifacts_env(monkeypatch)
+        monkeypatch.setenv("KINDLING_ARTIFACTS_STORAGE_PATH", str(tmp_path))
+        (tmp_path / "config").mkdir()
+        (tmp_path / "config" / "settings.yaml").write_text("existing")
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path("settings.yaml").write_text("updated")
+            skipped = runner.invoke(cli, ["workspace", "deploy", "--platform", "fabric"])
+            overwritten = runner.invoke(
+                cli, ["workspace", "deploy", "--platform", "fabric", "--overwrite"]
+            )
+
+        assert skipped.exit_code == 0, skipped.output
+        assert "(exists, skipped)" in skipped.output
+        assert overwritten.exit_code == 0, overwritten.output
+        assert (tmp_path / "config" / "settings.yaml").read_text() == "updated"
+
+    def test_package_deploy_uploads_to_local_store_with_scheme_neutral_json(
+        self, tmp_path, monkeypatch
+    ):
+        _clear_artifacts_env(monkeypatch)
+        monkeypatch.setenv("KINDLING_ARTIFACTS_STORAGE_PATH", str(tmp_path))
+
+        def fake_run(cmd, cwd=None, capture_output=False, text=False):
+            dist = Path(cwd) / "dist"
+            dist.mkdir(exist_ok=True)
+            (dist / "domain_records-1.2.3-py3-none-any.whl").write_bytes(b"wheel")
+            return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("kindling_cli.cli.subprocess.run", fake_run)
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            package_dir = Path("packages/domain_records")
+            package_dir.mkdir(parents=True)
+            (package_dir / "pyproject.toml").write_text(
+                '[tool.poetry]\nname = "domain-records"\nversion = "1.2.3"\n',
+                encoding="utf-8",
+            )
+            result = runner.invoke(
+                cli,
+                [
+                    "package",
+                    "deploy",
+                    "domain-records",
+                    "--local-folder",
+                    str(package_dir),
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "packages" / "domain_records-1.2.3-py3-none-any.whl").exists()
+        payload = json.loads(result.output[result.output.index("{") :])
+        assert payload["artifacts_path"] == str(tmp_path)
+        assert payload["packages_path"] == "packages"
+        assert "storage_account" not in payload
+        assert "container" not in payload
+
+    def test_package_deploy_json_keeps_legacy_fields_for_abfss(self, monkeypatch):
+        _clear_artifacts_env(monkeypatch)
+
+        def fake_run(cmd, cwd=None, capture_output=False, text=False):
+            dist = Path(cwd) / "dist"
+            dist.mkdir(exist_ok=True)
+            (dist / "domain_records-1.2.3-py3-none-any.whl").write_bytes(b"wheel")
+            return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("kindling_cli.cli.subprocess.run", fake_run)
+        monkeypatch.setattr(
+            "kindling_cli.cli._deploy_wheels",
+            lambda store, wheels, quiet=False: len(wheels),
+        )
+        monkeypatch.setattr("kindling_cli.cli._get_blob_service_client", lambda account: object())
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            package_dir = Path("packages/domain_records")
+            package_dir.mkdir(parents=True)
+            (package_dir / "pyproject.toml").write_text(
+                '[tool.poetry]\nname = "domain-records"\nversion = "1.2.3"\n',
+                encoding="utf-8",
+            )
+            result = runner.invoke(
+                cli,
+                [
+                    "package",
+                    "deploy",
+                    "domain-records",
+                    "--local-folder",
+                    str(package_dir),
+                    "--storage-account",
+                    "acct",
+                    "--base-path",
+                    "dev",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output[result.output.index("{") :])
+        assert payload["artifacts_path"] == "abfss://artifacts@acct.dfs.core.windows.net/dev"
+        assert payload["storage_account"] == "acct"
+        assert payload["container"] == "artifacts"
+        assert payload["packages_path"] == "dev/packages"
+
+    def test_runtime_deploy_local_source_to_local_store(self, tmp_path, monkeypatch):
+        _clear_artifacts_env(monkeypatch)
+        source_dir = tmp_path / "dist"
+        source_dir.mkdir()
+        (source_dir / "spark_kindling-0.9.25-py3-none-any.whl").write_bytes(b"fake-wheel")
+        dest_dir = tmp_path / "artifacts"
+        dest_dir.mkdir()
+
+        result = CliRunner().invoke(
+            cli,
+            [
+                "runtime",
+                "deploy",
+                "--source",
+                f"local:{source_dir}",
+                "--dest",
+                str(dest_dir),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert (dest_dir / "packages" / "spark_kindling-0.9.25-py3-none-any.whl").exists()
+
+    def test_runtime_deploy_accepts_volumes_dest(self, tmp_path, monkeypatch):
+        _clear_artifacts_env(monkeypatch)
+        source_dir = tmp_path / "dist"
+        source_dir.mkdir()
+        (source_dir / "spark_kindling-0.9.25-py3-none-any.whl").write_bytes(b"fake-wheel")
+
+        uploaded = {}
+
+        class _FilesStub:
+            def upload(self, path, contents, overwrite=None):
+                uploaded[path] = contents.read()
+
+            def get_metadata(self, path):
+                from databricks.sdk.errors import NotFound
+
+                raise NotFound(path)
+
+        monkeypatch.setattr(
+            "kindling_sdk.artifact_store.create_databricks_workspace_client",
+            lambda host=None: types.SimpleNamespace(files=_FilesStub()),
+        )
+
+        result = CliRunner().invoke(
+            cli,
+            [
+                "runtime",
+                "deploy",
+                "--source",
+                f"local:{source_dir}",
+                "--dest",
+                "/Volumes/main/kindling/artifacts",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert (
+            "/Volumes/main/kindling/artifacts/packages/spark_kindling-0.9.25-py3-none-any.whl"
+            in uploaded
+        )
+
+    def test_runtime_deploy_rejects_dbfs_dest(self, tmp_path, monkeypatch):
+        _clear_artifacts_env(monkeypatch)
+        result = CliRunner().invoke(
+            cli,
+            [
+                "runtime",
+                "deploy",
+                "--source",
+                f"local:{tmp_path}",
+                "--dest",
+                "dbfs:/FileStore/kindling",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "Unity Catalog volume" in result.output
+
+    def test_legacy_azure_env_resolves_to_same_abfss_destination(self, monkeypatch):
+        _clear_artifacts_env(monkeypatch)
+        monkeypatch.setenv("AZURE_STORAGE_ACCOUNT", "acct")
+        monkeypatch.setenv("AZURE_CONTAINER", "deploy")
+        monkeypatch.setenv("AZURE_BASE_PATH", "kindling")
+
+        from kindling_cli.cli import _resolve_destination
+
+        assert _resolve_destination() == "abfss://deploy@acct.dfs.core.windows.net/kindling"


### PR DESCRIPTION
## Summary

Introduces `kindling_sdk.artifact_store` (Phase 1 of #207): the artifacts path's shape now declares the design-time write backend, matching how the runtime already interprets the same `artifacts_storage_path` string.

- **`ArtifactStore` ABC** with root-relative operations (upload/download/list/exists/delete_prefix) and three backends:
  - `AbfssArtifactStore` — existing `BlobServiceClient` logic moved in; sovereign-cloud endpoint handling and overwrite/skip semantics unchanged
  - `VolumesArtifactStore` — databricks-sdk Files API; parent-dir ensure on upload, recursive list walk, files-then-directories delete
  - `LocalArtifactStore` — tests and local dev
- **`artifact_store_for(path)` dispatch**: `abfss://` | `/Volumes/...` | `file://` | existing local dir; `dbfs:/` rejected with a Unity Catalog volume hint
- **`resolve_artifacts_path()`**: one resolution chain — explicit path → legacy storage flags → `KINDLING_ARTIFACTS_STORAGE_PATH` (the Dynaconf env spelling of the runtime's existing `artifacts_storage_path` key, so one variable configures both sides) → legacy `AZURE_*` env triple synthesized to abfss
- **`create_databricks_workspace_client()`**: shared auth chain (token, `AZURE_*` service principal, azure-cli), mirroring `DatabricksAPI` for Phase 2 reuse
- **CLI rewired onto stores**: workspace init/deploy, package deploy, runtime deploy (`--source`/`--dest` accept any store root; cross-backend staging→prod promotion via store-to-store copy), app run version check. New `--artifacts-path` option on the three deploy commands; legacy `--storage-account`/`--container`/`--base-path` remain supported
- **`package deploy --json`**: scheme-neutral `artifacts_path` field; deprecated `storage_account`/`container` kept for abfss; per-wheel progress echoes no longer contaminate JSON stdout
- `kindling_sdk` now requires `databricks-sdk >=0.20.0` (Files API directory operations)

Phase 1 of #207; SDK `deploy_app` dedupe and test-cleanup/docs follow in later phases.

## Test plan

- `poe test-unit`: **2169 passed**, 1 skipped (includes 368 lines of new `test_artifact_store.py` coverage)
- `poe test-integration`: **122 passed**, 1 skipped — KDA packaging/deployment simulation and full local Spark suite
- Internal review: APPROVED WITH NOTES — two non-blocking MINOR nits (newly-dead `platform_provider` imports in `cli.py`; `VolumesArtifactStore` eager vs. abfss lazy auth) deferred to Phase 2 cleanup
- gitleaks scan of push range: clean

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)
