### PR TITLE
fix(cli): accept Databricks auth alternatives at pre-flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ All notable changes to spark-kindling are documented here.
   of failing (a partial triple still fails naming the missing vars). CI
   jobs that relied on `env check --platform fabric|synapse` to enforce
   service-principal presence will now pass in that no-SP case.
+  Pre-flight resource vars are also reconciled with what the SDK clients
+  actually require: `env check --platform fabric` now checks
+  `FABRIC_LAKEHOUSE_ID` alongside `FABRIC_WORKSPACE_ID` (matching the run
+  gate and `FabricAPI.from_env`), and the synapse run gate now requires
+  `SYNAPSE_SPARK_POOL_NAME` alongside `SYNAPSE_WORKSPACE_NAME` (matching
+  `env check` and the Livy batch URLs `SynapseAPI` builds) — synapse runs
+  without a pool name previously passed pre-flight and then failed
+  against `sparkPools/None`.
 
 ## [0.12.0] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to spark-kindling are documented here.
 
+## Unreleased
+
+### Fixed
+
+- **Databricks pre-flight no longer hard-requires `DATABRICKS_TOKEN`**
+  (gh#211). The CLI run gate and `env check` now accept any of the SDK's
+  auth alternatives, evaluated in the SDK's resolution order:
+  `DATABRICKS_TOKEN`, the `AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/
+  `AZURE_CLIENT_SECRET` service principal triple, or a usable Azure CLI
+  session (probed lazily and secret-safely with
+  `az account get-access-token --output none`). Pre-flight failures list
+  all three alternatives plus the PAT-disabled workaround (minting an
+  Entra ID token for the Databricks first-party resource). A partial
+  service principal triple is called out by name — the SDK silently
+  ignores it and falls through, so pre-flight is where users learn this.
+  `env check --platform fabric|synapse` is now aligned with the run gate
+  and the auto-detect path: a wholly absent service principal triple
+  passes with an informational `az login / managed identity` line instead
+  of failing (a partial triple still fails naming the missing vars). CI
+  jobs that relied on `env check --platform fabric|synapse` to enforce
+  service-principal presence will now pass in that no-SP case.
+
 ## [0.12.0] - 2026-07-28
 
 ### Changed

--- a/docs/reference/cli_reference.md
+++ b/docs/reference/cli_reference.md
@@ -135,15 +135,25 @@ Check whether the local environment is ready for Kindling.
 |---|---|---|
 | `--config PATH` | `settings.yaml` | Settings file to validate |
 | `--local` | — | Also check Java, PySpark, delta-spark, and hadoop-azure JARs |
-| `--platform databricks\|fabric\|synapse` | auto-detected | Check platform credential env vars; reports each as SET or MISSING with `export` hints. Exits 1 if any are missing |
+| `--platform databricks\|fabric\|synapse` | auto-detected | Check platform pre-flight readiness: required vars are reported as SET or MISSING with `export` hints, and authentication alternatives are listed in the SDK's resolution order. Exits 1 unless the platform is ready |
 
-Platform credential vars checked:
+Platform pre-flight requirements:
 
-| Platform | Required vars |
-|---|---|
-| `databricks` | `DATABRICKS_HOST`, `DATABRICKS_TOKEN` |
-| `fabric` | `FABRIC_WORKSPACE_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` |
-| `synapse` | `SYNAPSE_WORKSPACE_NAME`, `SYNAPSE_SPARK_POOL_NAME`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` |
+| Platform | Required vars | Auth — one of |
+|---|---|---|
+| `databricks` | `DATABRICKS_HOST` | `DATABRICKS_TOKEN`; the `AZURE_TENANT_ID` + `AZURE_CLIENT_ID` + `AZURE_CLIENT_SECRET` service principal triple; or a usable Azure CLI session (`az login`) |
+| `fabric` | `FABRIC_WORKSPACE_ID` | the service principal triple, or `az login` / managed identity at run time |
+| `synapse` | `SYNAPSE_WORKSPACE_NAME`, `SYNAPSE_SPARK_POOL_NAME` | the service principal triple, or `az login` / managed identity at run time |
+
+A partially set service principal triple fails the check naming the missing
+vars. For Databricks workspaces with personal access tokens disabled, mint a
+short-lived Microsoft Entra ID token instead:
+
+```bash
+export DATABRICKS_TOKEN=$(az account get-access-token \
+  --resource 2ff814a6-3304-4ab8-85cb-cd0e6f879c1d \
+  --query accessToken -o tsv)
+```
 
 ```bash
 kindling env check --local
@@ -795,7 +805,7 @@ Re-run after pulling a new devcontainer image to pick up updated documentation.
 | `AZURE_CLIENT_SECRET` | all Azure auth | Service principal secret |
 | `AZURE_CLOUD` | Azure auth | Cloud environment (`AzureUSGovernment`, `AzureChinaCloud`, etc.) |
 | `DATABRICKS_HOST` | databricks platform | Databricks workspace URL |
-| `DATABRICKS_TOKEN` | databricks platform | Databricks PAT |
+| `DATABRICKS_TOKEN` | databricks platform | Databricks PAT (or Entra ID token) — one auth alternative; the `AZURE_*` service principal triple or an `az login` session also works |
 | `FABRIC_WORKSPACE_ID` | fabric platform | Fabric workspace GUID |
 | `FABRIC_LAKEHOUSE_ID` | fabric platform | Fabric lakehouse GUID |
 | `SYNAPSE_WORKSPACE_NAME` | synapse platform | Synapse workspace name |

--- a/docs/reference/cli_reference.md
+++ b/docs/reference/cli_reference.md
@@ -142,7 +142,7 @@ Platform pre-flight requirements:
 | Platform | Required vars | Auth — one of |
 |---|---|---|
 | `databricks` | `DATABRICKS_HOST` | `DATABRICKS_TOKEN`; the `AZURE_TENANT_ID` + `AZURE_CLIENT_ID` + `AZURE_CLIENT_SECRET` service principal triple; or a usable Azure CLI session (`az login`) |
-| `fabric` | `FABRIC_WORKSPACE_ID` | the service principal triple, or `az login` / managed identity at run time |
+| `fabric` | `FABRIC_WORKSPACE_ID`, `FABRIC_LAKEHOUSE_ID` | the service principal triple, or `az login` / managed identity at run time |
 | `synapse` | `SYNAPSE_WORKSPACE_NAME`, `SYNAPSE_SPARK_POOL_NAME` | the service principal triple, or `az login` / managed identity at run time |
 
 A partially set service principal triple fails the check naming the missing

--- a/packages/kindling_cli/kindling_cli/cli.py
+++ b/packages/kindling_cli/kindling_cli/cli.py
@@ -1465,7 +1465,7 @@ _AZURE_SP_PLATFORMS: frozenset = frozenset({"fabric", "synapse"})
 _PLATFORM_CREDENTIAL_VARS: Dict[str, List[str]] = {
     "synapse": ["SYNAPSE_WORKSPACE_NAME", "SYNAPSE_SPARK_POOL_NAME"],
     "databricks": ["DATABRICKS_HOST"],
-    "fabric": ["FABRIC_WORKSPACE_ID"],
+    "fabric": ["FABRIC_WORKSPACE_ID", "FABRIC_LAKEHOUSE_ID"],
 }
 
 _AZ_PROBE_TIMEOUT_SECONDS = 15

--- a/packages/kindling_cli/kindling_cli/cli.py
+++ b/packages/kindling_cli/kindling_cli/cli.py
@@ -1453,7 +1453,7 @@ _ABFSS_LOCAL_AUTH_JAR_SHA256 = "feb6236b362f717c79a11eecd05da0b16260799b255a19f5
 _PLATFORM_BASE_VARS: Dict[str, List[str]] = {
     "databricks": ["DATABRICKS_HOST"],
     "fabric": ["FABRIC_WORKSPACE_ID", "FABRIC_LAKEHOUSE_ID"],
-    "synapse": ["SYNAPSE_WORKSPACE_NAME"],
+    "synapse": ["SYNAPSE_WORKSPACE_NAME", "SYNAPSE_SPARK_POOL_NAME"],
 }
 
 # Only required when using service-principal auth; az login / managed identity needs none of these.
@@ -1925,8 +1925,9 @@ def env_check(config_path: Optional[Path], local_checks: bool, platform: Optiona
                              the AZURE_TENANT_ID/AZURE_CLIENT_ID/
                              AZURE_CLIENT_SECRET service principal triple,
                              or a usable Azure CLI session (az login)
-      --platform fabric      FABRIC_WORKSPACE_ID, plus the service principal
-                             triple or az login / managed identity
+      --platform fabric      FABRIC_WORKSPACE_ID and FABRIC_LAKEHOUSE_ID, plus
+                             the service principal triple or az login /
+                             managed identity
       --platform synapse     SYNAPSE_WORKSPACE_NAME, SYNAPSE_SPARK_POOL_NAME,
                              plus the service principal triple or az login /
                              managed identity

--- a/packages/kindling_cli/kindling_cli/cli.py
+++ b/packages/kindling_cli/kindling_cli/cli.py
@@ -304,12 +304,7 @@ def _wait_for_app_run(
 
 def _create_platform_api(platform: str):
     """Construct a remote platform API client from the current environment."""
-    missing = _missing_platform_vars(platform)
-    if missing:
-        raise click.ClickException(
-            f"Missing required environment variables for {platform}: {', '.join(missing)}.\n"
-            f"Run `kindling env check --platform {platform}` to verify your credentials."
-        )
+    _require_platform_credentials(platform)
 
     try:
         from kindling_sdk.platform_provider import create_platform_api_from_env
@@ -715,18 +710,13 @@ _PLATFORM_NOT_FOUND_MSG = (
 
 
 def _resolve_remote_platform(platform: Optional[str], require_credentials: bool = False) -> str:
-    """Resolve remote platform and optionally enforce base credential variables."""
+    """Resolve remote platform and optionally enforce pre-flight credentials."""
     resolved_platform = platform or _detect_platform_from_environment()
     if not resolved_platform:
         raise click.ClickException(_PLATFORM_NOT_FOUND_MSG)
 
     if require_credentials:
-        missing = _missing_platform_vars(resolved_platform)
-        if missing:
-            raise click.ClickException(
-                f"Missing required environment variables for {resolved_platform}: {', '.join(missing)}.\n"
-                f"Run `kindling env check --platform {resolved_platform}` to verify your credentials."
-            )
+        _require_platform_credentials(resolved_platform)
 
     return resolved_platform
 
@@ -1458,8 +1448,10 @@ _ABFSS_LOCAL_AUTH_JAR_URL = "https://github.com/sep/spark-kindling-framework/rel
 _ABFSS_LOCAL_AUTH_JAR_SHA256 = "feb6236b362f717c79a11eecd05da0b16260799b255a19f5f3575eb3184f67cc"
 
 
+# Resource locators only — authentication is modeled separately as
+# per-platform alternatives (see _PLATFORM_AUTH_ALTERNATIVES).
 _PLATFORM_BASE_VARS: Dict[str, List[str]] = {
-    "databricks": ["DATABRICKS_HOST", "DATABRICKS_TOKEN"],
+    "databricks": ["DATABRICKS_HOST"],
     "fabric": ["FABRIC_WORKSPACE_ID", "FABRIC_LAKEHOUSE_ID"],
     "synapse": ["SYNAPSE_WORKSPACE_NAME"],
 }
@@ -1468,40 +1460,212 @@ _PLATFORM_BASE_VARS: Dict[str, List[str]] = {
 _AZURE_SP_VARS: List[str] = ["AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET"]
 _AZURE_SP_PLATFORMS: frozenset = frozenset({"fabric", "synapse"})
 
-# [implementer] required credential vars for platform pre-flight check — ki-0nq
+# Non-auth env vars reported by `env check --platform <name>`; auth is
+# reported separately from _evaluate_platform_auth.
 _PLATFORM_CREDENTIAL_VARS: Dict[str, List[str]] = {
-    "synapse": [
-        "SYNAPSE_WORKSPACE_NAME",
-        "SYNAPSE_SPARK_POOL_NAME",
-        "AZURE_TENANT_ID",
-        "AZURE_CLIENT_ID",
-        "AZURE_CLIENT_SECRET",
-    ],
+    "synapse": ["SYNAPSE_WORKSPACE_NAME", "SYNAPSE_SPARK_POOL_NAME"],
+    "databricks": ["DATABRICKS_HOST"],
+    "fabric": ["FABRIC_WORKSPACE_ID"],
+}
+
+_AZ_PROBE_TIMEOUT_SECONDS = 15
+
+# Azure Databricks first-party application ID (public cloud) — the resource
+# AAD tokens must be minted for when workspace PATs are disabled.
+_DATABRICKS_AAD_RESOURCE_ID = "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d"
+
+_DATABRICKS_TOKEN_TIP = (
+    "Tip (PAT-disabled workspaces): export DATABRICKS_TOKEN=$(az account get-access-token "
+    f"--resource {_DATABRICKS_AAD_RESOURCE_ID} --query accessToken -o tsv)"
+)
+
+# Auth alternative kinds. "env": satisfied when every listed var is set.
+# "az-cli-probe": satisfied when `az account get-access-token` succeeds; a
+# valid pre-flight gate because the Azure CLI is the SDK's terminal fallback
+# for the platform, so a failed probe means a certain run failure.
+# "default-azure-credential": satisfied only when NO service-principal var is
+# set (a partial triple is a misconfiguration to surface, not a fallback).
+# Never probed: DefaultAzureCredential is broader than the az CLI — managed
+# identity can succeed where every pre-flight signal fails.
+_AUTH_ENV = "env"
+_AUTH_AZ_CLI_PROBE = "az-cli-probe"
+_AUTH_DEFAULT_AZURE_CREDENTIAL = "default-azure-credential"
+
+# (kind, label, env vars) per platform, in the SDK's credential resolution
+# order (token → service principal → Azure CLI / DefaultAzureCredential).
+_PLATFORM_AUTH_ALTERNATIVES: Dict[str, List[Tuple[str, str, List[str]]]] = {
     "databricks": [
-        "DATABRICKS_HOST",
-        "DATABRICKS_TOKEN",
+        (_AUTH_ENV, "DATABRICKS_TOKEN", ["DATABRICKS_TOKEN"]),
+        (_AUTH_ENV, "service principal", list(_AZURE_SP_VARS)),
+        (_AUTH_AZ_CLI_PROBE, "Azure CLI session (az login)", []),
     ],
     "fabric": [
-        "FABRIC_WORKSPACE_ID",
-        "AZURE_TENANT_ID",
-        "AZURE_CLIENT_ID",
-        "AZURE_CLIENT_SECRET",
+        (_AUTH_ENV, "service principal", list(_AZURE_SP_VARS)),
+        (_AUTH_DEFAULT_AZURE_CREDENTIAL, "az login / managed identity", []),
+    ],
+    "synapse": [
+        (_AUTH_ENV, "service principal", list(_AZURE_SP_VARS)),
+        (_AUTH_DEFAULT_AZURE_CREDENTIAL, "az login / managed identity", []),
     ],
 }
 
 
-def _print_platform_credential_check(platform: str) -> bool:
-    """Print a human-readable credential check for the given platform.
+def _azure_cli_session_available(timeout: float = _AZ_PROBE_TIMEOUT_SECONDS) -> bool:
+    """Return True when the Azure CLI holds a usable login session.
 
-    Each required env var is reported as SET or MISSING.  Missing vars include
-    an ``export`` hint.  Returns ``True`` when all vars are set, ``False``
-    when one or more are missing.
+    Probes with ``az account get-access-token --output none`` so no token
+    material ever reaches stdout or logs. Conservative on every failure
+    mode: a missing az binary, a non-zero exit, a timeout, or an OS error
+    all report False.
     """
-    vars_for_platform = _PLATFORM_CREDENTIAL_VARS.get(platform, [])
+    if shutil.which("az") is None:
+        return False
+    try:
+        result = subprocess.run(
+            ["az", "account", "get-access-token", "--output", "none"],
+            capture_output=True,
+            timeout=timeout,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return False
+    return result.returncode == 0
+
+
+def _evaluate_platform_auth(platform: str) -> Tuple[Optional[str], List[Dict[str, Any]]]:
+    """Evaluate the platform's auth alternatives against the environment.
+
+    Returns ``(satisfied_by, details)``: ``satisfied_by`` is the label of the
+    first satisfied alternative in SDK resolution order (None when no
+    alternative is satisfied), and ``details`` holds one entry per
+    alternative with keys ``kind``, ``label``, ``vars``, ``missing``,
+    ``satisfied``, ``probed``, and ``sp_partial``.
+
+    The az-cli probe is lazy: it only runs when no earlier alternative is
+    satisfied, so fully configured environments never pay the subprocess
+    cost.
+    """
+    satisfied_by: Optional[str] = None
+    details: List[Dict[str, Any]] = []
+    for kind, label, alt_vars in _PLATFORM_AUTH_ALTERNATIVES.get(platform, []):
+        entry: Dict[str, Any] = {
+            "kind": kind,
+            "label": label,
+            "vars": alt_vars,
+            "missing": [],
+            "satisfied": False,
+            "probed": False,
+            "sp_partial": False,
+        }
+        if kind == _AUTH_ENV:
+            entry["missing"] = [v for v in alt_vars if not os.getenv(v)]
+            entry["satisfied"] = not entry["missing"]
+        elif kind == _AUTH_AZ_CLI_PROBE:
+            if satisfied_by is None:
+                entry["probed"] = True
+                entry["satisfied"] = _azure_cli_session_available()
+        else:  # _AUTH_DEFAULT_AZURE_CREDENTIAL
+            sp_missing = [v for v in _AZURE_SP_VARS if not os.getenv(v)]
+            entry["satisfied"] = len(sp_missing) == len(_AZURE_SP_VARS)
+            entry["sp_partial"] = 0 < len(sp_missing) < len(_AZURE_SP_VARS)
+        if entry["satisfied"] and satisfied_by is None:
+            satisfied_by = label
+        details.append(entry)
+    return satisfied_by, details
+
+
+def _auth_alternative_display_name(entry: Dict[str, Any]) -> str:
+    if entry["kind"] == _AUTH_ENV:
+        return " + ".join(entry["vars"])
+    return entry["label"]
+
+
+def _platform_auth_error(platform: str, details: List[Dict[str, Any]]) -> str:
+    """Build the run-gate failure message listing every auth alternative."""
+    lines = [f"No {platform} authentication configured. Set one of:"]
+    for entry in details:
+        bullet = _auth_alternative_display_name(entry)
+        if entry["kind"] == _AUTH_ENV and entry["label"] != bullet:
+            bullet += f" ({entry['label']})"
+        if entry["missing"] and entry["missing"] != entry["vars"]:
+            bullet += f" — missing: {', '.join(entry['missing'])}"
+        lines.append(f"  - {bullet}")
+    if platform == "databricks":
+        lines.append(_DATABRICKS_TOKEN_TIP)
+    lines.append(f"Run `kindling env check --platform {platform}` to verify your credentials.")
+    return "\n".join(lines)
+
+
+def _require_platform_credentials(platform: str) -> None:
+    """Pre-flight gate: base env vars present and authentication available.
+
+    Auth is only enforced for platforms whose alternatives are all decidable
+    in pre-flight (databricks: token → service principal → az-cli probe, the
+    SDK's exact chain). Platforms whose chain ends in DefaultAzureCredential
+    (fabric/synapse) are not auth-gated here — managed identity can succeed
+    where every pre-flight signal fails.
+    """
+    missing = _missing_platform_vars(platform)
+    if missing:
+        raise click.ClickException(
+            f"Missing required environment variables for {platform}: {', '.join(missing)}.\n"
+            f"Run `kindling env check --platform {platform}` to verify your credentials."
+        )
+
+    alternatives = _PLATFORM_AUTH_ALTERNATIVES.get(platform, [])
+    if not alternatives or any(
+        kind == _AUTH_DEFAULT_AZURE_CREDENTIAL for kind, _, _ in alternatives
+    ):
+        return
+    satisfied_by, details = _evaluate_platform_auth(platform)
+    if satisfied_by is None:
+        raise click.ClickException(_platform_auth_error(platform, details))
+
+
+def _render_auth_alternative_status(entry: Dict[str, Any], auth_ok: bool) -> str:
+    """Status text for one auth alternative line in `env check --platform`."""
+    if entry["kind"] == _AUTH_ENV:
+        if entry["satisfied"]:
+            return "SET"
+        partial = 0 < len(entry["missing"]) < len(entry["vars"])
+        if auth_ok:
+            if partial:
+                return f"partial — missing: {', '.join(entry['missing'])}"
+            return "not set"
+        if len(entry["vars"]) == 1:
+            var = entry["vars"][0]
+            hint = var.lower().replace("_", "-")
+            return f"MISSING  → set via: export {var}=<your-{hint}>"
+        return f"MISSING: {', '.join(entry['missing'])}"
+    if entry["kind"] == _AUTH_AZ_CLI_PROBE:
+        if not entry["probed"]:
+            return "not checked (earlier alternative satisfied)"
+        return "AVAILABLE" if entry["satisfied"] else "UNAVAILABLE — run: az login"
+    # _AUTH_DEFAULT_AZURE_CREDENTIAL
+    if entry["satisfied"]:
+        return "OK — resolved at run time"
+    if entry["sp_partial"]:
+        return "skipped — complete the service principal vars above or unset them"
+    return "not needed (service principal set)"
+
+
+def _print_platform_credential_check(platform: str) -> bool:
+    """Print a human-readable pre-flight check for the given platform.
+
+    Required (non-auth) env vars are reported as SET or MISSING with an
+    ``export`` hint. Authentication is reported as a list of alternatives in
+    the SDK's credential resolution order — the check passes when any one
+    alternative is satisfied. Returns ``True`` when the platform is ready.
+    """
+    base_vars = _PLATFORM_CREDENTIAL_VARS.get(platform, [])
+    satisfied_by, auth_details = _evaluate_platform_auth(platform)
+    auth_ok = satisfied_by is not None or not auth_details
+
     click.echo(f"Platform: {platform}")
+    names = list(base_vars) + [_auth_alternative_display_name(e) for e in auth_details]
+    col_width = max((len(n) for n in names), default=0) + 2
+
     missing_count = 0
-    col_width = max((len(v) for v in vars_for_platform), default=0) + 2
-    for var in vars_for_platform:
+    for var in base_vars:
         val = os.getenv(var)
         if val:
             click.echo(f"  {var:<{col_width}} SET")
@@ -1509,12 +1673,28 @@ def _print_platform_credential_check(platform: str) -> bool:
             missing_count += 1
             hint = var.lower().replace("_", "-")
             click.echo(f"  {var:<{col_width}} MISSING  → set via: export {var}=<your-{hint}>")
+
+    if auth_details:
+        click.echo("  Auth — one of:")
+        for entry in auth_details:
+            name = _auth_alternative_display_name(entry)
+            status = _render_auth_alternative_status(entry, auth_ok)
+            click.echo(f"    {name:<{col_width}} {status}")
+        if satisfied_by:
+            click.echo(f"  Auth satisfied via: {satisfied_by}")
+
     if missing_count:
         click.echo(
             f"\n{missing_count} missing."
             f" Run 'kindling env check --platform {platform}' again after setting them."
         )
-    return missing_count == 0
+    if not auth_ok:
+        click.echo(
+            f"\nNo {platform} authentication configured — set one of the alternatives above."
+        )
+        if platform == "databricks":
+            click.echo(_DATABRICKS_TOKEN_TIP)
+    return missing_count == 0 and auth_ok
 
 
 def _missing_platform_vars(platform: str) -> List[str]:
@@ -1735,15 +1915,21 @@ def env_check(config_path: Optional[Path], local_checks: bool, platform: Optiona
       - hadoop-azure JARs present in /tmp/hadoop-jars/
 
     \b
-    With --platform <name>, checks that the required credential env vars for
-    the given platform are set and reports each as SET or MISSING.  Missing
-    vars include an export hint.  Exits 1 if any vars are missing.
+    With --platform <name>, checks that the required env vars for the given
+    platform are set and that at least one authentication alternative is
+    satisfied.  Vars are reported as SET or MISSING with an export hint;
+    auth alternatives are listed in the SDK's credential resolution order.
+    Exits 1 unless the platform is ready.
 
-      --platform databricks  DATABRICKS_HOST, DATABRICKS_TOKEN
-      --platform fabric      FABRIC_WORKSPACE_ID, AZURE_TENANT_ID,
-                             AZURE_CLIENT_ID
+      --platform databricks  DATABRICKS_HOST, plus one of: DATABRICKS_TOKEN,
+                             the AZURE_TENANT_ID/AZURE_CLIENT_ID/
+                             AZURE_CLIENT_SECRET service principal triple,
+                             or a usable Azure CLI session (az login)
+      --platform fabric      FABRIC_WORKSPACE_ID, plus the service principal
+                             triple or az login / managed identity
       --platform synapse     SYNAPSE_WORKSPACE_NAME, SYNAPSE_SPARK_POOL_NAME,
-                             AZURE_TENANT_ID, AZURE_CLIENT_ID
+                             plus the service principal triple or az login /
+                             managed identity
 
     \b
     To download all required JARs run:
@@ -1806,7 +1992,18 @@ def env_check(config_path: Optional[Path], local_checks: bool, platform: Optiona
         for var in _PLATFORM_BASE_VARS.get(auto_platform, []):
             val = os.getenv(var)
             checks.append((f"env:{var}", bool(val), "set" if val else "missing"))
-        if auto_platform in _AZURE_SP_PLATFORMS:
+        if auto_platform == "databricks":
+            satisfied_by, _ = _evaluate_platform_auth(auto_platform)
+            checks.append(
+                (
+                    "databricks_auth",
+                    satisfied_by is not None,
+                    satisfied_by
+                    or "missing — set DATABRICKS_TOKEN, the AZURE_* service principal"
+                    " vars, or run az login",
+                )
+            )
+        elif auto_platform in _AZURE_SP_PLATFORMS:
             sp_vals = [os.getenv(v) for v in _AZURE_SP_VARS]
             if any(sp_vals):
                 for var, val in zip(_AZURE_SP_VARS, sp_vals):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -305,6 +305,22 @@ def test_env_check_fabric_requires_lakehouse_id(monkeypatch):
     assert "export FABRIC_LAKEHOUSE_ID=" in result.output
 
 
+def test_env_check_synapse_requires_spark_pool_name(monkeypatch):
+    """The run gate and env check must require the pool name: SynapseAPI
+    interpolates it unconditionally into Livy batch URLs, so a passing
+    pre-flight without it yields requests against sparkPools/None."""
+    monkeypatch.setenv("SYNAPSE_WORKSPACE_NAME", "my-ws")
+    monkeypatch.delenv("SYNAPSE_SPARK_POOL_NAME", raising=False)
+    for var, value in zip(_AZURE_SP_VARS, ("tid", "cid", "secret")):
+        monkeypatch.setenv(var, value)
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["env", "check", "--platform", "synapse"])
+
+    assert result.exit_code != 0
+    assert "SYNAPSE_SPARK_POOL_NAME" in result.output
+
+
 def test_env_check_platform_help_shows_flag():
     """--help output should mention --platform."""
     runner = CliRunner()
@@ -2135,6 +2151,7 @@ _BLANK_PLATFORM_DETECT_VARS = {
     "FABRIC_WORKSPACE_ID": "",
     "FABRIC_LAKEHOUSE_ID": "",
     "SYNAPSE_WORKSPACE_NAME": "",
+    "SYNAPSE_SPARK_POOL_NAME": "",
     "DATABRICKS_HOST": "",
     # Blank out SP creds so real .env values don't leak into platform env-check tests
     "AZURE_TENANT_ID": "",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2133,6 +2133,7 @@ class TestAppRunCommand:
 
 _BLANK_PLATFORM_DETECT_VARS = {
     "FABRIC_WORKSPACE_ID": "",
+    "FABRIC_LAKEHOUSE_ID": "",
     "SYNAPSE_WORKSPACE_NAME": "",
     "DATABRICKS_HOST": "",
     # Blank out SP creds so real .env values don't leak into platform env-check tests
@@ -2251,6 +2252,7 @@ class TestEnvCheckPlatform:
             "fabric",
             {
                 "FABRIC_WORKSPACE_ID": "ws-1",
+                "FABRIC_LAKEHOUSE_ID": "lh-1",
                 "AZURE_TENANT_ID": "tenant-1",
                 "AZURE_CLIENT_ID": "client-1",
                 "AZURE_CLIENT_SECRET": "secret-1",
@@ -2270,7 +2272,9 @@ class TestEnvCheckPlatform:
 
     def test_fabric_no_sp_passes_with_informational_auth_line(self, az_probe_calls):
         """A wholly absent SP triple is fine — DefaultAzureCredential covers it."""
-        result = self._run_with_env("fabric", {"FABRIC_WORKSPACE_ID": "ws-1"})
+        result = self._run_with_env(
+            "fabric", {"FABRIC_WORKSPACE_ID": "ws-1", "FABRIC_LAKEHOUSE_ID": "lh-1"}
+        )
         assert result.exit_code == 0
         assert "MISSING" not in result.output
         assert "az login / managed identity" in result.output

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -288,6 +288,23 @@ def test_env_check_platform_partial_set_reports_correctly(monkeypatch):
     assert "AZURE_CLIENT_SECRET" in result.output
 
 
+def test_env_check_fabric_requires_lakehouse_id(monkeypatch):
+    """env check must gate on every var the run gate and FabricAPI.from_env
+    require — a passing check with FABRIC_LAKEHOUSE_ID unset would let the
+    subsequent remote command fail."""
+    monkeypatch.setenv("FABRIC_WORKSPACE_ID", "wid")
+    monkeypatch.delenv("FABRIC_LAKEHOUSE_ID", raising=False)
+    for var, value in zip(_AZURE_SP_VARS, ("tid", "cid", "secret")):
+        monkeypatch.setenv(var, value)
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["env", "check", "--platform", "fabric"])
+
+    assert result.exit_code != 0
+    assert "FABRIC_LAKEHOUSE_ID" in result.output
+    assert "export FABRIC_LAKEHOUSE_ID=" in result.output
+
+
 def test_env_check_platform_help_shows_flag():
     """--help output should mention --platform."""
     runner = CliRunner()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import os
+import subprocess
 import sys
 import types
 import zipfile
@@ -11,6 +12,8 @@ import pytest
 import yaml
 from click.testing import CliRunner
 from kindling_cli.cli import (
+    _AZURE_SP_VARS,
+    _azure_cli_session_available,
     _find_wheels,
     _generate_bootstrap_notebook,
     _generate_sample_notebook,
@@ -20,6 +23,7 @@ from kindling_cli.cli import (
     _render_environment_bootstrap_source,
     _render_starter_notebook_source,
     _resolve_account_url,
+    _resolve_remote_platform,
     cli,
 )
 
@@ -249,13 +253,15 @@ def test_env_check_platform_all_vars_set_exits_zero(monkeypatch):
     assert "MISSING" not in result.output
     output_lines = [l.strip() for l in result.output.splitlines() if l.strip()]
     set_lines = [l for l in output_lines if "SET" in l]
-    assert len(set_lines) == 5
+    # Two base vars plus the satisfied service-principal auth alternative.
+    assert len(set_lines) == 3
 
 
 def test_env_check_platform_missing_shows_export_hint(monkeypatch):
     """Missing vars should include 'export VAR=<your-...' hint."""
-    for var in ("DATABRICKS_HOST", "DATABRICKS_TOKEN"):
+    for var in ("DATABRICKS_HOST", "DATABRICKS_TOKEN", *_AZURE_SP_VARS):
         monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr("kindling_cli.cli._azure_cli_session_available", lambda **kw: False)
     runner = CliRunner()
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ["env", "check", "--platform", "databricks"])
@@ -267,7 +273,8 @@ def test_env_check_platform_missing_shows_export_hint(monkeypatch):
 def test_env_check_platform_partial_set_reports_correctly(monkeypatch):
     """If only some vars are set, SET and MISSING are both reported."""
     monkeypatch.setenv("FABRIC_WORKSPACE_ID", "wid")
-    for var in ("AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET"):
+    monkeypatch.setenv("AZURE_TENANT_ID", "tid")
+    for var in ("AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET"):
         monkeypatch.delenv(var, raising=False)
     runner = CliRunner()
     with runner.isolated_filesystem():
@@ -277,6 +284,8 @@ def test_env_check_platform_partial_set_reports_correctly(monkeypatch):
     assert "FABRIC_WORKSPACE_ID" in result.output
     assert "SET" in result.output
     assert "MISSING" in result.output
+    assert "AZURE_CLIENT_ID" in result.output
+    assert "AZURE_CLIENT_SECRET" in result.output
 
 
 def test_env_check_platform_help_shows_flag():
@@ -2117,6 +2126,22 @@ _BLANK_PLATFORM_DETECT_VARS = {
 
 
 class TestEnvCheckPlatform:
+    @pytest.fixture(autouse=True)
+    def az_probe_calls(self, monkeypatch):
+        """Record az-cli probe calls and answer False — tests never shell out.
+
+        Tests that need a live az session monkeypatch the probe again to
+        return True.
+        """
+        calls = []
+
+        def fake_probe(**kwargs):
+            calls.append(kwargs)
+            return False
+
+        monkeypatch.setattr("kindling_cli.cli._azure_cli_session_available", fake_probe)
+        return calls
+
     def _run_with_env(self, platform: str, env: dict):
         runner = CliRunner()
         merged = {**_BLANK_PLATFORM_DETECT_VARS, **env}
@@ -2127,7 +2152,7 @@ class TestEnvCheckPlatform:
             )
         return result
 
-    def test_databricks_all_vars_set_passes(self):
+    def test_databricks_all_vars_set_passes(self, az_probe_calls):
         result = self._run_with_env(
             "databricks",
             {
@@ -2140,8 +2165,37 @@ class TestEnvCheckPlatform:
         assert "SET" in result.output
         assert "MISSING" not in result.output
         assert result.exit_code == 0
+        # Token satisfied the check — the lazy probe must not run.
+        assert az_probe_calls == []
+
+    def test_databricks_sp_only_passes(self, az_probe_calls):
+        result = self._run_with_env(
+            "databricks",
+            {
+                "DATABRICKS_HOST": "https://adb-123.azuredatabricks.net",
+                "AZURE_TENANT_ID": "tenant-1",
+                "AZURE_CLIENT_ID": "client-1",
+                "AZURE_CLIENT_SECRET": "secret-1",
+            },
+        )
+        assert result.exit_code == 0
+        assert "MISSING" not in result.output
+        assert "service principal" in result.output
+        assert az_probe_calls == []
+
+    def test_databricks_az_cli_session_only_passes(self, monkeypatch):
+        monkeypatch.setattr("kindling_cli.cli._azure_cli_session_available", lambda **kw: True)
+        result = self._run_with_env(
+            "databricks",
+            {"DATABRICKS_HOST": "https://adb-123.azuredatabricks.net"},
+        )
+        assert result.exit_code == 0
+        assert "MISSING" not in result.output
+        assert "Azure CLI session (az login)" in result.output
+        assert "AVAILABLE" in result.output
 
     def test_databricks_missing_token_fails(self):
+        """No token, no service principal, no az session — pre-flight fails."""
         result = self._run_with_env(
             "databricks",
             {"DATABRICKS_HOST": "https://adb-123.azuredatabricks.net"},
@@ -2149,6 +2203,31 @@ class TestEnvCheckPlatform:
         assert "DATABRICKS_TOKEN" in result.output
         assert "MISSING" in result.output
         assert result.exit_code != 0
+
+    def test_databricks_no_auth_lists_alternatives_and_workaround(self):
+        result = self._run_with_env(
+            "databricks",
+            {"DATABRICKS_HOST": "https://adb-123.azuredatabricks.net"},
+        )
+        assert result.exit_code != 0
+        assert "DATABRICKS_TOKEN" in result.output
+        assert "AZURE_TENANT_ID + AZURE_CLIENT_ID + AZURE_CLIENT_SECRET" in result.output
+        assert "Azure CLI session (az login)" in result.output
+        assert "UNAVAILABLE" in result.output
+        # PAT-disabled workaround: mint an AAD token for the Databricks resource.
+        assert "az account get-access-token" in result.output
+        assert "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d" in result.output
+
+    def test_databricks_partial_sp_fails_naming_missing_vars(self):
+        result = self._run_with_env(
+            "databricks",
+            {
+                "DATABRICKS_HOST": "https://adb-123.azuredatabricks.net",
+                "AZURE_TENANT_ID": "tenant-1",
+            },
+        )
+        assert result.exit_code != 0
+        assert "MISSING: AZURE_CLIENT_ID, AZURE_CLIENT_SECRET" in result.output
 
     def test_fabric_all_vars_set_passes(self):
         result = self._run_with_env(
@@ -2171,6 +2250,60 @@ class TestEnvCheckPlatform:
         assert "FABRIC_WORKSPACE_ID" in result.output
         assert "MISSING" in result.output
         assert result.exit_code != 0
+
+    def test_fabric_no_sp_passes_with_informational_auth_line(self, az_probe_calls):
+        """A wholly absent SP triple is fine — DefaultAzureCredential covers it."""
+        result = self._run_with_env("fabric", {"FABRIC_WORKSPACE_ID": "ws-1"})
+        assert result.exit_code == 0
+        assert "MISSING" not in result.output
+        assert "az login / managed identity" in result.output
+        # DefaultAzureCredential is broader than the az CLI — never probed.
+        assert az_probe_calls == []
+
+    def test_fabric_partial_sp_fails_naming_missing_vars(self, az_probe_calls):
+        result = self._run_with_env(
+            "fabric",
+            {"FABRIC_WORKSPACE_ID": "ws-1", "AZURE_TENANT_ID": "tenant-1"},
+        )
+        assert result.exit_code != 0
+        assert "MISSING: AZURE_CLIENT_ID, AZURE_CLIENT_SECRET" in result.output
+        assert az_probe_calls == []
+
+    def test_fabric_missing_base_var_fails_even_with_full_sp(self):
+        result = self._run_with_env(
+            "fabric",
+            {
+                "AZURE_TENANT_ID": "tenant-1",
+                "AZURE_CLIENT_ID": "client-1",
+                "AZURE_CLIENT_SECRET": "secret-1",
+            },
+        )
+        assert result.exit_code != 0
+        assert "FABRIC_WORKSPACE_ID" in result.output
+        assert "MISSING" in result.output
+
+    def test_synapse_no_sp_passes_with_informational_auth_line(self, az_probe_calls):
+        result = self._run_with_env(
+            "synapse",
+            {"SYNAPSE_WORKSPACE_NAME": "my-ws", "SYNAPSE_SPARK_POOL_NAME": "my-pool"},
+        )
+        assert result.exit_code == 0
+        assert "MISSING" not in result.output
+        assert "az login / managed identity" in result.output
+        assert az_probe_calls == []
+
+    def test_synapse_partial_sp_fails_naming_missing_vars(self, az_probe_calls):
+        result = self._run_with_env(
+            "synapse",
+            {
+                "SYNAPSE_WORKSPACE_NAME": "my-ws",
+                "SYNAPSE_SPARK_POOL_NAME": "my-pool",
+                "AZURE_CLIENT_ID": "client-1",
+            },
+        )
+        assert result.exit_code != 0
+        assert "MISSING: AZURE_TENANT_ID, AZURE_CLIENT_SECRET" in result.output
+        assert az_probe_calls == []
 
     def test_synapse_all_vars_set_passes(self):
         result = self._run_with_env(
@@ -2241,6 +2374,152 @@ class TestEnvCheckPlatform:
             )
         assert "[PASS] platform: databricks" in result.output
         assert "env:DATABRICKS_HOST" in result.output
+        assert "[PASS] databricks_auth: DATABRICKS_TOKEN" in result.output
+
+    def _auto_detect_databricks_no_token(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ["config", "init"])
+            return runner.invoke(
+                cli,
+                ["env", "check"],
+                env={
+                    **_BLANK_PLATFORM_DETECT_VARS,
+                    "DATABRICKS_HOST": "https://adb-123.azuredatabricks.net",
+                },
+                catch_exceptions=False,
+            )
+
+    def test_auto_detect_databricks_az_session_passes_auth_check(self, monkeypatch):
+        monkeypatch.setattr("kindling_cli.cli._azure_cli_session_available", lambda **kw: True)
+        result = self._auto_detect_databricks_no_token()
+        assert "[PASS] databricks_auth: Azure CLI session (az login)" in result.output
+        assert result.exit_code == 0
+
+    def test_auto_detect_databricks_no_auth_fails_auth_check(self):
+        result = self._auto_detect_databricks_no_token()
+        assert "[FAIL] databricks_auth" in result.output
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# _azure_cli_session_available — az-cli auth probe (gh#211)
+# ---------------------------------------------------------------------------
+
+
+class TestAzureCliSessionAvailable:
+    def test_false_when_az_not_installed(self, monkeypatch):
+        monkeypatch.setattr("kindling_cli.cli.shutil.which", lambda _name: None)
+        assert _azure_cli_session_available() is False
+
+    def test_true_on_zero_exit_with_no_token_on_stdout(self, monkeypatch):
+        monkeypatch.setattr("kindling_cli.cli.shutil.which", lambda _name: "/usr/bin/az")
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            return types.SimpleNamespace(returncode=0)
+
+        monkeypatch.setattr("kindling_cli.cli.subprocess.run", fake_run)
+        assert _azure_cli_session_available() is True
+        # --output none keeps token material off stdout/logs; output is captured.
+        assert captured["cmd"] == ["az", "account", "get-access-token", "--output", "none"]
+        assert captured["kwargs"]["capture_output"] is True
+        assert captured["kwargs"]["timeout"] > 0
+
+    def test_false_on_nonzero_exit(self, monkeypatch):
+        monkeypatch.setattr("kindling_cli.cli.shutil.which", lambda _name: "/usr/bin/az")
+        monkeypatch.setattr(
+            "kindling_cli.cli.subprocess.run",
+            lambda *a, **kw: types.SimpleNamespace(returncode=1),
+        )
+        assert _azure_cli_session_available() is False
+
+    def test_false_on_timeout(self, monkeypatch):
+        monkeypatch.setattr("kindling_cli.cli.shutil.which", lambda _name: "/usr/bin/az")
+
+        def fake_run(*_args, **_kwargs):
+            raise subprocess.TimeoutExpired(cmd="az", timeout=15)
+
+        monkeypatch.setattr("kindling_cli.cli.subprocess.run", fake_run)
+        assert _azure_cli_session_available() is False
+
+    def test_false_on_oserror(self, monkeypatch):
+        monkeypatch.setattr("kindling_cli.cli.shutil.which", lambda _name: "/usr/bin/az")
+
+        def fake_run(*_args, **_kwargs):
+            raise OSError("broken pipe")
+
+        monkeypatch.setattr("kindling_cli.cli.subprocess.run", fake_run)
+        assert _azure_cli_session_available() is False
+
+
+# ---------------------------------------------------------------------------
+# Run gate — _resolve_remote_platform(require_credentials=True) (gh#211)
+# ---------------------------------------------------------------------------
+
+
+class TestDatabricksRunGate:
+    @pytest.fixture(autouse=True)
+    def _databricks_host_only_env(self, monkeypatch):
+        monkeypatch.setenv("DATABRICKS_HOST", "https://adb-123.azuredatabricks.net")
+        for var in ("DATABRICKS_TOKEN", *_AZURE_SP_VARS):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_az_cli_session_satisfies_gate(self, monkeypatch):
+        monkeypatch.setattr("kindling_cli.cli._azure_cli_session_available", lambda **kw: True)
+        assert _resolve_remote_platform("databricks", require_credentials=True) == "databricks"
+
+    def test_token_satisfies_gate_without_probe(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            "kindling_cli.cli._azure_cli_session_available",
+            lambda **kw: calls.append(kw) or False,
+        )
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi-abc")
+        assert _resolve_remote_platform("databricks", require_credentials=True) == "databricks"
+        assert calls == []
+
+    def test_no_auth_raises_listing_alternatives(self, monkeypatch):
+        monkeypatch.setattr("kindling_cli.cli._azure_cli_session_available", lambda **kw: False)
+        with pytest.raises(click.ClickException) as excinfo:
+            _resolve_remote_platform("databricks", require_credentials=True)
+        message = excinfo.value.message
+        assert "DATABRICKS_TOKEN" in message
+        assert "AZURE_TENANT_ID + AZURE_CLIENT_ID + AZURE_CLIENT_SECRET" in message
+        assert "Azure CLI session (az login)" in message
+        assert "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d" in message
+        assert "env check --platform databricks" in message
+
+    def test_partial_sp_failure_names_missing_vars(self, monkeypatch):
+        monkeypatch.setattr("kindling_cli.cli._azure_cli_session_available", lambda **kw: False)
+        monkeypatch.setenv("AZURE_TENANT_ID", "tenant-1")
+        with pytest.raises(click.ClickException) as excinfo:
+            _resolve_remote_platform("databricks", require_credentials=True)
+        assert "missing: AZURE_CLIENT_ID, AZURE_CLIENT_SECRET" in excinfo.value.message
+
+    def test_missing_host_message_unchanged(self, monkeypatch):
+        monkeypatch.delenv("DATABRICKS_HOST", raising=False)
+        with pytest.raises(click.ClickException) as excinfo:
+            _resolve_remote_platform("databricks", require_credentials=True)
+        assert (
+            "Missing required environment variables for databricks: DATABRICKS_HOST"
+            in excinfo.value.message
+        )
+
+    def test_fabric_gate_stays_base_vars_only(self, monkeypatch):
+        """fabric/synapse never required SP vars at the run gate — unchanged."""
+        calls = []
+        monkeypatch.setattr(
+            "kindling_cli.cli._azure_cli_session_available",
+            lambda **kw: calls.append(kw) or False,
+        )
+        monkeypatch.setenv("FABRIC_WORKSPACE_ID", "ws-1")
+        monkeypatch.setenv("FABRIC_LAKEHOUSE_ID", "lake-1")
+        monkeypatch.setenv("AZURE_TENANT_ID", "tenant-1")  # partial SP on purpose
+        assert _resolve_remote_platform("fabric", require_credentials=True) == "fabric"
+        assert calls == []
 
 
 # ---------------------------------------------------------------------------
@@ -2388,15 +2667,18 @@ def test_runner_register_json_output(monkeypatch):
     assert payload["job_id"] == "job-my-app"
 
 
-def test_runner_register_fails_when_platform_vars_missing(monkeypatch):
+def test_runner_register_fails_when_platform_auth_missing(monkeypatch):
     monkeypatch.setenv("DATABRICKS_HOST", "https://adb-123.azuredatabricks.net")
-    monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
+    for var in ("DATABRICKS_TOKEN", *_AZURE_SP_VARS):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr("kindling_cli.cli._azure_cli_session_available", lambda **kw: False)
     runner = CliRunner()
     result = runner.invoke(
         cli, ["runner", "register", "--app", "my-app", "--platform", "databricks"]
     )
     assert result.exit_code != 0
-    assert "Missing required environment variables" in result.output
+    assert "No databricks authentication configured" in result.output
+    assert "DATABRICKS_TOKEN" in result.output
 
 
 def test_runner_status_summary(monkeypatch):


### PR DESCRIPTION
## Summary

The CLI pre-flight demanded `DATABRICKS_TOKEN` in both the run gate and `env check --platform databricks`, while the SDK it gates resolves credentials as token → `AZURE_*` service principal → Azure CLI login. PAT-disabled workspaces (perfectly usable via `az login`) were blocked before the SDK ever ran.

This models auth as per-platform alternatives evaluated once in SDK order and rendered by all three consumers (run gate, `env check --platform`, `env check` auto-detect):

- **`_PLATFORM_BASE_VARS[databricks]` shrinks to the resource locator** (`DATABRICKS_HOST`); auth is modeled separately in a new `_PLATFORM_AUTH_ALTERNATIVES` table
- **New lazy az-cli probe** (`az account get-access-token --output none`, bounded 15s timeout, no token text on stdout) runs only when the token is absent and the SP triple incomplete; all failure modes → False
- **New `_require_platform_credentials()`** dedupes the run-gate message in `_create_platform_api` and `_resolve_remote_platform`; databricks failures list all three alternatives plus the PAT-disabled workaround (Entra ID token minted for the Databricks first-party resource). fabric/synapse run gates stay base-vars-only
- **`env check --platform`** renders base vars as before plus an "Auth — one of:" section; exit 0 iff base vars set and one alternative satisfied. fabric/synapse align with the run gate and auto-detect: an absent SP triple passes with an informational az login / managed identity line, a partial SP triple still fails naming the missing vars; never az-probed since `DefaultAzureCredential` is broader than the az CLI
- **`env check` auto-detect** appends a `databricks_auth` check

## Test plan

- `poe test-unit`: **2246 passed**, 1 skipped — includes ~296 lines of new/updated `test_cli.py` coverage (auth-alternative evaluation for all SP full/partial/absent cases, az-probe failure modes, env check rendering)
- Internal review: APPROVE — implementation matches the approved DESIGN exactly; `_evaluate_platform_auth` traced by hand for all SP cases; all findings informational
- CHANGELOG calls out the fabric/synapse behavior-change risk (CI jobs enforcing SP presence via env check now pass in the no-SP case)
- gitleaks scan of push range: clean

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)
