### PR TITLE
feat(config): overlay datapipes:/dataentities: config onto registered metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,25 @@ All notable changes to spark-kindling are documented here.
   contaminates JSON stdout with per-wheel progress echoes. Requires
   databricks-sdk >= 0.20.0 (Files API directory operations) for volume
   roots.
+- **Config override overlay for pipes and entities**: top-level
+  `datapipes:`/`dataentities:` config sections now overlay registered
+  `PipeMetadata`/`EntityMetadata` via `ConfigPatternMatcher` glob patterns
+  (gh#30). Bootstrap applies the overlay once after local package
+  registrations import; the compiled patterns persist on the managers, so
+  later registrations (workspace packages, app `register_all()`, notebook
+  cells) are overlaid at registration — before anything executes.
+  Resolution always starts from the original declaration params, so the
+  pass is idempotent and re-callable for hot reload
+  (`config_service.reload()` + `bootstrap.apply_config_overrides()`).
+  Identity and structural fields (`pipeid`/`execute`,
+  `entityid`/`schema`/`sql`) are never overridable; underscore keys
+  (`_enabled`, `_remove_tags`, ...) are carried inertly until gh#32.
+  Entity validation re-runs on overlaid metadata (failing fast at
+  bootstrap with config-overlay context), and SCD2 current-row companions
+  converge with config — enabling SCD by config creates the companion,
+  disabling it removes the auto-created one. Runtime channels keep their
+  per-read precedence above baked patterns: `set_entity_tags`, then
+  `tag_overrides`.
 - **Wildcard config pattern engine**: new `kindling.config_patterns` module
   with `ConfigPatternMatcher` — glob patterns (`*`, `?`, `**`) over
   dot-segmented pipe/entity ids, tiered specificity (exact > single

--- a/docs/proposals/package_config_architecture.md
+++ b/docs/proposals/package_config_architecture.md
@@ -832,6 +832,51 @@ class ConfigPatternMatcher:
 
 ### Phase 2: Registry with Config Overlay
 
+> **Implementation note (2026-07-28):** Phase 2 shipped in
+> `data_pipes.py`/`data_entities.py`/`bootstrap.py` (gh#30). The reference
+> sketches below are kept unchanged for history; the shipped semantics
+> follow them except for four deliberate deltas:
+>
+> 1. **Overlay-at-registration, not only one bootstrap pass.** The
+>    compiled matcher persists on each manager after
+>    `apply_config_overrides()`, and `register_pipe`/`register_entity`
+>    build stored metadata through the same overlay path. Registrations
+>    keep happening after bootstrap's pass (workspace packages, app
+>    `register_all()`, notebook cells); the acceptance criterion is
+>    overrides applied before anything *executes*, and the persisted
+>    matcher makes that invariant structural. With no
+>    `datapipes:`/`dataentities:` config the matcher is empty and
+>    registration behavior is byte-for-byte unchanged.
+> 2. **The per-read runtime channels are retained, not retired.** The
+>    durable file-config channel (`dataentities:` patterns) is baked into
+>    stored metadata as proposed, but `get_entity_definition()` keeps its
+>    retrieval-time merges for `set_entity_tags` (runtime-mutable — the
+>    ADX provider's documented per-run windowing loop depends on it) and
+>    the `tag_overrides` context (JIT parameters). Precedence, lowest to
+>    highest: declared params < `dataentities:` patterns (baked) <
+>    `set_entity_tags` (per-read) < `tag_overrides` (per-read).
+> 3. **Underscore keys are carried inertly, not interpreted.** `_enabled`
+>    and friends resolve through the matcher but are dropped (with a
+>    debug log) when metadata is constructed — Phase 3 (gh#32) interprets
+>    them at exactly that seam. The sketch's `_internal_enabled` field
+>    does not exist. Identity/structural fields (`pipeid`+`execute`;
+>    `entityid`+`schema`+`sql`) are never config-overridable.
+> 4. **Bootstrap fetches the managers by their registry ABCs.** The
+>    Phase 3 sketch resolves `DataPipesManager`/`DataEntityManager`
+>    directly, but the injector caches interface and concrete-class
+>    bindings as *separate* singletons — decorators register into the
+>    `DataPipesRegistry`/`DataEntityRegistry` instances, so the shipped
+>    `bootstrap.apply_config_overrides()` resolves those (and skips a
+>    custom-bound registry that lacks the method).
+>
+> SCD2 current-row companions converge as derived state on every apply
+> pass: config enabling SCD creates the companion (with registration
+> signals), disabling it or changing `scd.current_entity_id` removes the
+> stale auto-created one, and a still-desired companion is rebuilt
+> silently from its overlaid base. Entity validation re-runs on overlaid
+> metadata at registration and at every apply pass, wrapping failures
+> with the entity id and config-overlay context.
+
 ```python
 # packages/kindling/data_pipes.py (revised)
 
@@ -1150,12 +1195,13 @@ dataentities:
 ### Phase 2: Config Overlay (Week 3-4)
 
 ```
-- [ ] Add apply_config_overrides() to DataPipesManager (retain raw params, overlay on top)
-- [ ] Add apply_config_overrides() to DataEntityManager (same pattern; retire the
-      existing lazy per-read merge in get_entity_definition() in favor of this)
-- [ ] Call apply_config_overrides() from bootstrap after config load
-- [ ] Ensure backward compatibility (registration behavior is unchanged)
-- [ ] Write integration tests, including hot-reload re-overlay
+- [x] Add apply_config_overrides() to DataPipesManager (retain raw params, overlay on top)
+- [x] Add apply_config_overrides() to DataEntityManager (same pattern; the per-read
+      merge in get_entity_definition() is retained for the runtime channels — see
+      the Phase 2 implementation note)
+- [x] Call apply_config_overrides() from bootstrap after config load
+- [x] Ensure backward compatibility (registration behavior is unchanged)
+- [x] Write integration tests, including hot-reload re-overlay
 ```
 
 ### Phase 3: Tag Management & Features (Week 5)

--- a/packages/kindling/bootstrap.py
+++ b/packages/kindling/bootstrap.py
@@ -171,6 +171,42 @@ def _import_local_package_registrations(logger) -> None:
     )
 
 
+def apply_config_overrides() -> None:
+    """Overlay ``datapipes:``/``dataentities:`` config sections onto
+    registered pipe/entity metadata.
+
+    Called from ``initialize_framework`` right after local package
+    registrations import, and safely re-callable after
+    ``config_service.reload()`` for hot reload. The managers keep the
+    compiled patterns, so items registered later (workspace packages, app
+    ``register_all``, notebook cells) are overlaid at registration.
+    """
+    from kindling.data_entities import DataEntityRegistry
+    from kindling.data_pipes import DataPipesRegistry
+
+    config_service = get_kindling_service(ConfigService)
+    # Fetch by the registry ABCs: decorators register into the interface
+    # singletons, and the injector caches interface and concrete-class
+    # bindings separately.
+    pipes_registry = get_kindling_service(DataPipesRegistry)
+    entity_registry = get_kindling_service(DataEntityRegistry)
+    for registry in (pipes_registry, entity_registry):
+        overlay = getattr(registry, "apply_config_overrides", None)
+        if overlay is None:
+            # Custom registry binding without overlay support.
+            _BOOTSTRAP_LOGGER.debug(
+                "%s does not support config overrides — skipping overlay",
+                type(registry).__name__,
+            )
+            continue
+        overlay(config_service)
+    _BOOTSTRAP_LOGGER.debug(
+        "Config overrides applied to %s pipe(s) and %s entit(y/ies)",
+        len(list(pipes_registry.get_pipe_ids())),
+        len(list(entity_registry.get_entity_ids())),
+    )
+
+
 def _merge_with_spark_kindling_config(config: Dict[str, Any]) -> Dict[str, Any]:
     """Merge SparkConf-derived config with explicit config (explicit wins)."""
     spark_kindling_config = _get_spark_kindling_config()
@@ -1557,7 +1593,6 @@ def _bind_plain_telemetry_providers(logger=None) -> None:
     resolve the concrete class keep working.
     """
     from injector import singleton
-
     from kindling.plain_telemetry import (
         PlainPythonLoggerProvider,
         PlainPythonTraceProvider,
@@ -1817,6 +1852,13 @@ def initialize_framework(config: Dict[str, Any], app_name: Optional[str] = None)
         # This must happen after the session exists so conf.set() works.
         _apply_spark_configs(config_service, logger)
         _import_local_package_registrations(logger)
+
+        # Overlay datapipes:/dataentities: config sections onto everything
+        # registered so far; the managers keep the compiled patterns so
+        # later registrations (workspace packages, app register_all) are
+        # overlaid at registration — before any pipe executes.
+        apply_config_overrides()
+        logger.info("Config overrides applied to registered pipes and entities")
 
         # Resolve any @secret references now that platform services are available.
         try:

--- a/packages/kindling/bootstrap.py
+++ b/packages/kindling/bootstrap.py
@@ -202,8 +202,8 @@ def apply_config_overrides() -> None:
         overlay(config_service)
     _BOOTSTRAP_LOGGER.debug(
         "Config overrides applied to %s pipe(s) and %s entit(y/ies)",
-        len(list(pipes_registry.get_pipe_ids())),
-        len(list(entity_registry.get_entity_ids())),
+        sum(1 for _ in pipes_registry.get_pipe_ids()),
+        sum(1 for _ in entity_registry.get_entity_ids()),
     )
 
 

--- a/packages/kindling/data_entities.py
+++ b/packages/kindling/data_entities.py
@@ -8,12 +8,14 @@ from typing import Any, Callable, Dict, List, Optional
 
 from delta.tables import DeltaTable
 from injector import Binder, Injector, inject, singleton
-from pyspark.sql import DataFrame
-
+from kindling.config_patterns import ConfigPatternMatcher
 from kindling.injection import *
 from kindling.signaling import SignalEmitter, SignalProvider
 from kindling.spark_config import *
 from kindling.spark_log_provider import *
+from pyspark.sql import DataFrame
+
+_ENTITY_LOGGER = logging.getLogger("kindling.data_entities")
 
 ROUTING_KEY_METHODS: tuple[str, ...] = ("hash", "concat")
 
@@ -722,6 +724,11 @@ class DataEntityRegistry(ABC):
 class DataEntityManager(DataEntityRegistry, SignalEmitter):
     """Manages entity registrations with signal emissions."""
 
+    # Identity and structural fields are never config-overridable; every
+    # other EntityMetadata field is, so new fields become overridable
+    # without code changes here.
+    _NON_OVERRIDABLE_FIELDS = ("entityid", "schema", "sql")
+
     @inject
     def __init__(
         self, signal_provider: SignalProvider = None, config_service: ConfigService = None
@@ -732,6 +739,16 @@ class DataEntityManager(DataEntityRegistry, SignalEmitter):
         # Run-scoped JIT tag overlays (see tag_overrides); win over both
         # declared tags and config-level set_entity_tags overrides.
         self._tag_overlays = {}
+        # Original registration params per entity (shallow copies). Config
+        # overlay always re-resolves from these, never from overlaid
+        # metadata, so re-applying is idempotent and never accumulates.
+        # SCD2 current-row companions are derived state and never appear
+        # here.
+        self._raw_params = {}
+        # Compiled dataentities: config section; persisted so entities
+        # registered after bootstrap's overlay pass (workspace packages,
+        # app register_all, notebook cells) are overlaid at registration.
+        self._matcher = None
 
     @contextmanager
     def tag_overrides(self, overrides):
@@ -761,48 +778,109 @@ class DataEntityManager(DataEntityRegistry, SignalEmitter):
             self._tag_overlays = previous
 
     def register_entity(self, entityid, **decorator_params):
-        entity = EntityMetadata(entityid, **decorator_params)
-        # Derived-vs-state exclusivity first: a derived entity carrying
-        # state tags should fail with "does not apply to a derived
-        # dataset", not with a downstream state-vocabulary complaint.
-        _validate_derived_config(entity)
-        _validate_scd_config(entity)
-        _validate_write_mode_tag(entity)
-        _validate_schema_drift_tag(entity)
+        self._raw_params[entityid] = dict(decorator_params)
+        entity = self._build_metadata(entityid, decorator_params)
+        self._validate_entity(entity)
 
         self.registry[entityid] = entity
         self.emit(
             "entity.registered",
             entity_id=entityid,
-            entity_name=decorator_params.get("name", entityid),
+            entity_name=entity.name,
         )
 
         scd_config = scd_config_from_tags(entity)
         if scd_config.enabled:
             self._register_scd2_current_companion(entity, scd_config)
 
+    def apply_config_overrides(self, config_service: ConfigService) -> None:
+        """Overlay the ``dataentities:`` config section onto registered entities.
+
+        Rebuilds every explicitly-registered entity from its original
+        registration params through the section's glob patterns
+        (``ConfigPatternMatcher`` semantics: mappings deep-merge, scalars
+        and lists replace, exact > single-wildcard > multi-wildcard),
+        re-validates the overlaid metadata, and re-derives SCD2 current-row
+        companions from the result (desired-state convergence). A missing
+        or empty section compiles to a matcher with zero patterns, making
+        the pass a structural no-op. The matcher persists on the manager so
+        later registrations self-overlay.
+
+        Idempotent and safely re-callable (hot reload: ``reload()`` config,
+        then call again). Not synchronized with running DAGs — a concurrent
+        run may observe a mix of old and new metadata across entities (same
+        caveat as ``tag_overrides``).
+        """
+        self._matcher = ConfigPatternMatcher(config_service.get("dataentities"))
+        for entityid, raw_params in self._raw_params.items():
+            entity = self._build_metadata(entityid, raw_params)
+            self._validate_entity(entity)
+            self.registry[entityid] = entity
+        self._converge_scd2_companions()
+        _ENTITY_LOGGER.debug("Config overrides applied to %s entit(y/ies)", len(self._raw_params))
+
+    def _build_metadata(self, entityid, raw_params):
+        """Construct EntityMetadata from raw registration params plus any
+        config overrides matching ``entityid`` (no matcher yet -> raw as-is)."""
+        if self._matcher is None:
+            return EntityMetadata(entityid, **raw_params)
+
+        base = {
+            key: value
+            for key, value in raw_params.items()
+            if key not in self._NON_OVERRIDABLE_FIELDS
+        }
+        resolved = self._matcher.resolve_overrides(entityid, base)
+        overridable = {field.name for field in fields(EntityMetadata)} - set(
+            self._NON_OVERRIDABLE_FIELDS
+        )
+        params = {}
+        dropped = []
+        for key, value in resolved.items():
+            if key in self._NON_OVERRIDABLE_FIELDS:
+                dropped.append(key)
+            elif key in overridable or key in raw_params:
+                params[key] = value
+            else:
+                # Underscore keys (_enabled, _remove_tags, ...) ride along
+                # inertly until tag management interprets them; anything else
+                # is an unknown config key. Neither reaches the dataclass.
+                dropped.append(key)
+        if dropped:
+            _ENTITY_LOGGER.debug(
+                "Entity %s: config override keys not applied to metadata: %s",
+                entityid,
+                sorted(dropped),
+            )
+        for key in self._NON_OVERRIDABLE_FIELDS:
+            if key in raw_params:
+                params[key] = raw_params[key]
+        return EntityMetadata(entityid, **params)
+
+    def _validate_entity(self, entity: EntityMetadata) -> None:
+        """Run registration-time validations on (possibly overlaid) metadata."""
+        try:
+            # Derived-vs-state exclusivity first: a derived entity carrying
+            # state tags should fail with "does not apply to a derived
+            # dataset", not with a downstream state-vocabulary complaint.
+            _validate_derived_config(entity)
+            _validate_scd_config(entity)
+            _validate_write_mode_tag(entity)
+            _validate_schema_drift_tag(entity)
+        except ValueError as error:
+            if self._matcher is not None and self._matcher.get_matching_overrides(entity.entityid):
+                raise ValueError(
+                    f"Config overrides applied to entity '{entity.entityid}' "
+                    f"produced invalid metadata: {error}"
+                ) from error
+            raise
+
     def _register_scd2_current_companion(self, base: EntityMetadata, cfg: SCDConfig) -> None:
         """Register the read-only current-row companion for an SCD2 entity."""
         if cfg.current_entity_id in self.registry:
             return
 
-        companion_tags = {
-            key: value for key, value in (base.tags or {}).items() if not key.startswith("scd.")
-        }
-        companion_tags.update(
-            {
-                "scd.companion_of": base.entityid,
-                "scd.view_type": "current",
-                "provider.read_only": "true",
-                "provider_type": "current_view",
-            }
-        )
-        companion = replace(
-            base,
-            entityid=cfg.current_entity_id,
-            name=f"{base.name} (current)",
-            tags=companion_tags,
-        )
+        companion = self._build_companion_metadata(base, cfg)
         self.registry[cfg.current_entity_id] = companion
         self.emit(
             "entity.registered",
@@ -815,17 +893,98 @@ class DataEntityManager(DataEntityRegistry, SignalEmitter):
             companion_entity_id=cfg.current_entity_id,
         )
 
+    def _build_companion_metadata(self, base: EntityMetadata, cfg: SCDConfig) -> EntityMetadata:
+        """Derive the current-row companion's metadata from its (overlaid) base.
+
+        The companion id itself goes through pattern resolution with the
+        derived params as its base, so ``dataentities:`` patterns can target
+        companions directly — matching how ``entity_tags`` can target them
+        per-read. Companions stay unvalidated (parity with the previous
+        ``replace()`` derivation).
+        """
+        companion_tags = {
+            key: value for key, value in (base.tags or {}).items() if not key.startswith("scd.")
+        }
+        companion_tags.update(
+            {
+                "scd.companion_of": base.entityid,
+                "scd.view_type": "current",
+                "provider.read_only": "true",
+                "provider_type": "current_view",
+            }
+        )
+        derived_params = {
+            metadata_field.name: getattr(base, metadata_field.name)
+            for metadata_field in fields(EntityMetadata)
+            if metadata_field.name != "entityid"
+        }
+        derived_params["name"] = f"{base.name} (current)"
+        derived_params["tags"] = companion_tags
+        return self._build_metadata(cfg.current_entity_id, derived_params)
+
+    def _converge_scd2_companions(self) -> None:
+        """Re-derive SCD2 current-row companions after an overlay pass.
+
+        Companions are derived state (never in ``_raw_params``), so each
+        pass converges them onto the overlaid bases: SCD newly enabled by
+        config creates the companion (with registration signals), SCD
+        disabled or a changed ``current_entity_id`` removes the stale
+        auto-created one, and a still-desired companion is rebuilt in place
+        silently (no signal re-emission).
+        """
+        desired = {}
+        for entityid in self._raw_params:
+            base = self.registry.get(entityid)
+            cfg = scd_config_from_tags(base)
+            if cfg.enabled and cfg.current_entity_id not in self._raw_params:
+                desired[cfg.current_entity_id] = (base, cfg)
+
+        stale = [
+            companion_id
+            for companion_id, metadata in self.registry.items()
+            if companion_id not in self._raw_params
+            and (metadata.tags or {}).get("scd.companion_of")
+            and companion_id not in desired
+        ]
+        for companion_id in stale:
+            del self.registry[companion_id]
+            _ENTITY_LOGGER.debug("Removed stale SCD2 companion entity %s", companion_id)
+
+        for companion_id, (base, cfg) in desired.items():
+            already_registered = companion_id in self.registry
+            self.registry[companion_id] = self._build_companion_metadata(base, cfg)
+            if not already_registered:
+                self.emit(
+                    "entity.registered",
+                    entity_id=companion_id,
+                    entity_name=self.registry[companion_id].name,
+                )
+                self.emit(
+                    "entity.scd2_companion_registered",
+                    entity_id=base.entityid,
+                    companion_entity_id=companion_id,
+                )
+
     def get_entity_ids(self):
         return self.registry.keys()
 
     def get_entity_definition(self, name):
         """Get entity definition with tag overrides applied.
 
-        Tags merge at retrieval time, lowest to highest precedence:
-        declared tags, config-level overrides (``set_entity_tags``), then
-        any active run-scoped overlay (``tag_overrides``). Merging at
-        retrieval allows config to be loaded before or after entity
-        registration.
+        Tags layer lowest to highest precedence:
+
+        1. declared registration params,
+        2. ``dataentities:`` config patterns — durable file config, baked
+           into the stored metadata by ``apply_config_overrides`` (and by
+           registration itself once the matcher is set),
+        3. exact-id config map (``ConfigService.set_entity_tags``), merged
+           per-read because it is runtime-mutable (e.g. the ADX provider's
+           per-run windowing loop),
+        4. run-scoped ``tag_overrides`` context (JIT parameters), merged
+           per-read and restored on exit.
+
+        Layers 3 and 4 merge at retrieval time; that also allows config to
+        be loaded before or after entity registration.
         """
         base_entity = self.registry.get(name)
         if base_entity is None:

--- a/packages/kindling/data_pipes.py
+++ b/packages/kindling/data_pipes.py
@@ -8,13 +8,14 @@ from typing import Any, Callable, Dict, List, Optional
 
 from delta.tables import DeltaTable
 from injector import Binder, Injector, inject, singleton
-from pyspark.sql import DataFrame
-
+from kindling.config_patterns import ConfigPatternMatcher
 from kindling.injection import *
 from kindling.sentinels import UNSET
 from kindling.signaling import SignalEmitter, SignalProvider
+from kindling.spark_config import ConfigService
 from kindling.spark_log_provider import *
 from kindling.spark_trace import *
+from pyspark.sql import DataFrame
 
 from .data_entities import *
 from .data_entities import _raise_if_not_initialized
@@ -270,15 +271,85 @@ class DataPipesExecution(ABC):
 
 @GlobalInjector.singleton_autobind()
 class DataPipesManager(DataPipesRegistry):
+    # Identity and the execute callable are never config-overridable; every
+    # other PipeMetadata field is, so new fields become overridable without
+    # code changes here.
+    _NON_OVERRIDABLE_FIELDS = ("pipeid", "execute")
+
     @inject
     def __init__(self, lp: PythonLoggerProvider):
         self.registry = {}
+        # Original decorator params per pipe (shallow copies). Config overlay
+        # always re-resolves from these, never from overlaid metadata, so
+        # re-applying is idempotent and never accumulates.
+        self._raw_params = {}
+        # Compiled datapipes: config section; persisted so pipes registered
+        # after bootstrap's overlay pass (workspace packages, app
+        # register_all, notebook cells) are overlaid at registration.
+        self._matcher = None
         self.logger = lp.get_logger("data_pipes_manager")
         self.logger.debug("Data pipes manager initialized ...")
 
     def register_pipe(self, pipeid, **decorator_params):
-        self.registry[pipeid] = PipeMetadata(pipeid, **decorator_params)
+        self._raw_params[pipeid] = dict(decorator_params)
+        self.registry[pipeid] = self._build_metadata(pipeid, decorator_params)
         self.logger.debug(f"Pipe registered: {pipeid}")
+
+    def apply_config_overrides(self, config_service: ConfigService) -> None:
+        """Overlay the ``datapipes:`` config section onto registered pipes.
+
+        Rebuilds every registered pipe from its original decorator params
+        through the section's glob patterns (``ConfigPatternMatcher``
+        semantics: mappings deep-merge, scalars and lists replace, exact >
+        single-wildcard > multi-wildcard). A missing or empty section
+        compiles to a matcher with zero patterns, making the pass a
+        structural no-op. The matcher persists on the manager so later
+        registrations self-overlay.
+
+        Idempotent and safely re-callable (hot reload: ``reload()`` config,
+        then call again). Not synchronized with running DAGs — a concurrent
+        run may observe a mix of old and new metadata across pipes.
+        """
+        self._matcher = ConfigPatternMatcher(config_service.get("datapipes"))
+        for pipeid, raw_params in self._raw_params.items():
+            self.registry[pipeid] = self._build_metadata(pipeid, raw_params)
+        self.logger.debug(f"Config overrides applied to {len(self._raw_params)} pipe(s)")
+
+    def _build_metadata(self, pipeid, raw_params):
+        """Construct PipeMetadata from raw decorator params plus any config
+        overrides matching ``pipeid`` (no matcher yet -> raw as-is)."""
+        if self._matcher is None:
+            return PipeMetadata(pipeid, **raw_params)
+
+        base = {
+            key: value
+            for key, value in raw_params.items()
+            if key not in self._NON_OVERRIDABLE_FIELDS
+        }
+        resolved = self._matcher.resolve_overrides(pipeid, base)
+        overridable = {field.name for field in fields(PipeMetadata)} - set(
+            self._NON_OVERRIDABLE_FIELDS
+        )
+        params = {}
+        dropped = []
+        for key, value in resolved.items():
+            if key in self._NON_OVERRIDABLE_FIELDS:
+                dropped.append(key)
+            elif key in overridable or key in raw_params:
+                params[key] = value
+            else:
+                # Underscore keys (_enabled, _remove_tags, ...) ride along
+                # inertly until tag management interprets them; anything else
+                # is an unknown config key. Neither reaches the dataclass.
+                dropped.append(key)
+        if dropped:
+            self.logger.debug(
+                f"Pipe {pipeid}: config override keys not applied to metadata: {sorted(dropped)}"
+            )
+        for key in self._NON_OVERRIDABLE_FIELDS:
+            if key in raw_params:
+                params[key] = raw_params[key]
+        return PipeMetadata(pipeid, **params)
 
     def get_pipe_ids(self):
         return self.registry.keys()

--- a/tests/integration/test_config_override_overlay_integration.py
+++ b/tests/integration/test_config_override_overlay_integration.py
@@ -1,0 +1,153 @@
+"""Integration tests for the datapipes:/dataentities: config overlay (gh#30).
+
+Boots the full framework standalone (fresh subprocess, like
+tests/unit/test_di_wiring_standalone.py) with settings YAML carrying
+datapipes/dataentities pattern sections, then verifies:
+
+- effective pipe/entity metadata post-bootstrap (register-time overlay
+  through the persisted matcher — registrations happen after bootstrap,
+  the app-code lifecycle),
+- an executed pipe proves overridden tags flow into execution (the
+  output entity's declared provider_type would fail; the config override
+  routes persistence to the memory provider),
+- hot reload: mutate config, re-call bootstrap.apply_config_overrides(),
+  metadata re-resolves from raw params with no accumulation.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+pytestmark = [pytest.mark.integration]
+
+SETTINGS_YAML = textwrap.dedent("""\
+    datapipes:
+      "it.**":
+        tags:
+          overlaid: "yes"
+      "it.orders_to_summary":
+        name: "Overridden Orders Summary"
+
+    dataentities:
+      "it.*":
+        tags:
+          layer: "test"
+      "it.summary":
+        tags:
+          provider_type: "memory"
+    """)
+
+
+def _run_fresh_python(code: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+
+def test_standalone_bootstrap_applies_overlay_and_hot_reloads(tmp_path):
+    settings_path = tmp_path / "settings.yaml"
+    settings_path.write_text(SETTINGS_YAML, encoding="utf-8")
+
+    result = _run_fresh_python(f"""
+        from kindling.bootstrap import apply_config_overrides, initialize_framework
+
+        initialize_framework(
+            {{
+                "platform": "standalone",
+                "environment": "local",
+                "config_files": [{str(settings_path)!r}],
+            }}
+        )
+
+        from kindling.data_entities import DataEntities, DataEntityRegistry
+        from kindling.data_pipes import DataPipes, DataPipesExecution, DataPipesRegistry
+        from kindling.injection import GlobalInjector, get_kindling_service
+        from kindling.spark_config import ConfigService, get_or_create_spark_session
+
+        # Registrations happen AFTER bootstrap's overlay pass (the app-code
+        # lifecycle): the persisted matcher must overlay them at registration.
+        DataEntities.entity(
+            entityid="it.orders",
+            name="orders",
+            merge_columns=[],
+            tags={{"provider_type": "memory"}},
+            schema=None,
+        )
+        # Declared provider_type would fail at persist time if the config
+        # override did not rewrite it to the memory provider.
+        DataEntities.entity(
+            entityid="it.summary",
+            name="summary",
+            merge_columns=[],
+            tags={{"provider_type": "unregistered_provider"}},
+            schema=None,
+        )
+
+        @DataPipes.pipe(
+            pipeid="it.orders_to_summary",
+            name="Orders To Summary",
+            tags={{}},
+            input_entity_ids=["it.orders"],
+            output_entity_id="it.summary",
+            output_type="memory",
+        )
+        def orders_to_summary(it_orders):
+            return it_orders
+
+        pipes_registry = GlobalInjector.get(DataPipesRegistry)
+        entity_registry = GlobalInjector.get(DataEntityRegistry)
+
+        pipe = pipes_registry.get_pipe_definition("it.orders_to_summary")
+        assert pipe.tags.get("overlaid") == "yes", pipe.tags
+        assert pipe.name == "Overridden Orders Summary", pipe.name
+        assert pipe.execute is orders_to_summary
+
+        summary = entity_registry.get_entity_definition("it.summary")
+        assert summary.tags.get("provider_type") == "memory", summary.tags
+        assert summary.tags.get("layer") == "test", summary.tags
+
+        # Execute the pipe: overridden provider_type must drive persistence.
+        spark = get_or_create_spark_session()
+        spark.createDataFrame([(1, "a"), (2, "b")], ["id", "val"]).createOrReplaceTempView(
+            "it_orders"
+        )
+        executor = GlobalInjector.get(DataPipesExecution)
+        executor.run_datapipes(["it.orders_to_summary"])
+        assert spark.table("it_summary").count() == 2
+
+        # Hot reload: rewrite the settings file (drop the it.** pattern and
+        # the whole dataentities section), reload config, re-call the
+        # bootstrap helper. config_service.set() is unsuitable here — with
+        # MERGE_ENABLED_FOR_DYNACONF it merges into the existing section
+        # rather than replacing it.
+        import pathlib
+
+        pathlib.Path({str(settings_path)!r}).write_text(
+            'datapipes:\\n  "it.orders_to_summary":\\n    name: "Second Name"\\n',
+            encoding="utf-8",
+        )
+        config_service = get_kindling_service(ConfigService)
+        reload_result = config_service.reload()
+        assert reload_result["status"] == "success", reload_result
+        apply_config_overrides()
+
+        pipe = pipes_registry.get_pipe_definition("it.orders_to_summary")
+        assert pipe.name == "Second Name", pipe.name
+        # Re-resolution starts from raw decorator params: the first
+        # overlay's tag must not survive (no accumulation).
+        assert "overlaid" not in pipe.tags, pipe.tags
+
+        summary = entity_registry.get_entity_definition("it.summary")
+        assert summary.tags.get("provider_type") == "unregistered_provider", summary.tags
+        assert "layer" not in summary.tags, summary.tags
+
+        print("OVERLAY_INTEGRATION_OK")
+        """)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OVERLAY_INTEGRATION_OK" in result.stdout

--- a/tests/unit/test_bootstrap_standalone.py
+++ b/tests/unit/test_bootstrap_standalone.py
@@ -60,6 +60,8 @@ def test_detect_platform_can_fall_back_to_standalone():
 
 def test_initialize_framework_uses_explicit_config_files_for_standalone():
     from kindling.bootstrap import initialize_framework
+    from kindling.data_entities import DataEntityRegistry
+    from kindling.data_pipes import DataPipesRegistry
     from kindling.platform_provider import PlatformServiceProvider
     from kindling.spark_config import ConfigService
     from kindling.spark_log_provider import PythonLoggerProvider
@@ -71,6 +73,8 @@ def test_initialize_framework_uses_explicit_config_files_for_standalone():
     config_service = _config_service_with_defaults()
     platform_service_provider = MagicMock(spec=PlatformServiceProvider)
     standalone_service = MagicMock()
+    pipes_registry = MagicMock()
+    entity_registry = MagicMock()
 
     def _get_service(iface):
         if iface is ConfigService:
@@ -79,6 +83,10 @@ def test_initialize_framework_uses_explicit_config_files_for_standalone():
             return logger_provider
         if iface is PlatformServiceProvider:
             return platform_service_provider
+        if iface is DataPipesRegistry:
+            return pipes_registry
+        if iface is DataEntityRegistry:
+            return entity_registry
         raise AssertionError(f"Unexpected service lookup: {iface}")
 
     with (

--- a/tests/unit/test_config_override_overlay.py
+++ b/tests/unit/test_config_override_overlay.py
@@ -1,0 +1,547 @@
+"""Unit tests for the datapipes:/dataentities: config override overlay (gh#30).
+
+Covers DataPipesManager.apply_config_overrides,
+DataEntityManager.apply_config_overrides (including SCD2 companion
+convergence), overlay-at-registration through the persisted matcher, and
+the bootstrap.apply_config_overrides() helper.
+"""
+
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from kindling.data_entities import DataEntityManager, EntityMetadata
+from kindling.data_pipes import DataPipesManager, PipeMetadata
+
+
+def make_pipes_manager():
+    logger_provider = Mock()
+    logger_provider.get_logger.return_value = Mock()
+    return DataPipesManager(logger_provider)
+
+
+def make_config_service(sections):
+    """Stub ConfigService returning top-level sections by key."""
+    config_service = MagicMock()
+    config_service.get.side_effect = lambda key, default=None: sections.get(key, default)
+    return config_service
+
+
+def sample_execute(df):
+    return df
+
+
+def register_sample_pipe(manager, pipeid="bronze.ingest_orders", **overrides):
+    params = {
+        "name": "Ingest Orders",
+        "execute": sample_execute,
+        "tags": {"domain": "sales"},
+        "input_entity_ids": ["raw.orders"],
+        "output_entity_id": "bronze.orders",
+        "output_type": "delta",
+    }
+    params.update(overrides)
+    manager.register_pipe(pipeid, **params)
+    return params
+
+
+class TestPipeConfigOverlay:
+    """DataPipesManager.apply_config_overrides"""
+
+    def test_patterns_merge_tags_and_replace_scalars(self):
+        manager = make_pipes_manager()
+        register_sample_pipe(manager)
+        config_service = make_config_service(
+            {
+                "datapipes": {
+                    "bronze.*": {"tags": {"layer": "bronze"}},
+                    "bronze.ingest_orders": {"output_type": "parquet"},
+                }
+            }
+        )
+
+        manager.apply_config_overrides(config_service)
+
+        pipe = manager.get_pipe_definition("bronze.ingest_orders")
+        assert pipe.tags == {"domain": "sales", "layer": "bronze"}
+        assert pipe.output_type == "parquet"
+
+    def test_execute_callable_preserved_identically(self):
+        manager = make_pipes_manager()
+        register_sample_pipe(manager)
+        config_service = make_config_service(
+            {"datapipes": {"**": {"tags": {"managed": "true"}, "execute": "clobber"}}}
+        )
+
+        manager.apply_config_overrides(config_service)
+
+        assert manager.get_pipe_definition("bronze.ingest_orders").execute is sample_execute
+
+    def test_name_output_type_use_watermark_overridable(self):
+        manager = make_pipes_manager()
+        register_sample_pipe(manager)
+        config_service = make_config_service(
+            {
+                "datapipes": {
+                    "bronze.ingest_orders": {
+                        "name": "Overridden Name",
+                        "output_type": "memory",
+                        "use_watermark": True,
+                        "input_entity_ids": ["raw.orders_v2"],
+                    }
+                }
+            }
+        )
+
+        manager.apply_config_overrides(config_service)
+
+        pipe = manager.get_pipe_definition("bronze.ingest_orders")
+        assert pipe.name == "Overridden Name"
+        assert pipe.output_type == "memory"
+        assert pipe.use_watermark is True
+        assert pipe.input_entity_ids == ["raw.orders_v2"]
+
+    def test_unknown_and_underscore_keys_are_inert(self):
+        baseline_manager = make_pipes_manager()
+        register_sample_pipe(baseline_manager)
+        baseline_manager.apply_config_overrides(make_config_service({}))
+        baseline = baseline_manager.get_pipe_definition("bronze.ingest_orders")
+
+        manager = make_pipes_manager()
+        register_sample_pipe(manager)
+        config_service = make_config_service(
+            {
+                "datapipes": {
+                    "bronze.ingest_orders": {
+                        "_enabled": False,
+                        "_remove_tags": ["debug"],
+                        "not_a_metadata_field": 42,
+                    }
+                }
+            }
+        )
+
+        manager.apply_config_overrides(config_service)
+
+        assert manager.get_pipe_definition("bronze.ingest_orders") == baseline
+        debug_calls = [
+            str(call) for call in manager.logger.debug.call_args_list if "not applied" in str(call)
+        ]
+        assert debug_calls, "dropped config keys should be debug-logged"
+        assert "_enabled" in debug_calls[0]
+        assert "not_a_metadata_field" in debug_calls[0]
+
+    def test_reapply_is_idempotent(self):
+        manager = make_pipes_manager()
+        register_sample_pipe(manager)
+        config_service = make_config_service(
+            {"datapipes": {"bronze.*": {"tags": {"layer": "bronze"}, "name": "Renamed"}}}
+        )
+
+        manager.apply_config_overrides(config_service)
+        first = manager.get_pipe_definition("bronze.ingest_orders")
+        manager.apply_config_overrides(config_service)
+        second = manager.get_pipe_definition("bronze.ingest_orders")
+
+        assert first == second
+
+    def test_config_change_reresolves_from_raw_without_accumulation(self):
+        manager = make_pipes_manager()
+        register_sample_pipe(manager)
+
+        manager.apply_config_overrides(
+            make_config_service({"datapipes": {"bronze.*": {"tags": {"layer": "bronze"}}}})
+        )
+        manager.apply_config_overrides(
+            make_config_service({"datapipes": {"bronze.*": {"tags": {"sla": "4h"}}}})
+        )
+
+        pipe = manager.get_pipe_definition("bronze.ingest_orders")
+        # 'layer' came from the first overlay only; re-resolution starts
+        # from the raw decorator params, so it must not survive.
+        assert pipe.tags == {"domain": "sales", "sla": "4h"}
+
+    def test_registration_after_apply_is_overlaid(self):
+        manager = make_pipes_manager()
+        manager.apply_config_overrides(
+            make_config_service({"datapipes": {"bronze.*": {"tags": {"layer": "bronze"}}}})
+        )
+
+        register_sample_pipe(manager, pipeid="bronze.ingest_items")
+
+        pipe = manager.get_pipe_definition("bronze.ingest_items")
+        assert pipe.tags == {"domain": "sales", "layer": "bronze"}
+
+    def test_missing_or_empty_section_is_noop(self):
+        for section in ({}, {"datapipes": {}}):
+            manager = make_pipes_manager()
+            params = register_sample_pipe(manager)
+            before = manager.get_pipe_definition("bronze.ingest_orders")
+
+            manager.apply_config_overrides(make_config_service(section))
+
+            pipe = manager.get_pipe_definition("bronze.ingest_orders")
+            assert pipe == before
+            assert pipe.execute is params["execute"]
+
+    def test_registration_without_matcher_matches_legacy_behavior(self):
+        manager = make_pipes_manager()
+        register_sample_pipe(manager)
+
+        pipe = manager.get_pipe_definition("bronze.ingest_orders")
+        assert pipe == PipeMetadata(
+            pipeid="bronze.ingest_orders",
+            name="Ingest Orders",
+            execute=sample_execute,
+            tags={"domain": "sales"},
+            input_entity_ids=["raw.orders"],
+            output_entity_id="bronze.orders",
+            output_type="delta",
+        )
+
+
+def make_entity_manager(config_service=None):
+    signal_provider = MagicMock()
+    signal_provider.create_signal.return_value = MagicMock()
+    return DataEntityManager(signal_provider, config_service)
+
+
+def register_sample_entity(manager, entityid="bronze.orders", **overrides):
+    params = {
+        "name": "orders",
+        "merge_columns": ["order_id"],
+        "tags": {"layer": "bronze"},
+        "schema": None,
+    }
+    params.update(overrides)
+    manager.register_entity(entityid, **params)
+    return params
+
+
+def emitted_signals(manager):
+    return [call.args[0] for call in manager.emit.call_args_list]
+
+
+class TestEntityConfigOverlay:
+    """DataEntityManager.apply_config_overrides"""
+
+    def test_patterns_merge_tags_and_replace_lists(self):
+        manager = make_entity_manager()
+        register_sample_entity(manager)
+        config_service = make_config_service(
+            {
+                "dataentities": {
+                    "bronze.*": {"tags": {"team": "core"}},
+                    "bronze.orders": {
+                        "merge_columns": ["order_id", "region"],
+                        "partition_columns": ["date"],
+                        "cluster_columns": ["region"],
+                        "name": "orders_renamed",
+                    },
+                }
+            }
+        )
+
+        manager.apply_config_overrides(config_service)
+
+        entity = manager.get_entity_definition("bronze.orders")
+        assert entity.tags == {"layer": "bronze", "team": "core"}
+        assert entity.merge_columns == ["order_id", "region"]
+        assert entity.partition_columns == ["date"]
+        assert entity.cluster_columns == ["region"]
+        assert entity.name == "orders_renamed"
+
+    def test_schema_and_sql_never_overridable(self):
+        manager = make_entity_manager()
+        schema_sentinel = object()
+        register_sample_entity(manager, schema=schema_sentinel)
+        config_service = make_config_service(
+            {"dataentities": {"bronze.orders": {"schema": "clobber", "sql": "SELECT 1"}}}
+        )
+
+        manager.apply_config_overrides(config_service)
+
+        entity = manager.get_entity_definition("bronze.orders")
+        assert entity.schema is schema_sentinel
+        assert entity.sql is None
+
+    def test_unknown_and_underscore_keys_are_inert(self):
+        manager = make_entity_manager()
+        register_sample_entity(manager)
+        baseline = manager.get_entity_definition("bronze.orders")
+        config_service = make_config_service(
+            {"dataentities": {"bronze.orders": {"_enabled": False, "mystery": "x"}}}
+        )
+
+        manager.apply_config_overrides(config_service)
+
+        assert manager.get_entity_definition("bronze.orders") == baseline
+
+    def test_reapply_reresolves_from_raw_without_accumulation(self):
+        manager = make_entity_manager()
+        register_sample_entity(manager)
+
+        manager.apply_config_overrides(
+            make_config_service({"dataentities": {"bronze.*": {"tags": {"team": "core"}}}})
+        )
+        manager.apply_config_overrides(
+            make_config_service({"dataentities": {"bronze.*": {"tags": {"sla": "4h"}}}})
+        )
+
+        entity = manager.get_entity_definition("bronze.orders")
+        assert entity.tags == {"layer": "bronze", "sla": "4h"}
+
+    def test_registration_after_apply_is_overlaid(self):
+        manager = make_entity_manager()
+        manager.apply_config_overrides(
+            make_config_service({"dataentities": {"bronze.*": {"tags": {"team": "core"}}}})
+        )
+
+        register_sample_entity(manager, entityid="bronze.items")
+
+        entity = manager.get_entity_definition("bronze.items")
+        assert entity.tags == {"layer": "bronze", "team": "core"}
+
+    def test_missing_section_is_noop(self):
+        manager = make_entity_manager()
+        register_sample_entity(manager)
+        before = manager.get_entity_definition("bronze.orders")
+
+        manager.apply_config_overrides(make_config_service({}))
+
+        assert manager.get_entity_definition("bronze.orders") == before
+
+    def test_invalid_overlay_raises_at_apply_with_entity_id(self):
+        manager = make_entity_manager()
+        register_sample_entity(manager, merge_columns=[])
+        config_service = make_config_service(
+            {"dataentities": {"bronze.orders": {"tags": {"write.mode": "insert"}}}}
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            manager.apply_config_overrides(config_service)
+
+        message = str(exc_info.value)
+        assert "bronze.orders" in message
+        assert "Config overrides" in message
+        assert "merge_columns" in str(exc_info.value.__cause__)
+
+    def test_invalid_overlay_raises_at_registration_too(self):
+        manager = make_entity_manager()
+        manager.apply_config_overrides(
+            make_config_service(
+                {"dataentities": {"bronze.orders": {"tags": {"write.mode": "insert"}}}}
+            )
+        )
+
+        with pytest.raises(ValueError, match="Config overrides"):
+            register_sample_entity(manager, merge_columns=[])
+
+    def test_invalid_raw_params_not_blamed_on_config(self):
+        manager = make_entity_manager()
+        manager.apply_config_overrides(
+            make_config_service({"dataentities": {"other.*": {"tags": {"team": "core"}}}})
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            register_sample_entity(manager, merge_columns=[], tags={"write.mode": "insert"})
+
+        assert "Config overrides" not in str(exc_info.value)
+
+
+class TestScd2CompanionConvergence:
+    """SCD2 current-row companions re-derive from overlaid bases."""
+
+    SCD_TAGS = {"layer": "silver", "scd.type": "2"}
+
+    def test_tag_added_to_base_reflects_in_companion(self):
+        manager = make_entity_manager()
+        register_sample_entity(manager, entityid="silver.customers", tags=dict(self.SCD_TAGS))
+
+        manager.apply_config_overrides(
+            make_config_service({"dataentities": {"silver.*": {"tags": {"team": "core"}}}})
+        )
+
+        companion = manager.registry["silver.customers.current"]
+        assert companion.tags["team"] == "core"
+        assert companion.tags["scd.companion_of"] == "silver.customers"
+        assert companion.tags["provider_type"] == "current_view"
+
+    def test_scd_enabled_by_config_creates_companion_with_signals(self):
+        manager = make_entity_manager()
+        register_sample_entity(manager, entityid="silver.customers")
+        assert "silver.customers.current" not in manager.registry
+        manager.emit = MagicMock()
+
+        manager.apply_config_overrides(
+            make_config_service({"dataentities": {"silver.customers": {"tags": {"scd.type": "2"}}}})
+        )
+
+        assert "silver.customers.current" in manager.registry
+        assert "entity.registered" in emitted_signals(manager)
+        assert "entity.scd2_companion_registered" in emitted_signals(manager)
+
+    def test_scd_disabled_by_config_removes_companion(self):
+        manager = make_entity_manager()
+        register_sample_entity(manager, entityid="silver.customers", tags=dict(self.SCD_TAGS))
+        assert "silver.customers.current" in manager.registry
+
+        manager.apply_config_overrides(
+            make_config_service({"dataentities": {"silver.customers": {"tags": {"scd.type": ""}}}})
+        )
+
+        assert "silver.customers.current" not in manager.registry
+
+    def test_changed_current_entity_id_moves_companion(self):
+        manager = make_entity_manager()
+        register_sample_entity(manager, entityid="silver.customers", tags=dict(self.SCD_TAGS))
+
+        manager.apply_config_overrides(
+            make_config_service(
+                {
+                    "dataentities": {
+                        "silver.customers": {
+                            "tags": {"scd.current_entity_id": "silver.customers.latest"}
+                        }
+                    }
+                }
+            )
+        )
+
+        assert "silver.customers.current" not in manager.registry
+        assert "silver.customers.latest" in manager.registry
+
+    def test_unchanged_companion_replaced_without_reemission(self):
+        manager = make_entity_manager()
+        register_sample_entity(manager, entityid="silver.customers", tags=dict(self.SCD_TAGS))
+        manager.emit = MagicMock()
+
+        manager.apply_config_overrides(make_config_service({}))
+
+        assert "silver.customers.current" in manager.registry
+        assert manager.emit.call_count == 0
+
+    def test_companion_id_itself_resolves_patterns(self):
+        manager = make_entity_manager()
+        register_sample_entity(manager, entityid="silver.customers", tags=dict(self.SCD_TAGS))
+
+        manager.apply_config_overrides(
+            make_config_service(
+                {"dataentities": {"silver.customers.current": {"tags": {"read_scope": "current"}}}}
+            )
+        )
+
+        companion = manager.registry["silver.customers.current"]
+        assert companion.tags["read_scope"] == "current"
+        base = manager.get_entity_definition("silver.customers")
+        assert "read_scope" not in base.tags
+
+    def test_user_registered_entity_with_companion_id_is_never_clobbered(self):
+        manager = make_entity_manager()
+        register_sample_entity(
+            manager, entityid="silver.customers.current", tags={"layer": "silver"}
+        )
+        register_sample_entity(manager, entityid="silver.customers", tags=dict(self.SCD_TAGS))
+        user_owned = manager.registry["silver.customers.current"]
+
+        manager.apply_config_overrides(make_config_service({}))
+
+        assert manager.registry["silver.customers.current"] == user_owned
+
+
+class TestRuntimeChannelsStillWinPerRead:
+    """set_entity_tags and tag_overrides stay per-read above baked patterns."""
+
+    def test_set_entity_tags_wins_over_baked_patterns(self):
+        config_service = MagicMock()
+        config_service.get.side_effect = lambda key, default=None: {
+            "dataentities": {"bronze.orders": {"tags": {"provider.start": "baked"}}}
+        }.get(key, default)
+        config_service.get_entity_tags.return_value = {"provider.start": "per-read"}
+        manager = make_entity_manager(config_service)
+        register_sample_entity(manager)
+
+        manager.apply_config_overrides(config_service)
+
+        entity = manager.get_entity_definition("bronze.orders")
+        assert entity.tags["provider.start"] == "per-read"
+
+    def test_tag_overrides_context_wins_and_restores(self):
+        config_service = MagicMock()
+        config_service.get.side_effect = lambda key, default=None: {
+            "dataentities": {"bronze.orders": {"tags": {"provider.start": "baked"}}}
+        }.get(key, default)
+        config_service.get_entity_tags.return_value = {"provider.start": "per-read"}
+        manager = make_entity_manager(config_service)
+        register_sample_entity(manager)
+        manager.apply_config_overrides(config_service)
+
+        with manager.tag_overrides({"bronze.orders": {"provider.start": "jit"}}):
+            assert manager.get_entity_definition("bronze.orders").tags["provider.start"] == "jit"
+
+        assert manager.get_entity_definition("bronze.orders").tags["provider.start"] == "per-read"
+
+
+class TestBootstrapApplyConfigOverrides:
+    """bootstrap.apply_config_overrides() helper"""
+
+    def _patch_services(self, monkeypatch, config_service, pipes_registry, entity_registry):
+        import kindling.bootstrap as bootstrap
+        from kindling.data_entities import DataEntityRegistry
+        from kindling.data_pipes import DataPipesRegistry
+        from kindling.spark_config import ConfigService
+
+        services = {
+            ConfigService: config_service,
+            DataPipesRegistry: pipes_registry,
+            DataEntityRegistry: entity_registry,
+        }
+        monkeypatch.setattr(bootstrap, "get_kindling_service", lambda iface: services[iface])
+        return bootstrap
+
+    def test_applies_to_both_managers_via_injector(self, monkeypatch):
+        config_service = make_config_service(
+            {
+                "datapipes": {"bronze.*": {"tags": {"layer": "bronze"}}},
+                "dataentities": {"bronze.*": {"tags": {"team": "core"}}},
+            }
+        )
+        pipes_manager = make_pipes_manager()
+        register_sample_pipe(pipes_manager)
+        entity_manager = make_entity_manager()
+        register_sample_entity(entity_manager)
+        bootstrap = self._patch_services(monkeypatch, config_service, pipes_manager, entity_manager)
+
+        bootstrap.apply_config_overrides()
+
+        assert pipes_manager.get_pipe_definition("bronze.ingest_orders").tags == {
+            "domain": "sales",
+            "layer": "bronze",
+        }
+        assert entity_manager.get_entity_definition("bronze.orders").tags == {
+            "layer": "bronze",
+            "team": "core",
+        }
+
+    def test_tolerates_absent_sections(self, monkeypatch):
+        config_service = make_config_service({})
+        pipes_manager = make_pipes_manager()
+        register_sample_pipe(pipes_manager)
+        entity_manager = make_entity_manager()
+        register_sample_entity(entity_manager)
+        bootstrap = self._patch_services(monkeypatch, config_service, pipes_manager, entity_manager)
+
+        bootstrap.apply_config_overrides()
+
+        assert pipes_manager.get_pipe_definition("bronze.ingest_orders").tags == {"domain": "sales"}
+        assert entity_manager.get_entity_definition("bronze.orders").tags == {"layer": "bronze"}
+
+    def test_skips_registry_without_overlay_support(self, monkeypatch):
+        config_service = make_config_service({})
+        pipes_manager = make_pipes_manager()
+        legacy_registry = MagicMock(spec=["register_entity", "get_entity_ids"])
+        legacy_registry.get_entity_ids.return_value = []
+        bootstrap = self._patch_services(
+            monkeypatch, config_service, pipes_manager, legacy_registry
+        )
+
+        bootstrap.apply_config_overrides()


### PR DESCRIPTION
## Summary

Wires the wildcard pattern engine (`ConfigPatternMatcher`, #31/#205) into the pipe/entity registries as a config override overlay (#30):

- **`DataPipesManager`/`DataEntityManager`** retain raw registration params and gain `apply_config_overrides(config_service)`: rebuilds every registered item from its original params through the `datapipes:`/`dataentities:` glob-pattern sections, so the pass is idempotent and re-callable for hot reload (`config_service.reload()` + bootstrap helper)
- **Compiled matcher persists on each manager** and registration builds metadata through the same overlay path, so registrations after bootstrap's pass (workspace packages, app `register_all`, notebook cells) are overlaid before anything executes. With no config sections the matcher is empty and registration behavior is byte-for-byte unchanged
- **Identity/structural fields are never overridable** (`pipeid`/`execute`; `entityid`/`schema`/`sql`); underscore keys (`_enabled`, `_remove_tags`, …) and unknown keys are dropped from metadata with a debug log (#32 will interpret them at this seam)
- **Entity validation re-runs on overlaid metadata** at registration and at every apply pass, wrapping failures with config-overlay context. SCD2 current-row companions converge as derived state: config enabling SCD creates the companion (with signals), disabling it or changing `scd.current_entity_id` removes the stale auto-created one, unchanged companions rebuild silently
- **`get_entity_definition` keeps its per-read merges** for the runtime channels; precedence lowest→highest: declared params < `dataentities:` patterns (baked) < `set_entity_tags` (per-read) < `tag_overrides` context (per-read)
- **`bootstrap.apply_config_overrides()`** fetches the managers by their registry ABCs (interface and concrete-class bindings cache as separate singletons) and runs right after `_import_local_package_registrations` in `initialize_framework`

## Test plan

- `poe test-unit`: **2155 passed** — includes 547 lines of new `test_config_override_overlay.py` coverage
- `poe test-integration`: **123 passed** — includes new `test_config_override_overlay_integration.py` (153 lines)
- Internal review: APPROVE, no blockers — diff matches the human-approved DESIGN; both documented deviations (per-read runtime channels retained, register-time overlay extension) explicitly flagged as non-blocking in the plan
- gitleaks scan of push range: clean

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)
