### PR TITLE
feat(telemetry): comprehensive built-in tracing instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,70 @@
 
 All notable changes to spark-kindling are documented here.
 
+## Unreleased
+
+### Added
+
+- **Comprehensive tracing instrumentation** (gh#210): every major framework
+  operation now produces a coherent span tree on all three trace providers.
+  - Entity-provider operations (read/write/append/merge/replace/ensure/
+    stream setup) are traced automatically at the `EntityProviderRegistry`
+    chokepoint (`kindling.trace_ops`) — object identity, `isinstance`
+    capability probes, and `hasattr` checks are preserved; micro-batch hot
+    loops never produce spans.
+  - Structural seam spans: pipe read/persist, watermark
+    get_cursor/save_cursor/read_changes, config reload, migration
+    plan/apply/per-entity/per-change/blue-green sub-steps/snapshot,
+    orchestrator plan/generation/pipe (covering retries), streaming
+    orchestrator start/stop and recovery attempts, file ingestion
+    (per-file at verbose level), and job deploy/create/run.
+  - Bootstrap span tree: phase windows (config download → app run) are
+    recorded and retro-flushed as `kindling.bootstrap/initialize` plus one
+    child per phase with faithful timestamps via the new
+    `SparkTraceProvider.record_span` (concrete ABC default, so third-party
+    providers keep working).
+  - Design-time CLI spans (`kindling.cli`) around workspace init/deploy,
+    app deploy/run, package deploy, and runtime deploy, gated by
+    `KINDLING_TRACE=1` (no ConfigService exists pre-app-load).
+  - New config keys `kindling.telemetry.tracing.enabled` (default true)
+    and `kindling.telemetry.tracing.level` (minimal/standard/verbose,
+    default standard), read once at initialization.
+  - Spans now carry `parent_id`/`parentSpanId`, so trees are linked
+    explicitly rather than inferred from time containment.
+  - Public `kindling.test_framework.RecordingTraceProvider` for asserting
+    span structure in tests (`find()`/`tree()` helpers).
+  - Decision record: `docs/proposals/comprehensive_tracing_instrumentation.md`.
+
+### Changed
+
+- **Span names normalized to the `kindling.<area>` convention** (gh#210):
+  `data_pipes_executer/execute_datapipes` → `kindling.pipes/run`,
+  `pipe-{pipeid}/execute_datapipe` → `kindling.pipes/pipe.run` (+`pipe_id`
+  attr), `data_utils/merge_and_watermark|replace_entity_table` → single
+  `kindling.pipes/persist` span, stage spans → `kindling.pipes/stage`,
+  `kindling-app-{name}/*` → `kindling.apps/*` (+`app_name` attr),
+  `SimpleFileIngestionProcessor/process_path` → `kindling.ingestion/process`,
+  `query-{label}/streaming_query` → `kindling.streaming/query` (+ label
+  attr), generation executor `execute_{mode}` → `kindling.orchestrator/run`.
+  Dashboards keyed on the old names must re-key. Span attributes are now
+  whitelisted per seam — `pipe.tags`/caller-supplied stage details are no
+  longer exported wholesale (tags may carry credential references).
+- `EventBasedSparkTrace` restores the enclosing span on exit: consecutive
+  top-level operations in one session now get distinct trace ids (matching
+  the plain and OTel providers) instead of blurring into one trace.
+
+### Fixed
+
+- **Failed merges can no longer advance the watermark past unpersisted
+  data**: the batch persist path swallowed merge/append failures inside a
+  `reraise=False` span, fired `persist.after_persist`, and let
+  WatermarkAspect record the pending cursor. The consolidated persist span
+  propagates failures, pairing `persist.persist_failed` with the raise.
+- `AzureMonitorTraceProvider.start_span` constructed `SparkSpan` without
+  the required `traceId` (TypeError on first manual span under the otel
+  provider); it now adopts the OTel trace id when available.
+- File ingestion's trace component no longer names a nonexistent class.
+
 ## [0.12.1] - 2026-07-29
 
 ### Fixed

--- a/docs/contributing/logging_tracing.md
+++ b/docs/contributing/logging_tracing.md
@@ -110,6 +110,41 @@ logger = lp.get_logger("custom_logger").with_pattern(
 
 The tracing system provides distributed tracing capabilities to track operations across multiple components, including capturing timing, errors, and context information.
 
+### Span naming convention
+
+Spans follow a fixed naming scheme so the exported span-name set stays small
+(an OTel export cardinality constraint) and dashboards stay stable:
+
+- **component** = `kindling.<area>`: `kindling.pipes`, `kindling.entity.<provider_type>`,
+  `kindling.watermark`, `kindling.config`, `kindling.migration`,
+  `kindling.bootstrap`, `kindling.streaming`, `kindling.orchestrator`,
+  `kindling.ingestion`, `kindling.apps`, `kindling.deploy`, `kindling.cli`.
+  The constants live in `kindling.trace_ops`.
+- **operation** = a short stable verb (`run`, `pipe.run`, `read`, `persist`,
+  `get_cursor`, `apply`, …). Ids, names, and counts are span **attributes**,
+  never part of the component or operation.
+- **attributes are whitelisted per seam**: ids (`pipe_id`, `entity_id`,
+  `run_id`, `persist_id`, …), `provider_type`, durations, counts, booleans,
+  and cursors. Never export `entity.tags`/`pipe.tags` wholesale (tags may
+  carry credential references), never DataFrames, and never call
+  `df.count()` just to record a size — actions in span details run real
+  Spark jobs.
+- **levels**: spans are tiered `minimal` (bootstrap, pipes run/pipe/read/
+  persist, migration, apps, deploy, cli), `standard` (adds provider ops,
+  watermark, config reload, streaming lifecycle, orchestrator
+  plan/generation), and `verbose` (adds per-file ingestion spans). See the
+  `kindling.telemetry.tracing.*` keys in the configuration reference.
+- All framework instrumentation passes `reraise=True`: a span must never
+  swallow the exception it observed.
+
+Provider entity operations (`read_entity`, `merge_to_entity`, …) are traced
+automatically at the `EntityProviderRegistry` chokepoint — do not add
+per-provider spans for them. Hot loops never produce spans: streaming
+micro-batches are span *events* on the long-lived query span
+(`kindling.streaming`/`query`), and `DeltaEntityProvider._merge_batch`
+deliberately bypasses the per-instance op wrapper via
+`type(self).merge_to_entity(self, ...)`.
+
 ### Core Components
 
 #### CustomEventEmitter
@@ -184,7 +219,32 @@ class SparkTraceProvider(ABC):
     ) -> None:
         """End a manually started span. Optionally record an error."""
         pass
+
+    def record_span(
+        self,
+        operation: str,
+        component: str,
+        start_time: datetime,
+        end_time: datetime,
+        details: dict = None,
+        error: Optional[str] = None,
+    ) -> None:
+        """Record an already-completed span with explicit timestamps."""
 ```
+
+`record_span` is a **concrete default** on the ABC (it routes through
+`start_span`/`end_span` and carries the true timestamps in
+`recordedStartTime`/`recordedEndTime` details), so third-party or
+duck-typed providers keep working without changes. The built-in providers
+override it to honor the given timestamps natively — bootstrap uses this to
+retro-flush its phase tree once a provider is finally resolvable.
+
+Spans also carry a `parent_id` (the enclosing span's id at open time, `None`
+for roots), emitted as `parentSpanId` in START/END event details by the
+event-based providers. Trees are therefore reconstructable by explicit
+links, not just time containment. The OTel provider parents natively.
+Exiting a span restores the enclosing span as current, so consecutive
+top-level operations get distinct trace ids.
 
 #### EventBasedSparkTrace
 
@@ -341,12 +401,15 @@ inline comment.
    - WARN: Warning conditions
    - ERROR: Error conditions
 
-3. **Structured Details**: Include structured details in traces for easier analysis:
+3. **Structured, whitelisted details**: Include structured details in traces
+   for easier analysis — ids, counts you already have, booleans, cursors.
+   Never trigger Spark actions to fill an attribute (`df.count()` runs a
+   real job), and never pass tag dictionaries wholesale:
    ```python
    details = {
        "entity_id": entity.entityid,
-       "record_count": df.count(),
-       "execution_id": execution_id
+       "row_count": already_computed_count,  # never df.count() here
+       "execution_id": execution_id,
    }
    ```
 
@@ -356,4 +419,17 @@ inline comment.
    ```python
    with trace_provider.span(component="Processing", operation="TransformData", reraise=True):
        # With reraise=True, exceptions will be captured in the trace and then re-thrown
+   ```
+
+6. **Testing spans**: assert span structure with the public
+   `kindling.test_framework.RecordingTraceProvider` — it records every span
+   (component, operation, details, parent_id, events, errors, open/close
+   order) and offers `find(component=, operation=)` and `tree()` helpers:
+   ```python
+   from kindling.test_framework import RecordingTraceProvider
+
+   tp = RecordingTraceProvider()
+   service = MyService(tp=tp, ...)
+   service.do_work()
+   assert tp.find(component="kindling.pipes", operation="persist")[0].closed
    ```

--- a/docs/proposals/comprehensive_tracing_instrumentation.md
+++ b/docs/proposals/comprehensive_tracing_instrumentation.md
@@ -1,0 +1,124 @@
+# Proposal: Comprehensive Tracing Instrumentation
+
+**Status:** Implemented (gh#210). This document is the decision record for
+how the framework got span coverage and, in particular, why the
+signal-bridging aspect approach was rejected.
+
+## Goal
+
+A coherent span tree for every major framework operation on all three trace
+providers (EventBasedSparkTrace, PlainPythonTraceProvider,
+AzureMonitorTraceProvider), assertable in unit tests, with no code changes
+required to adopt and nothing emitted from hot loops:
+
+- standalone `run_datapipes` yields `run → pipe.run → read×N → persist`
+  with entity-provider operation children;
+- bootstrap yields `initialize → config_download → … → app_run`;
+- migration, streaming, deploy, and design-time CLI operations yield
+  equivalent trees.
+
+## Decision summary
+
+1. **Provider-op tracer at the registry chokepoint** (`kindling.trace_ops`).
+   Every provider resolution funnels through
+   `EntityProviderRegistry.get_provider`; the resolved instance's op methods
+   are shadowed per-instance with span wrappers. Object identity is
+   preserved, so `isinstance` capability probes, `hasattr` checks
+   (`merge_to_entity` is in no ABC), and cached-singleton semantics all
+   hold. This is the "provider-wide coverage without touching providers".
+   The legacy `EntityProvider` DI singleton (the `self.ep` path) is the same
+   delta instance, wrapped once at bootstrap.
+2. **Direct context-manager spans at structural seams** — pipes
+   read/persist, watermarking, config reload, migration, orchestrator
+   plan/generation/pipe, streaming lifecycle and recovery, ingestion,
+   deploy. All new instrumentation passes `reraise=True`.
+3. **Bootstrap tree via retro-recording.** Early phases predate a usable
+   ConfigService and the final provider is only settled after extension
+   imports, so live early spans are impossible by construction. Phase
+   windows are recorded in a plain list and flushed once at the end of a
+   full initialization through the new `record_span` provider method
+   (explicit timestamps). Failures before a usable ConfigService lose the
+   tree (stdlib logs only).
+4. **Config-first gating**: `kindling.telemetry.tracing.enabled` (default
+   true) and `kindling.telemetry.tracing.level`
+   (minimal/standard/verbose, default standard), read once at bootstrap
+   wiring (registration-gated like WatermarkAspect) and cached per service.
+   The `telemetry.tracing.*` namespace was chosen over the issue's literal
+   `kindling.tracing.*` for family consistency.
+5. **Naming convention**: component = `kindling.<area>`, operation = short
+   stable verb, ids/counts as whitelisted attributes, never in names.
+   Existing spans were renamed to the convention while adoption is low
+   (`execute_datapipes` → `kindling.pipes`/`run`, `pipe-{id}` →
+   `pipe.run` + `pipe_id` attr, `query-{label}` →
+   `kindling.streaming`/`query`, …). The pipe span previously exported
+   `pipe.tags` wholesale — tags may carry credential references and are now
+   replaced by a whitelist.
+6. **Design-time CLI**: separate process, no DI — a lazily built
+   PlainPythonTraceProvider gated by `KINDLING_TRACE=1`. The SDK stays
+   untouched (it deliberately has no kindling-core dependency); CLI-side
+   spans bracket its calls.
+7. **Provider-layer fixes** required for tree coherence: parent restore on
+   span exit in EventBasedSparkTrace (consecutive runs no longer share a
+   trace id), `SparkSpan.parent_id` + `parentSpanId` emission (trees are
+   linked, not inferred from time containment), the otel `start_span`
+   missing-`traceId` TypeError, and `record_span` (ABC-default so
+   third-party providers keep working).
+8. **Persist reraise fix** (data correctness, found during design): the
+   batch persist path swallowed merge failures (`reraise=False` inner
+   span), fired `persist.after_persist`, and let WatermarkAspect advance
+   the watermark past unpersisted data. The consolidated persist span
+   passes `reraise=True` and the failure path is regression-tested.
+
+## Rejected: signal-bridging TraceAspect (issue option 1)
+
+The issue's preferred direction was an aspect subscribing to signals and
+pairing before/after emissions into spans, on the principle that signals
+are the universal instrumentation seam. Inverting the gap analysis (adding
+signals where they are missing rather than direct spans) was explicitly
+considered and rejected on evidence:
+
+- **No correlation keys** outside four seams (persist_id, execution_id,
+  run_id, batch_id): before/after pairing is ambiguous under DAG-parallel
+  execution. `SignalPayload.operation_id` exists but is used nowhere.
+- **Missing failure signals** (`entity.read_failed`, `watermark.get_failed`,
+  …): a bridged span would leak open on failure. Observability needs
+  exception-safe bracketing that today's payloads cannot guarantee — the
+  WatermarkAspect precedent attaches *behavior* via signals, not brackets.
+- **Provider signals are delta-only** (SignalEmitter is mixed into that one
+  concrete class; 1/9 coverage), so "bridge the signals" degenerates into
+  "add emissions to every provider" — at which point the aspect's
+  no-per-provider-edits advantage evaporates.
+- **Paired events cannot context-nest**: the OTel provider needs a live
+  context manager for parenting; bridged pairs produce flat trees.
+- **Hot-loop budget**: delta's `merge_as_stream` emits
+  `entity.before/after_merge` per micro-batch; bridging would turn every
+  batch into spans. (That per-batch signal cost itself is a latent issue if
+  a consumer ever subscribes — noted, untouched here.)
+
+Revisit only if signals later gain a uniform `operation_id` plus complete
+failure pairs. Other rejected alternatives: `set_provider_decorator` as the
+op-tracer seam (single-slot public seam claimed for execution-mode provider
+personalities; taking it breaks user decorators), dynamic subclass proxies
+(break cached-instance identity), and a NoopTraceProvider binding for
+`enabled=false` (registration-gating is simpler and matches the
+WatermarkAspect pattern).
+
+## Accepted risks / follow-ups
+
+- **Span renames change exported names**: dashboards keyed on
+  `execute_datapipes`/`merge_and_watermark` must re-key. Normalizing now,
+  while adoption is low, was chosen over freezing legacy names.
+- **EventBased parent-restore changes semantics**: consecutive runs in one
+  session previously shared one trace id; each top-level operation is now
+  its own trace (matches Plain/OTel).
+- **DAG-parallel + OTel**: worker-thread pipe spans do not parent to the
+  run span (OTel context does not cross threads automatically; core cannot
+  import otel). EventBased/Plain inherit the trace id via the shared
+  current_span — racy but functional, pre-existing. Follow-up if needed:
+  contextvars-based current span with propagation at task submission.
+- **Otel extension without a connection string silently no-ops all spans**
+  — pre-existing, more consequential now that instrumentation is
+  comprehensive. Recommended follow-up issue: warn and fall back.
+- **Defaults on** (`enabled=true`, `level=standard`) add span volume for
+  every user on upgrade, honoring "no code changes to adopt"; the opt-out
+  is documented in the configuration reference.

--- a/docs/reference/config_reference.md
+++ b/docs/reference/config_reference.md
@@ -152,18 +152,40 @@ YAML keys:
 - `kindling.telemetry.logging.level`: Logging level (INFO/WARN/DEBUG).
 - `kindling.telemetry.logging.print`: If true, print logs to stdout.
 - `kindling.telemetry.tracing.print`: If true, print trace spans to stdout.
+- `kindling.telemetry.tracing.enabled` (default `true`): Master switch for
+  the framework's span instrumentation — provider-op tracing, structural
+  seam spans, and the bootstrap span tree. Read once at initialization
+  (registration-gated); a config hot-reload does not re-gate a running
+  process. Set `false` to opt out of instrumentation added in 0.13.
+- `kindling.telemetry.tracing.level` (`minimal` | `standard` | `verbose`,
+  default `standard`): Span volume tier. `minimal` keeps bootstrap, pipe
+  run/read/persist, migration, app, deploy, and CLI spans. `standard` adds
+  entity-provider operation spans, watermark spans, config reload,
+  streaming lifecycle, and orchestrator plan/generation spans. `verbose`
+  adds per-file ingestion spans.
+- `kindling.telemetry.azure_monitor.enable_logging` /
+  `kindling.telemetry.azure_monitor.enable_tracing`: Enable the Azure
+  Monitor OpenTelemetry providers (requires the `kindling-ext-otel-azure`
+  extension).
+- `kindling.telemetry.azure_monitor.connection_string`: Application
+  Insights connection string used by the Azure Monitor providers. Without
+  it the extension's providers no-op.
 
 Flat keys (supported for bootstrap/back-compat):
 
 - `log_level`: Logging level.
 - `print_logging`: Print logs to stdout.
-- `print_trace`: Print traces to stdout.
+- `print_trace` / `print_tracing`: Print traces to stdout.
 
 Legacy/compat keys (translated into flat keys):
 
 - `kindling.TELEMETRY.logging.level`
 - `kindling.TELEMETRY.logging.print`
 - `kindling.TELEMETRY.tracing.print`
+
+Design-time CLI tracing (no ConfigService exists before an app loads) is
+env-gated instead: `KINDLING_TRACE=1` enables `kindling.cli` spans and
+`KINDLING_KINDLING__TELEMETRY__TRACING__PRINT=true` prints them.
 
 ### Secrets
 

--- a/packages/extensions/kindling_ext_otel_azure/kindling_ext_otel_azure/trace_provider.py
+++ b/packages/extensions/kindling_ext_otel_azure/kindling_ext_otel_azure/trace_provider.py
@@ -1,16 +1,16 @@
 """Azure Monitor OpenTelemetry trace provider implementation."""
 
+import uuid
 from contextlib import contextmanager
 from datetime import datetime
 from typing import Any, Dict, Optional
 
 from injector import inject
-from opentelemetry import trace
-from opentelemetry.trace import Status, StatusCode
-
 from kindling.injection import GlobalInjector
 from kindling.spark_config import ConfigService
 from kindling.spark_trace import SparkSpan, SparkTraceProvider
+from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
 
 from .config import AzureMonitorConfig
 
@@ -154,11 +154,18 @@ class AzureMonitorTraceProvider(SparkTraceProvider):
                 otel_span.set_attribute("operation", operation)
             self._set_span_attributes(otel_span, details)
 
+        trace_id = None
+        if otel_span is not None:
+            span_context = otel_span.get_span_context()
+            if span_context is not None and span_context.trace_id:
+                trace_id = uuid.UUID(int=span_context.trace_id)
+
         spark_span = SparkSpan(
             id=str(id(otel_span)) if otel_span else "noop",
             component=component or "",
             operation=operation or "",
             attributes=details or {},
+            traceId=trace_id or uuid.uuid4(),
             start_time=datetime.now(),
             reraise=False,
         )
@@ -196,3 +203,35 @@ class AzureMonitorTraceProvider(SparkTraceProvider):
             else:
                 otel_span.set_status(Status(StatusCode.OK))
             otel_span.end()
+
+    def record_span(
+        self,
+        operation: str,
+        component: str,
+        start_time: datetime,
+        end_time: datetime,
+        details: dict = None,
+        error: Optional[str] = None,
+    ) -> None:
+        """Record an already-completed span, honoring the given timestamps."""
+        if not self._tracer:
+            return
+        span_name = (
+            f"{component}.{operation}"
+            if component and operation
+            else (operation or component or "span")
+        )
+        otel_span = self._tracer.start_span(
+            span_name, start_time=int(start_time.timestamp() * 1_000_000_000)
+        )
+        if component:
+            otel_span.set_attribute("component", component)
+        if operation:
+            otel_span.set_attribute("operation", operation)
+        self._set_span_attributes(otel_span, details)
+        if error:
+            otel_span.set_status(Status(StatusCode.ERROR, error))
+            otel_span.add_event("error", attributes={"exception.message": error})
+        else:
+            otel_span.set_status(Status(StatusCode.OK))
+        otel_span.end(end_time=int(end_time.timestamp() * 1_000_000_000))

--- a/packages/kindling/bootstrap.py
+++ b/packages/kindling/bootstrap.py
@@ -1848,6 +1848,19 @@ def initialize_framework(config: Dict[str, Any], app_name: Optional[str] = None)
             GlobalInjector.get(WatermarkAspect).register()
             logger.info("Watermark aspect registered")
 
+        # Registration-gated tracing wiring (WatermarkAspect pattern): read
+        # kindling.telemetry.tracing.* once and enable provider-op tracing at
+        # the registry chokepoint. Runs on every platform — standalone pipe
+        # runs must produce span trees too. A config reload does not
+        # un-register. Extensions have already imported by now, so the
+        # resolved SparkTraceProvider is the final one for this process.
+        try:
+            from kindling.trace_ops import configure_op_tracing
+
+            configure_op_tracing(config_service, logger)
+        except Exception as tracing_error:
+            logger.debug(f"Provider op tracing wiring failed (non-fatal): {tracing_error}")
+
         # Apply spark_configs to the live Spark session.
         # This must happen after the session exists so conf.set() works.
         _apply_spark_configs(config_service, logger)

--- a/packages/kindling/bootstrap.py
+++ b/packages/kindling/bootstrap.py
@@ -8,6 +8,8 @@ import subprocess
 import sys
 import tempfile
 import uuid
+from contextlib import contextmanager
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -39,6 +41,89 @@ _BOOTSTRAP_STAGE_ID = uuid.uuid4().hex[:12]
 _BOOTSTRAP_LOGGER = logging.getLogger("kindling.bootstrap")
 _LOCAL_PACKAGE_MODULES_ENV = "KINDLING_LOCAL_PACKAGE_MODULES"
 _LOCAL_PACKAGE_REGISTRATION_NAMESPACES = ("entities", "pipes", "ingestion")
+
+
+class _BootstrapPhaseRecorder:
+    """Collects bootstrap phase timings before any trace provider can exist.
+
+    Early bootstrap phases predate a usable ConfigService, and the final
+    trace-provider identity is only settled once extensions have imported —
+    live spans are impossible by construction. Phases are recorded here
+    (plain list, no DI, no JVM) and retro-flushed as one span tree at the
+    end of a full initialization via SparkTraceProvider.record_span.
+    """
+
+    def __init__(self):
+        self.phases: List[Dict[str, Any]] = []
+        self.start_time: Optional[datetime] = None
+
+    def reset(self, start_time: datetime) -> None:
+        self.phases = []
+        self.start_time = start_time
+
+
+_PHASE_RECORDER = _BootstrapPhaseRecorder()
+
+
+@contextmanager
+def _bootstrap_phase(name: str):
+    """Record one bootstrap phase's wall-clock window (and error, if any)."""
+    entry: Dict[str, Any] = {"name": name, "start": datetime.now(), "end": None, "error": None}
+    _PHASE_RECORDER.phases.append(entry)
+    try:
+        yield
+    except Exception as phase_error:
+        entry["error"] = str(phase_error)
+        raise
+    finally:
+        entry["end"] = datetime.now()
+
+
+def _flush_bootstrap_trace(config_service, error: Optional[str] = None) -> None:
+    """Retro-record the bootstrap span tree once a provider is resolvable.
+
+    Emits a root kindling.bootstrap/initialize span (a live CM span so the
+    per-phase children parent to it and share its trace id on every
+    provider) whose true window rides in attributes, plus one record_span
+    child per phase with the faithful timestamps. Failures preceding a
+    usable ConfigService never reach this point — that tree is lost and
+    only stdlib-logged (documented limitation). Flushing must never break
+    bootstrap.
+    """
+    recorder = _PHASE_RECORDER
+    if recorder.start_time is None or not recorder.phases:
+        return
+    try:
+        from kindling.spark_trace import SparkTraceProvider
+        from kindling.trace_ops import COMPONENT_BOOTSTRAP, tracing_gates
+
+        if not tracing_gates(config_service).minimal:
+            return
+        tp = GlobalInjector.get(SparkTraceProvider)
+        end_time = recorder.phases[-1]["end"] or datetime.now()
+        root_details = {
+            "started_at": recorder.start_time.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3],
+            "duration_seconds": f"{(end_time - recorder.start_time).total_seconds():.3f}",
+            "phase_count": len(recorder.phases),
+        }
+        if error:
+            root_details["error"] = error
+        with tp.span(operation="initialize", component=COMPONENT_BOOTSTRAP, details=root_details):
+            for entry in recorder.phases:
+                tp.record_span(
+                    entry["name"],
+                    COMPONENT_BOOTSTRAP,
+                    entry["start"],
+                    entry["end"] or end_time,
+                    error=entry["error"],
+                )
+    except Exception as flush_error:
+        _BOOTSTRAP_LOGGER.debug("Bootstrap trace flush failed (non-fatal): %s", flush_error)
+    finally:
+        # One flush per recorded initialization — a later failed/aborted
+        # init must not re-emit this tree.
+        recorder.phases = []
+        recorder.start_time = None
 
 
 def _parse_spark_conf_value(value: Any) -> Any:
@@ -1623,6 +1708,11 @@ def initialize_framework(config: Dict[str, Any], app_name: Optional[str] = None)
         _import_local_package_registrations(logger_provider.get_logger("KindlingBootstrap"))
         return existing_service
 
+    # Full (non-short-circuited) initialization: record phase timings for the
+    # retro-flushed bootstrap span tree. Short-circuited re-inits above
+    # deliberately record nothing.
+    _PHASE_RECORDER.reset(start_time=datetime.now())
+
     # Extract bootstrap settings
     artifacts_storage_path = config.get("artifacts_storage_path")
     explicit_platform = config.get("platform_environment") or config.get("platform")
@@ -1661,30 +1751,46 @@ def initialize_framework(config: Dict[str, Any], app_name: Optional[str] = None)
             # Continue without platform/workspace-specific configs
 
     if use_lake_packages and artifacts_storage_path:
-        initial_temp_path = _resolve_initial_download_temp_path(config, platform)
-        downloaded_config_files = download_config_files(
-            artifacts_storage_path=artifacts_storage_path,
-            environment=environment,
-            platform=platform,
-            workspace_id=workspace_id,
-            app_name=app_name,
-            temp_path=initial_temp_path,
-        )
-        if config_files:
-            config_files = downloaded_config_files + config_files
-        else:
-            config_files = downloaded_config_files
+        with _bootstrap_phase("config_download"):
+            initial_temp_path = _resolve_initial_download_temp_path(config, platform)
+            downloaded_config_files = download_config_files(
+                artifacts_storage_path=artifacts_storage_path,
+                environment=environment,
+                platform=platform,
+                workspace_id=workspace_id,
+                app_name=app_name,
+                temp_path=initial_temp_path,
+            )
+            if config_files:
+                config_files = downloaded_config_files + config_files
+            else:
+                config_files = downloaded_config_files
 
     from kindling.spark_config import configure_injector_with_config
 
     # Check if ConfigService is already properly initialized
-    try:
-        config_service = get_kindling_service(ConfigService)
-        # Check if it's actually initialized (dynaconf will be None if not)
-        if hasattr(config_service, "dynaconf") and config_service.dynaconf is not None:
-            _BOOTSTRAP_LOGGER.debug("Config service already initialized, skipping configuration")
-        else:
-            # ConfigService exists but not initialized yet, set it up
+    with _bootstrap_phase("config_init"):
+        try:
+            config_service = get_kindling_service(ConfigService)
+            # Check if it's actually initialized (dynaconf will be None if not)
+            if hasattr(config_service, "dynaconf") and config_service.dynaconf is not None:
+                _BOOTSTRAP_LOGGER.debug(
+                    "Config service already initialized, skipping configuration"
+                )
+            else:
+                # ConfigService exists but not initialized yet, set it up
+                injector = configure_injector_with_config(
+                    config_files=config_files,
+                    initial_config=config,  # BOOTSTRAP_CONFIG as overrides
+                    environment=environment,
+                    artifacts_storage_path=artifacts_storage_path,
+                    platform=platform,
+                    workspace_id=workspace_id,
+                    app_name=app_name,
+                )
+                config_service = get_kindling_service(ConfigService)
+        except Exception:
+            # ConfigService doesn't exist yet, set it up
             injector = configure_injector_with_config(
                 config_files=config_files,
                 initial_config=config,  # BOOTSTRAP_CONFIG as overrides
@@ -1695,41 +1801,31 @@ def initialize_framework(config: Dict[str, Any], app_name: Optional[str] = None)
                 app_name=app_name,
             )
             config_service = get_kindling_service(ConfigService)
-    except Exception:
-        # ConfigService doesn't exist yet, set it up
-        injector = configure_injector_with_config(
-            config_files=config_files,
-            initial_config=config,  # BOOTSTRAP_CONFIG as overrides
-            environment=environment,
-            artifacts_storage_path=artifacts_storage_path,
-            platform=platform,
-            workspace_id=workspace_id,
-            app_name=app_name,
-        )
-        config_service = get_kindling_service(ConfigService)
 
     logger = get_kindling_service(PythonLoggerProvider).get_logger("KindlingBootstrap")
     logger.info("Starting framework initialization")
 
     # Best-effort runtime feature discovery. These values are written into
     # kindling.runtime.features.* and can be overridden by kindling.features.*.
-    try:
-        from kindling.features import discover_runtime_features
+    with _bootstrap_phase("feature_discovery"):
+        try:
+            from kindling.features import discover_runtime_features
 
-        discover_runtime_features(config_service, logger=logger)
-    except Exception as feature_error:
-        logger.debug(f"Runtime feature discovery failed (non-fatal): {feature_error}")
+            discover_runtime_features(config_service, logger=logger)
+        except Exception as feature_error:
+            logger.debug(f"Runtime feature discovery failed (non-fatal): {feature_error}")
 
     # Capability-based telemetry selection: without a py4j JVM bridge (UC
     # shared/standard access mode clusters, Spark Connect) the JVM-backed
     # providers only degrade per call; swap in the plain-python
     # implementations instead. Overridable via kindling.features.spark.jvm_bridge.
-    try:
-        if get_feature_bool(config_service, "spark.jvm_bridge", default=True) is False:
-            _bind_plain_telemetry_providers(logger)
-            logger = get_kindling_service(PythonLoggerProvider).get_logger("KindlingBootstrap")
-    except Exception as telemetry_error:
-        logger.debug(f"Telemetry provider selection failed (non-fatal): {telemetry_error}")
+    with _bootstrap_phase("telemetry_binding"):
+        try:
+            if get_feature_bool(config_service, "spark.jvm_bridge", default=True) is False:
+                _bind_plain_telemetry_providers(logger)
+                logger = get_kindling_service(PythonLoggerProvider).get_logger("KindlingBootstrap")
+        except Exception as telemetry_error:
+            logger.debug(f"Telemetry provider selection failed (non-fatal): {telemetry_error}")
 
     # Helpful diagnostics for system tests / feature-gated behavior.
     # These keys are safe to log (no secrets) and explain why certain Delta operations
@@ -1757,6 +1853,7 @@ def initialize_framework(config: Dict[str, Any], app_name: Optional[str] = None)
     except Exception:
         pass
 
+    _bootstrap_error = None
     try:
         # Read from general kindling config (not bootstrap namespace)
         # bootstrap is just for temp backwards compatibility mapping
@@ -1820,16 +1917,18 @@ def initialize_framework(config: Dict[str, Any], app_name: Optional[str] = None)
         if install_bootstrap_dependencies_flag is None:
             install_bootstrap_dependencies_flag = platform != "standalone"
 
-        if install_bootstrap_dependencies_flag:
-            install_bootstrap_dependencies(
-                logger,
-                bootstrap_deps_config,
-                artifacts_storage_path=artifacts_storage_path,
-            )
-        else:
-            logger.info("Skipping bootstrap dependency installation")
+        with _bootstrap_phase("dependency_install"):
+            if install_bootstrap_dependencies_flag:
+                install_bootstrap_dependencies(
+                    logger,
+                    bootstrap_deps_config,
+                    artifacts_storage_path=artifacts_storage_path,
+                )
+            else:
+                logger.info("Skipping bootstrap dependency installation")
 
-        platformservice = initialize_platform_services(platform, config_service, logger)
+        with _bootstrap_phase("platform_init"):
+            platformservice = initialize_platform_services(platform, config_service, logger)
         logger.info("Platform services initialized")
 
         # Attach the watermark aspect: incremental reads and watermark
@@ -1841,47 +1940,52 @@ def initialize_framework(config: Dict[str, Any], app_name: Optional[str] = None)
         # owns_incrementality capability, surfaced here as config by
         # initialize()) also runs without it — the aspect is simply never
         # registered.
-        if platform != "standalone" and not config.get("engine_owns_incrementality"):
-            from kindling.injection import GlobalInjector
-            from kindling.watermarking import WatermarkAspect
+        with _bootstrap_phase("aspect_registration"):
+            if platform != "standalone" and not config.get("engine_owns_incrementality"):
+                from kindling.injection import GlobalInjector
+                from kindling.watermarking import WatermarkAspect
 
-            GlobalInjector.get(WatermarkAspect).register()
-            logger.info("Watermark aspect registered")
+                GlobalInjector.get(WatermarkAspect).register()
+                logger.info("Watermark aspect registered")
 
-        # Registration-gated tracing wiring (WatermarkAspect pattern): read
-        # kindling.telemetry.tracing.* once and enable provider-op tracing at
-        # the registry chokepoint. Runs on every platform — standalone pipe
-        # runs must produce span trees too. A config reload does not
-        # un-register. Extensions have already imported by now, so the
-        # resolved SparkTraceProvider is the final one for this process.
-        try:
-            from kindling.trace_ops import configure_op_tracing
+            # Registration-gated tracing wiring (WatermarkAspect pattern):
+            # read kindling.telemetry.tracing.* once and enable provider-op
+            # tracing at the registry chokepoint. Runs on every platform —
+            # standalone pipe runs must produce span trees too. A config
+            # reload does not un-register. Extensions have already imported
+            # by now, so the resolved SparkTraceProvider is the final one
+            # for this process.
+            try:
+                from kindling.trace_ops import configure_op_tracing
 
-            configure_op_tracing(config_service, logger)
-        except Exception as tracing_error:
-            logger.debug(f"Provider op tracing wiring failed (non-fatal): {tracing_error}")
+                configure_op_tracing(config_service, logger)
+            except Exception as tracing_error:
+                logger.debug(f"Provider op tracing wiring failed (non-fatal): {tracing_error}")
 
         # Apply spark_configs to the live Spark session.
         # This must happen after the session exists so conf.set() works.
-        _apply_spark_configs(config_service, logger)
-        _import_local_package_registrations(logger)
+        with _bootstrap_phase("registrations_import"):
+            _apply_spark_configs(config_service, logger)
+            _import_local_package_registrations(logger)
 
         # Overlay datapipes:/dataentities: config sections onto everything
         # registered so far; the managers keep the compiled patterns so
         # later registrations (workspace packages, app register_all) are
         # overlaid at registration — before any pipe executes.
-        apply_config_overrides()
+        with _bootstrap_phase("config_overlay"):
+            apply_config_overrides()
         logger.info("Config overrides applied to registered pipes and entities")
 
         # Resolve any @secret references now that platform services are available.
-        try:
-            from kindling.config_loaders import load_secrets_from_provider
+        with _bootstrap_phase("secret_resolution"):
+            try:
+                from kindling.config_loaders import load_secrets_from_provider
 
-            if hasattr(config_service, "dynaconf") and config_service.dynaconf is not None:
-                load_secrets_from_provider(config_service.dynaconf, silent=True)
-                logger.debug("Resolved @secret references with platform secret provider")
-        except Exception as secret_resolution_error:
-            logger.warning(f"Secret resolution pass failed: {secret_resolution_error}")
+                if hasattr(config_service, "dynaconf") and config_service.dynaconf is not None:
+                    load_secrets_from_provider(config_service.dynaconf, silent=True)
+                    logger.debug("Resolved @secret references with platform secret provider")
+            except Exception as secret_resolution_error:
+                logger.warning(f"Secret resolution pass failed: {secret_resolution_error}")
 
         load_workspace_packages_default = False if platform == "standalone" else True
         load_workspace_packages_value = config_service.get(
@@ -1909,48 +2013,59 @@ def initialize_framework(config: Dict[str, Any], app_name: Optional[str] = None)
             f"(type: {type(load_workspace_packages_flat).__name__})"
         )
 
-        if load_workspace_packages_value:
-            ignored_folders = config_service.get("kindling.bootstrap.ignored_folders", [])
-            workspace_packages = get_kindling_service(NotebookManager).get_all_packages(
-                ignored_folders=ignored_folders
-            )
-            logger.debug(
-                f"Found {len(workspace_packages)} workspace packages: {workspace_packages}"
-            )
-            load_workspace_packages(platformservice, workspace_packages, logger)
-            logger.info(f"Loaded {len(workspace_packages)} workspace packages")
-        else:
-            logger.info("Skipping workspace package loading (load_workspace_packages=False)")
-            # Pre-seed the notebook cache so any subsequent call to get_all_notebooks()
-            # returns immediately instead of hitting the platform API, which may be
-            # unavailable from the Spark cluster in some environments.
-            try:
-                loader = get_kindling_service(NotebookManager)
-                if loader._notebook_cache is None:
-                    loader._notebook_cache = []
-                    loader._folder_cache = set()
-                    logger.debug("Notebook cache pre-seeded empty (load_workspace_packages=False)")
-            except Exception as _pre_seed_err:
-                logger.debug(f"Could not pre-seed notebook cache: {_pre_seed_err}")
+        with _bootstrap_phase("workspace_packages"):
+            if load_workspace_packages_value:
+                ignored_folders = config_service.get("kindling.bootstrap.ignored_folders", [])
+                workspace_packages = get_kindling_service(NotebookManager).get_all_packages(
+                    ignored_folders=ignored_folders
+                )
+                logger.debug(
+                    f"Found {len(workspace_packages)} workspace packages: {workspace_packages}"
+                )
+                load_workspace_packages(platformservice, workspace_packages, logger)
+                logger.info(f"Loaded {len(workspace_packages)} workspace packages")
+            else:
+                logger.info("Skipping workspace package loading (load_workspace_packages=False)")
+                # Pre-seed the notebook cache so any subsequent call to get_all_notebooks()
+                # returns immediately instead of hitting the platform API, which may be
+                # unavailable from the Spark cluster in some environments.
+                try:
+                    loader = get_kindling_service(NotebookManager)
+                    if loader._notebook_cache is None:
+                        loader._notebook_cache = []
+                        loader._folder_cache = set()
+                        logger.debug(
+                            "Notebook cache pre-seeded empty (load_workspace_packages=False)"
+                        )
+                except Exception as _pre_seed_err:
+                    logger.debug(f"Could not pre-seed notebook cache: {_pre_seed_err}")
 
         logger.info("Framework initialization complete")
 
         if app_name:
             logger.info(f"Auto-running app: {app_name}")
-            try:
-                runner = get_kindling_service(DataAppRunner)
-                logger.debug(f"Got DataAppRunner: {type(runner).__name__}")
-                runner.run_app(app_name)
-                logger.warning(f"App '{app_name}' completed successfully")
-            except Exception as app_error:
-                logger.exception(f"App execution failed: {str(app_error)}")
-                raise
+            with _bootstrap_phase("app_run"):
+                try:
+                    runner = get_kindling_service(DataAppRunner)
+                    logger.debug(f"Got DataAppRunner: {type(runner).__name__}")
+                    runner.run_app(app_name)
+                    logger.warning(f"App '{app_name}' completed successfully")
+                except Exception as app_error:
+                    logger.exception(f"App execution failed: {str(app_error)}")
+                    raise
 
         return platformservice
 
     except Exception as e:
         logger.error(f"Framework initialization failed: {str(e)}")
+        _bootstrap_error = str(e)
         raise
+    finally:
+        # Retro-flush the bootstrap span tree now that the final trace
+        # provider is settled. On failure the failing phase (and root)
+        # carry the error; failures before a usable ConfigService never
+        # reach this try and their tree is lost (stdlib logs only).
+        _flush_bootstrap_trace(config_service, error=_bootstrap_error)
 
 
 def bootstrap_framework(config: Dict[str, Any], logger=None):

--- a/packages/kindling/data_apps.py
+++ b/packages/kindling/data_apps.py
@@ -14,13 +14,13 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import yaml
-from packaging.version import InvalidVersion, Version
-
 from kindling.injection import *
 from kindling.platform_provider import *
 from kindling.spark_config import *
 from kindling.spark_log_provider import *
 from kindling.spark_trace import *
+from kindling.trace_ops import COMPONENT_APPS
+from packaging.version import InvalidVersion, Version
 
 from .app_files import is_deployable_app_file, is_settings_overlay
 from .notebook_framework import *
@@ -451,7 +451,10 @@ class DataAppManager(DataAppRunner):
         """Run an app with full lifecycle management"""
         self.logger.info(f"DataAppManager.run_app() starting for app: {app_name}")
         with self.tp.span(
-            component=f"kindling-app-{app_name}", operation="running", details={}, reraise=True
+            component=COMPONENT_APPS,
+            operation="run",
+            details={"app_name": app_name},
+            reraise=True,
         ):
             temp_dir = None
             try:
@@ -468,9 +471,9 @@ class DataAppManager(DataAppRunner):
                 # Install dependencies
                 self.logger.info(f"Step 2: Installing dependencies for: {app_name}")
                 with self.tp.span(
-                    component=f"kindling-app-{app_name}",
-                    operation="loading_dependencies",
-                    details={},
+                    component=COMPONENT_APPS,
+                    operation="install_dependencies",
+                    details={"app_name": app_name},
                     reraise=True,
                 ):
                     temp_dir = self._install_app_dependencies(
@@ -481,9 +484,9 @@ class DataAppManager(DataAppRunner):
                 # Load and execute app code
                 self.logger.info(f"Step 3: Loading app code for: {app_name}")
                 with self.tp.span(
-                    component=f"kindling-app-{app_name}",
-                    operation="loading_code",
-                    details={},
+                    component=COMPONENT_APPS,
+                    operation="load_code",
+                    details={"app_name": app_name},
                     reraise=True,
                 ):
                     code, loaded_entry_point = self._load_app_code(
@@ -495,9 +498,9 @@ class DataAppManager(DataAppRunner):
 
                 self.logger.info(f"Step 4: Executing app code for: {app_name}")
                 with self.tp.span(
-                    component=f"kindling-app-{app_name}",
-                    operation="executing_code",
-                    details={},
+                    component=COMPONENT_APPS,
+                    operation="execute_code",
+                    details={"app_name": app_name},
                     reraise=True,
                 ):
                     result = self._execute_app(app_name, code, loaded_entry_point)

--- a/packages/kindling/data_pipes.py
+++ b/packages/kindling/data_pipes.py
@@ -15,6 +15,7 @@ from kindling.signaling import SignalEmitter, SignalProvider
 from kindling.spark_config import ConfigService
 from kindling.spark_log_provider import *
 from kindling.spark_trace import *
+from kindling.trace_ops import COMPONENT_PIPES
 from pyspark.sql import DataFrame
 
 from .data_entities import *
@@ -435,7 +436,10 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
             # reraise=True: a swallowed span exception would leave the failed
             # run looking successful to the caller.
             with self.tp.span(
-                component="data_pipes_executer", operation="execute_datapipes", reraise=True
+                component=COMPONENT_PIPES,
+                operation="run",
+                details={"run_id": run_id, "pipe_count": len(pipes)},
+                reraise=True,
             ):
                 for index, pipeid in enumerate(pipes):
                     pipe = self.dpr.get_pipe_definition(pipeid)
@@ -453,10 +457,17 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
                     )
 
                     try:
+                        # Whitelisted attributes only — pipe.tags may carry
+                        # credential references and must never be exported
+                        # wholesale as span attributes.
                         with self.tp.span(
-                            operation="execute_datapipe",
-                            component=f"pipe-{pipeid}",
-                            details=pipe.tags,
+                            operation="pipe.run",
+                            component=COMPONENT_PIPES,
+                            details={
+                                "pipe_id": pipeid,
+                                "pipe_name": pipe.name,
+                                "run_id": run_id,
+                            },
                             reraise=True,
                         ):
                             was_skipped = self._execute_datapipe(

--- a/packages/kindling/data_pipes.py
+++ b/packages/kindling/data_pipes.py
@@ -3,6 +3,7 @@ import logging
 import time
 import uuid
 from abc import ABC, abstractmethod
+from contextlib import nullcontext
 from dataclasses import dataclass, fields
 from typing import Any, Callable, Dict, List, Optional
 
@@ -15,7 +16,7 @@ from kindling.signaling import SignalEmitter, SignalProvider
 from kindling.spark_config import ConfigService
 from kindling.spark_log_provider import *
 from kindling.spark_trace import *
-from kindling.trace_ops import COMPONENT_PIPES
+from kindling.trace_ops import COMPONENT_PIPES, tracing_gates
 from pyspark.sql import DataFrame
 
 from .data_entities import *
@@ -372,6 +373,7 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
         erps: EntityReadPersistStrategy,
         tp: SparkTraceProvider,
         signal_provider: SignalProvider = None,
+        config: ConfigService = None,
     ):
         self._init_signal_emitter(signal_provider)
         self.erps = erps
@@ -379,6 +381,7 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
         self.dpe = dpe
         self.logger = lp.get_logger("data_pipes_executer")
         self.tp = tp
+        self._trace_gates = tracing_gates(config)
 
     def run_datapipes(
         self,
@@ -435,12 +438,17 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
         try:
             # reraise=True: a swallowed span exception would leave the failed
             # run looking successful to the caller.
-            with self.tp.span(
-                component=COMPONENT_PIPES,
-                operation="run",
-                details={"run_id": run_id, "pipe_count": len(pipes)},
-                reraise=True,
-            ):
+            run_span = (
+                self.tp.span(
+                    component=COMPONENT_PIPES,
+                    operation="run",
+                    details={"run_id": run_id, "pipe_count": len(pipes)},
+                    reraise=True,
+                )
+                if self._trace_gates.minimal
+                else nullcontext()
+            )
+            with run_span:
                 for index, pipeid in enumerate(pipes):
                     pipe = self.dpr.get_pipe_definition(pipeid)
                     if no_watermark and pipe.use_watermark:
@@ -460,16 +468,21 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
                         # Whitelisted attributes only — pipe.tags may carry
                         # credential references and must never be exported
                         # wholesale as span attributes.
-                        with self.tp.span(
-                            operation="pipe.run",
-                            component=COMPONENT_PIPES,
-                            details={
-                                "pipe_id": pipeid,
-                                "pipe_name": pipe.name,
-                                "run_id": run_id,
-                            },
-                            reraise=True,
-                        ):
+                        pipe_span = (
+                            self.tp.span(
+                                operation="pipe.run",
+                                component=COMPONENT_PIPES,
+                                details={
+                                    "pipe_id": pipeid,
+                                    "pipe_name": pipe.name,
+                                    "run_id": run_id,
+                                },
+                                reraise=True,
+                            )
+                            if self._trace_gates.minimal
+                            else nullcontext()
+                        )
+                        with pipe_span:
                             was_skipped = self._execute_datapipe(
                                 pipe_entity_reader(pipe), pipe_activator(pipe), pipe
                             )

--- a/packages/kindling/entity_provider_delta.py
+++ b/packages/kindling/entity_provider_delta.py
@@ -1830,7 +1830,11 @@ class DeltaEntityProvider(
                     .filter(col("__row_rank") == 1)
                     .drop("__row_rank")
                 )
-            self.merge_to_entity(batch_df, entity)
+            # Class-attribute lookup deliberately bypasses the per-instance
+            # tracing wrapper (trace_ops): a span per micro-batch would blow
+            # the hot-loop budget. Per-batch visibility comes from the
+            # streaming listener's batch_progress events instead.
+            type(self).merge_to_entity(self, batch_df, entity)
 
         writer = (
             df.writeStream.outputMode("update")

--- a/packages/kindling/entity_provider_registry.py
+++ b/packages/kindling/entity_provider_registry.py
@@ -29,7 +29,23 @@ class EntityProviderRegistry:
         self._provider_classes: Dict[str, Type[BaseEntityProvider]] = {}
         self._provider_instances: Dict[str, BaseEntityProvider] = {}
         self._provider_decorator = None
+        self._op_tracing = None
         self._register_builtin_providers()
+
+    def enable_op_tracing(self, trace_provider, level: str) -> None:
+        """Trace provider op methods on every instance — cached and future.
+
+        Wrapping happens per instance at resolution time via
+        ``trace_ops.wrap_provider_ops`` (bound-method shadowing: identity,
+        isinstance, and hasattr probes are preserved). Idempotent; set once
+        by bootstrap wiring — the registry itself never reads config.
+        """
+        from .trace_ops import wrap_provider_ops
+
+        self._op_tracing = (trace_provider, level)
+        for provider_type, instance in self._provider_instances.items():
+            wrap_provider_ops(instance, trace_provider, provider_type)
+        self.logger.info(f"Provider op tracing enabled (level={level})")
 
     def set_provider_decorator(self, decorator) -> None:
         """Wrap every provider instance — cached and future — in `decorator`.
@@ -118,6 +134,10 @@ class EntityProviderRegistry:
             provider_instance = GlobalInjector.get(provider_class)
             if self._provider_decorator is not None:
                 provider_instance = self._provider_decorator(provider_instance)
+            if self._op_tracing is not None:
+                from .trace_ops import wrap_provider_ops
+
+                wrap_provider_ops(provider_instance, self._op_tracing[0], provider_type)
             self._provider_instances[provider_type] = provider_instance
             self.logger.info(f"Created provider instance: {provider_type}")
             return provider_instance

--- a/packages/kindling/execution_orchestrator.py
+++ b/packages/kindling/execution_orchestrator.py
@@ -7,7 +7,6 @@ generation-based execution while preserving existing executor options.
 from typing import Any, List, Optional
 
 from injector import inject
-
 from kindling.execution_strategy import ExecutionPlanGenerator, ExecutionStrategy
 from kindling.generation_executor import (
     UNSET,
@@ -16,7 +15,10 @@ from kindling.generation_executor import (
 )
 from kindling.injection import GlobalInjector
 from kindling.signaling import SignalEmitter, SignalProvider
+from kindling.spark_config import ConfigService
 from kindling.spark_log_provider import PythonLoggerProvider
+from kindling.spark_trace import SparkTraceProvider
+from kindling.trace_ops import COMPONENT_ORCHESTRATOR, tracing_gates
 
 
 @GlobalInjector.singleton_autobind()
@@ -38,10 +40,14 @@ class ExecutionOrchestrator(SignalEmitter):
         generation_executor: GenerationExecutor,
         logger_provider: PythonLoggerProvider,
         signal_provider: SignalProvider = None,
+        tp: Optional[SparkTraceProvider] = None,
+        config: Optional[ConfigService] = None,
     ):
         self.plan_generator = plan_generator
         self.generation_executor = generation_executor
         self.logger = logger_provider.get_logger("execution_orchestrator")
+        self.tp = tp
+        self._trace_gates = tracing_gates(config)
         self._init_signal_emitter(signal_provider)
 
     def execute(
@@ -63,7 +69,18 @@ class ExecutionOrchestrator(SignalEmitter):
         Execution options left UNSET resolve from `kindling.execution.*`
         config inside GenerationExecutor; passed values override config.
         """
-        plan = self.plan_generator.generate_plan(pipe_ids, strategy=strategy)
+        if self.tp is not None and self._trace_gates.standard:
+            plan_details = {"pipe_count": len(pipe_ids)}
+            with self.tp.span(
+                operation="plan",
+                component=COMPONENT_ORCHESTRATOR,
+                details=plan_details,
+                reraise=True,
+            ):
+                plan = self.plan_generator.generate_plan(pipe_ids, strategy=strategy)
+                plan_details["generation_count"] = plan.total_generations()
+        else:
+            plan = self.plan_generator.generate_plan(pipe_ids, strategy=strategy)
 
         self.emit(
             "orchestrator.plan_generated",

--- a/packages/kindling/file_ingestion.py
+++ b/packages/kindling/file_ingestion.py
@@ -5,15 +5,13 @@ import uuid
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import nullcontext
 from dataclasses import dataclass, fields
 from functools import reduce
 from typing import Any, Callable, Dict, List, Optional
 
 from delta.tables import DeltaTable
 from injector import Binder, Injector, inject, singleton
-from pyspark.sql import DataFrame
-from pyspark.sql.functions import current_timestamp, lit
-
 from kindling.data_entities import *
 from kindling.file_ingestion import *
 from kindling.injection import *
@@ -23,6 +21,9 @@ from kindling.spark_config import *
 from kindling.spark_log_provider import *
 from kindling.spark_session import *
 from kindling.spark_trace import *
+from kindling.trace_ops import COMPONENT_INGESTION, tracing_gates
+from pyspark.sql import DataFrame
+from pyspark.sql.functions import current_timestamp, lit
 
 
 @dataclass
@@ -174,6 +175,7 @@ class ParallelizingFileIngestionProcessor(FileIngestionProcessor, SignalEmitter)
         self.logger = lp.get_logger("SimpleFileIngestionProcessor")
         self.spark = get_or_create_spark_session()
         self.env = pep.get_service()
+        self._trace_gates = tracing_gates(config)
 
     def _build_df_plan(self, fn: str, path: str, transform: Optional[Callable] = None):
         """Build DataFrame plan without executing - keep it lazy.
@@ -259,10 +261,11 @@ class ParallelizingFileIngestionProcessor(FileIngestionProcessor, SignalEmitter)
             for df in dfs[1:]:
                 combined_df = combined_df.unionByName(df, allowMissingColumns=True)
 
-        # Spark reads all files for THIS table in parallel during write
+        # Spark reads all files for THIS table in parallel during write.
+        # No dedicated span here: the provider-op tracer (trace_ops) supplies
+        # the append_to_entity child span.
         try:
-            with self.tp.span(operation="append_to_entity"):
-                self.ep.append_to_entity(combined_df, de)
+            self.ep.append_to_entity(combined_df, de)
 
             self.logger.info(f"Successfully wrote {len(df_list)} files to {dest_entity_id}")
 
@@ -308,10 +311,13 @@ class ParallelizingFileIngestionProcessor(FileIngestionProcessor, SignalEmitter)
         success_files = 0
         failed_files = 0
 
+        # Component previously named a nonexistent class
+        # ("SimpleFileIngestionProcessor"); normalized to the naming
+        # convention (gh#210).
         with self.tp.span(
-            component="SimpleFileIngestionProcessor",
-            operation="process_path",
-            details={"path": path},
+            component=COMPONENT_INGESTION,
+            operation="process",
+            details={"path": path, "batch_id": batch_id},
             reraise=True,
         ):
             filenames = self.env.list(path)
@@ -333,8 +339,21 @@ class ParallelizingFileIngestionProcessor(FileIngestionProcessor, SignalEmitter)
                     # Emit before_file signal
                     self.emit("file_ingestion.before_file", filename=fn, batch_id=batch_id)
 
+                    # Per-file spans only at verbose level: paths can hold
+                    # thousands of files and standard runs must stay lean.
+                    file_span = (
+                        self.tp.span(
+                            operation="file",
+                            component=COMPONENT_INGESTION,
+                            details={"filename": fn, "batch_id": batch_id},
+                            reraise=True,
+                        )
+                        if self._trace_gates.verbose
+                        else nullcontext()
+                    )
                     try:
-                        result = self._build_df_plan(fn, path, transform)
+                        with file_span:
+                            result = self._build_df_plan(fn, path, transform)
                         if result:
                             dest_entity_id, df, file_info = result
                             df_plans[dest_entity_id].append((df, file_info))

--- a/packages/kindling/file_ingestion.py
+++ b/packages/kindling/file_ingestion.py
@@ -314,12 +314,17 @@ class ParallelizingFileIngestionProcessor(FileIngestionProcessor, SignalEmitter)
         # Component previously named a nonexistent class
         # ("SimpleFileIngestionProcessor"); normalized to the naming
         # convention (gh#210).
-        with self.tp.span(
-            component=COMPONENT_INGESTION,
-            operation="process",
-            details={"path": path, "batch_id": batch_id},
-            reraise=True,
-        ):
+        process_span = (
+            self.tp.span(
+                component=COMPONENT_INGESTION,
+                operation="process",
+                details={"path": path, "batch_id": batch_id},
+                reraise=True,
+            )
+            if self._trace_gates.minimal
+            else nullcontext()
+        )
+        with process_span:
             filenames = self.env.list(path)
             self.logger.info(f"Found {len(filenames)} files in {path}")
 

--- a/packages/kindling/generation_executor.py
+++ b/packages/kindling/generation_executor.py
@@ -50,6 +50,7 @@ from kindling.signaling import SignalEmitter, SignalProvider
 from kindling.spark_config import ConfigService
 from kindling.spark_log_provider import PythonLoggerProvider
 from kindling.spark_trace import SparkTraceProvider
+from kindling.trace_ops import COMPONENT_ORCHESTRATOR, COMPONENT_PIPES, tracing_gates
 
 
 class ErrorStrategy(Enum):
@@ -243,6 +244,7 @@ class GenerationExecutor(SignalEmitter):
         self.persist_strategy = persist_strategy
         self.tp = trace_provider
         self.logger = logger_provider.get_logger("generation_executor")
+        self._trace_gates = tracing_gates(config_service)
         self._init_signal_emitter(signal_provider)
         # Optional: used only for the retry-safety warning (merge-capable
         # output providers make retried persists idempotent).
@@ -344,8 +346,9 @@ class GenerationExecutor(SignalEmitter):
 
         try:
             with self.tp.span(
-                component="generation_executor",
-                operation=f"execute_{mode}",
+                component=COMPONENT_ORCHESTRATOR,
+                operation="run",
+                details={"run_id": run_id, "mode": mode},
             ):
                 blocked: Dict[str, str] = {}  # pipe_id -> upstream pipe that failed
                 for generation in plan.generations:
@@ -789,6 +792,56 @@ class GenerationExecutor(SignalEmitter):
         Pipes present in `blocked` (skip_dependents poisoning: pipe_id ->
         failed upstream pipe) are skipped without executing.
         """
+        if not self._trace_gates.standard:
+            return self._run_generation(
+                generation,
+                run_id,
+                is_streaming,
+                parallel,
+                max_workers,
+                error_strategy,
+                pipe_timeout,
+                streaming_options,
+                no_watermark,
+                blocked,
+            )
+        details = {
+            "run_id": run_id,
+            "generation": generation.number,
+            "pipe_count": len(generation.pipe_ids),
+        }
+        with self.tp.span(
+            operation="generation", component=COMPONENT_ORCHESTRATOR, details=details, reraise=True
+        ):
+            gen_result = self._run_generation(
+                generation,
+                run_id,
+                is_streaming,
+                parallel,
+                max_workers,
+                error_strategy,
+                pipe_timeout,
+                streaming_options,
+                no_watermark,
+                blocked,
+            )
+            details["failed_count"] = gen_result.failed_count
+            details["skipped_count"] = gen_result.skipped_count
+            return gen_result
+
+    def _run_generation(
+        self,
+        generation: Generation,
+        run_id: str,
+        is_streaming: bool,
+        parallel: bool,
+        max_workers: int,
+        error_strategy: ErrorStrategy,
+        pipe_timeout: Optional[float],
+        streaming_options: Optional[Dict[str, Any]],
+        no_watermark: bool = False,
+        blocked: Optional[Dict[str, str]] = None,
+    ) -> GenerationResult:
         gen_start = time.time()
         blocked = blocked or {}
 
@@ -948,6 +1001,37 @@ class GenerationExecutor(SignalEmitter):
         no_watermark: bool = False,
     ) -> PipeResult:
         """Execute a single pipe (batch or streaming), with retry per policy.
+
+        One pipe.run span covers all attempts; a failed pipe returns a
+        PipeResult rather than raising, so the outcome is carried in the
+        status/attempts attributes. Under parallel execution this runs on a
+        worker thread — spans inherit the shared current_span trace id.
+        """
+        if not self._trace_gates.minimal:
+            return self._execute_pipe_attempts(
+                pipe_id, run_id, is_streaming, pipe_timeout, streaming_options, no_watermark
+            )
+        details = {"pipe_id": pipe_id, "run_id": run_id, "streaming": is_streaming}
+        with self.tp.span(
+            operation="pipe.run", component=COMPONENT_PIPES, details=details, reraise=True
+        ):
+            result = self._execute_pipe_attempts(
+                pipe_id, run_id, is_streaming, pipe_timeout, streaming_options, no_watermark
+            )
+            details["status"] = result.status
+            details["attempts"] = result.attempts
+            return result
+
+    def _execute_pipe_attempts(
+        self,
+        pipe_id: str,
+        run_id: str,
+        is_streaming: bool,
+        pipe_timeout: Optional[float],
+        streaming_options: Optional[Dict[str, Any]],
+        no_watermark: bool = False,
+    ) -> PipeResult:
+        """The retry loop for one pipe.
 
         Only exceptions raised inside an attempt are retried. Timeouts
         surfaced by the parallel wrapper (`future.result`) are never retried

--- a/packages/kindling/job_deployment.py
+++ b/packages/kindling/job_deployment.py
@@ -21,6 +21,7 @@ import os
 import time
 import uuid
 import zipfile
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -29,7 +30,10 @@ from injector import inject
 from .app_files import is_deployable_app_file
 from .platform_provider import PlatformServiceProvider
 from .signaling import SignalEmitter, SignalProvider
+from .spark_config import ConfigService
 from .spark_log_provider import PythonLoggerProvider
+from .spark_trace import SparkTraceProvider
+from .trace_ops import COMPONENT_DEPLOY, tracing_gates
 
 # ============================================================================
 # UTILITIES - Pure functions for mechanical operations
@@ -222,6 +226,8 @@ class DataAppDeployer(SignalEmitter):
         platform_provider: PlatformServiceProvider,
         logger_provider: PythonLoggerProvider,
         signal_provider: Optional[SignalProvider] = None,
+        tp: Optional[SparkTraceProvider] = None,
+        config: Optional[ConfigService] = None,
     ):
         """Initialize deployer with injected dependencies
 
@@ -229,14 +235,26 @@ class DataAppDeployer(SignalEmitter):
             platform_provider: Provider for platform service
             logger_provider: Provider for logger
             signal_provider: Optional signal provider for event emissions
+            tp: Optional trace provider for deploy/run spans
+            config: Optional config service (tracing gates)
         """
         self.platform = platform_provider.get()
         self.logger = logger_provider.get()
+        self.tp = tp
+        self._trace_gates = tracing_gates(config)
         self._init_signal_emitter(signal_provider)
 
         # Initialize utilities (no DI needed - pure utilities)
         self.packager = AppPackager()
         self.validator = JobConfigValidator()
+
+    def _trace(self, operation: str, details: Optional[Dict[str, Any]] = None):
+        """Deploy spans are minimal-tier; no-op CM when tracing is off."""
+        if self.tp is None or not self._trace_gates.minimal:
+            return nullcontext()
+        return self.tp.span(
+            operation=operation, component=COMPONENT_DEPLOY, details=details, reraise=True
+        )
 
     def deploy_app(
         self,
@@ -257,6 +275,15 @@ class DataAppDeployer(SignalEmitter):
         Returns:
             Storage path where app was deployed
         """
+        with self._trace("app.deploy", {"app_name": app_name, "environment": environment or ""}):
+            return self._deploy_app(app_path, app_name, environment)
+
+    def _deploy_app(
+        self,
+        app_path: str,
+        app_name: str,
+        environment: Optional[str] = None,
+    ) -> str:
         platform_name = self.platform.get_platform_name()
         environment_name = (
             environment
@@ -325,6 +352,10 @@ class DataAppDeployer(SignalEmitter):
         Returns:
             Dictionary with job info including 'job_id'
         """
+        with self._trace("job.create", {"job_name": job_config.get("job_name", "unknown")}):
+            return self._create_job(job_config)
+
+    def _create_job(self, job_config: Dict[str, Any]) -> Dict[str, Any]:
         platform_name = self.platform.get_platform_name()
         job_name = job_config.get("job_name", "unknown")
 
@@ -411,6 +442,10 @@ class DataAppDeployer(SignalEmitter):
         Returns:
             Run ID for monitoring
         """
+        with self._trace("job.run", {"job_id": job_id}):
+            return self._run_job(job_id, parameters)
+
+    def _run_job(self, job_id: str, parameters: Dict[str, Any] = None) -> str:
         self.logger.info(f"Running job: {job_id}")
 
         self.emit("job.before_run", job_id=job_id, parameters=parameters)

--- a/packages/kindling/migration.py
+++ b/packages/kindling/migration.py
@@ -34,16 +34,39 @@ from __future__ import annotations
 
 import datetime
 import hashlib
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from injector import inject
-
 from kindling.data_entities import DataEntityRegistry, EntityMetadata
 from kindling.entity_provider_delta import DeltaEntityProvider, DeltaTableReference
 from kindling.injection import GlobalInjector
 from kindling.spark_log_provider import PythonLoggerProvider
+
+
+def _migration_span(operation: str, details: Optional[Dict[str, Any]] = None):
+    """Minimal-tier migration span; no-op when tracing is off or unresolvable.
+
+    Migrations are rare design-time/ops runs, so the trace provider is
+    resolved per call instead of threading it through the planner/applier/
+    manager constructors. Tracing must never break a migration.
+    """
+    try:
+        from kindling.spark_config import ConfigService
+        from kindling.spark_trace import SparkTraceProvider
+        from kindling.trace_ops import COMPONENT_MIGRATION, tracing_gates
+
+        if not tracing_gates(GlobalInjector.get(ConfigService)).minimal:
+            return nullcontext()
+        tp = GlobalInjector.get(SparkTraceProvider)
+        return tp.span(
+            operation=operation, component=COMPONENT_MIGRATION, details=details, reraise=True
+        )
+    except Exception:
+        return nullcontext()
+
 
 # ---------------------------------------------------------------------------
 # Enums
@@ -580,10 +603,11 @@ class MigrationApplier:
             if status.is_up_to_date:
                 self._logger.info(f"{status.entity.entityid}: up to date, nothing to do")
                 continue
-            if status.entity.is_sql_entity:
-                self._apply_sql_entity(status)
-            else:
-                self._apply_delta_entity(status, allow_destructive, backup, user_transforms)
+            with _migration_span("entity.apply", {"entity_id": status.entity.entityid}):
+                if status.entity.is_sql_entity:
+                    self._apply_sql_entity(status)
+                else:
+                    self._apply_delta_entity(status, allow_destructive, backup, user_transforms)
 
     def _apply_sql_entity(self, status: EntityMigrationStatus) -> None:
         """Apply CREATE_VIEW or UPDATE_VIEW — always safe, always idempotent."""
@@ -646,7 +670,11 @@ class MigrationApplier:
         # Apply safe changes first (they don't need a rewrite)
         for change in status.changes:
             if change.destructiveness == ChangeDestructiveness.SAFE:
-                self._apply_safe_delta_change(entity, table_ref, change)
+                with _migration_span(
+                    "change.apply",
+                    {"entity_id": entity.entityid, "change_kind": change.kind.value},
+                ):
+                    self._apply_safe_delta_change(entity, table_ref, change)
 
         # Collect destructive changes and apply via rewrite if needed
         destructive = [
@@ -746,33 +774,37 @@ class MigrationApplier:
             f"Blue-green rewrite for {entity.entityid}: building green table {green_name}"
         )
 
-        # Read existing data and apply transforms
-        old_df = spark.read.table(original_name)
-        new_df = self._apply_transforms(old_df, entity, changes, user_transforms)
+        # Read existing data and apply transforms, then write green
+        with _migration_span("rewrite.build", {"entity_id": entity.entityid}):
+            old_df = spark.read.table(original_name)
+            new_df = self._apply_transforms(old_df, entity, changes, user_transforms)
 
-        # Write green
-        writer = new_df.write.format("delta").mode("overwrite").option("overwriteSchema", "true")
-        if entity.partition_columns:
-            writer = writer.partitionBy(*entity.partition_columns)
-        writer.saveAsTable(green_name)
+            writer = (
+                new_df.write.format("delta").mode("overwrite").option("overwriteSchema", "true")
+            )
+            if entity.partition_columns:
+                writer = writer.partitionBy(*entity.partition_columns)
+            writer.saveAsTable(green_name)
 
         # Validate
-        old_count = old_df.count()
-        new_count = spark.read.table(green_name).count()
-        if new_count != old_count:
-            self._logger.warning(
-                f"Row count mismatch after rewrite for {entity.entityid}: "
-                f"old={old_count}, new={new_count}. Green table preserved at {green_name}."
-            )
-            raise RuntimeError(
-                f"Migration validation failed for '{entity.entityid}': "
-                f"row count changed from {old_count} to {new_count}."
-            )
+        with _migration_span("rewrite.validate", {"entity_id": entity.entityid}):
+            old_count = old_df.count()
+            new_count = spark.read.table(green_name).count()
+            if new_count != old_count:
+                self._logger.warning(
+                    f"Row count mismatch after rewrite for {entity.entityid}: "
+                    f"old={old_count}, new={new_count}. Green table preserved at {green_name}."
+                )
+                raise RuntimeError(
+                    f"Migration validation failed for '{entity.entityid}': "
+                    f"row count changed from {old_count} to {new_count}."
+                )
 
         # Swap: archive blue, promote green
         self._logger.info(f"Swapping tables: {original_name} -> blue archive, {green_name} -> live")
-        spark.sql(f"ALTER TABLE {quoted_original} RENAME TO {quoted_blue}")
-        spark.sql(f"ALTER TABLE {quoted_green} RENAME TO {quoted_original}")
+        with _migration_span("rewrite.swap", {"entity_id": entity.entityid}):
+            spark.sql(f"ALTER TABLE {quoted_original} RENAME TO {quoted_blue}")
+            spark.sql(f"ALTER TABLE {quoted_green} RENAME TO {quoted_original}")
         self._logger.info(
             f"Rewrite complete for {entity.entityid}. "
             f"Old data archived at {blue_archive_name}. "
@@ -795,13 +827,16 @@ class MigrationApplier:
         spark = get_or_create_spark_session()
 
         self._logger.info(f"In-place rewrite for {entity.entityid} at {table_ref.table_path}")
-        old_df = spark.read.format("delta").load(table_ref.table_path)
-        new_df = self._apply_transforms(old_df, entity, changes, user_transforms)
+        with _migration_span("rewrite.inplace", {"entity_id": entity.entityid}):
+            old_df = spark.read.format("delta").load(table_ref.table_path)
+            new_df = self._apply_transforms(old_df, entity, changes, user_transforms)
 
-        writer = new_df.write.format("delta").mode("overwrite").option("overwriteSchema", "true")
-        if entity.partition_columns:
-            writer = writer.partitionBy(*entity.partition_columns)
-        writer.save(table_ref.table_path)
+            writer = (
+                new_df.write.format("delta").mode("overwrite").option("overwriteSchema", "true")
+            )
+            if entity.partition_columns:
+                writer = writer.partitionBy(*entity.partition_columns)
+            writer.save(table_ref.table_path)
         self._logger.info(f"In-place rewrite complete for {entity.entityid}")
 
     # ------------------------------------------------------------------
@@ -816,15 +851,16 @@ class MigrationApplier:
         stamp = datetime.datetime.utcnow().strftime("%Y%m%d_%H%M%S")
         target = self._table_target(table_ref)
 
-        if self._provider._is_for_name_mode(table_ref.access_mode):
-            snapshot_name = f"{table_ref.table_name}_snapshot_{stamp}"
-            quoted_snap = self._provider._quote_table_identifier(snapshot_name)
-            self._logger.info(f"Snapshotting {entity.entityid} -> {snapshot_name}")
-            spark.sql(f"CREATE TABLE {quoted_snap} CLONE {target}")
-        else:
-            snapshot_path = f"{table_ref.table_path}/_snapshots/{stamp}"
-            self._logger.info(f"Snapshotting {entity.entityid} -> {snapshot_path}")
-            spark.sql(f"CREATE TABLE delta.`{snapshot_path}` CLONE {target}")
+        with _migration_span("snapshot", {"entity_id": entity.entityid}):
+            if self._provider._is_for_name_mode(table_ref.access_mode):
+                snapshot_name = f"{table_ref.table_name}_snapshot_{stamp}"
+                quoted_snap = self._provider._quote_table_identifier(snapshot_name)
+                self._logger.info(f"Snapshotting {entity.entityid} -> {snapshot_name}")
+                spark.sql(f"CREATE TABLE {quoted_snap} CLONE {target}")
+            else:
+                snapshot_path = f"{table_ref.table_path}/_snapshots/{stamp}"
+                self._logger.info(f"Snapshotting {entity.entityid} -> {snapshot_path}")
+                spark.sql(f"CREATE TABLE delta.`{snapshot_path}` CLONE {target}")
 
     # ------------------------------------------------------------------
     # Transform application
@@ -976,7 +1012,12 @@ class MigrationService:
 
     def plan(self) -> MigrationPlan:
         """Inspect all registered entities and return a MigrationPlan."""
-        return self._planner.plan()
+        details: Dict[str, Any] = {}
+        with _migration_span("plan", details):
+            plan = self._planner.plan()
+            details["entity_count"] = len(plan.statuses)
+            details["change_count"] = sum(len(s.changes) for s in plan.statuses)
+            return plan
 
     def apply(
         self,
@@ -986,12 +1027,20 @@ class MigrationService:
         user_transforms: Optional[Dict[str, object]] = None,
     ) -> None:
         """Apply a MigrationPlan."""
-        self._applier.apply(
-            plan,
-            allow_destructive=allow_destructive,
-            backup=backup,
-            user_transforms=user_transforms,
-        )
+        with _migration_span(
+            "apply",
+            {
+                "entity_count": len(plan.statuses),
+                "allow_destructive": allow_destructive,
+                "backup": backup.value,
+            },
+        ):
+            self._applier.apply(
+                plan,
+                allow_destructive=allow_destructive,
+                backup=backup,
+                user_transforms=user_transforms,
+            )
 
     def rollback(self, entity: EntityMetadata) -> None:
         """Restore the pre-migration blue archive to live (CATALOG mode only)."""

--- a/packages/kindling/plain_telemetry.py
+++ b/packages/kindling/plain_telemetry.py
@@ -20,7 +20,6 @@ from datetime import datetime
 from typing import Optional
 
 from injector import inject
-
 from kindling.spark_config import ConfigService
 from kindling.spark_log_provider import PythonLoggerProvider
 from kindling.spark_trace import SparkSpan, SparkTraceProvider
@@ -152,14 +151,14 @@ class PlainPythonTraceProvider(SparkTraceProvider):
             start_time=datetime.now(),
             traceId=parent.traceId if parent else uuid.uuid4(),
             reraise=reraise or (parent.reraise if parent else None),
+            parent_id=parent.id if parent else None,
         )
         self.current_span = current_span
 
-        self._emit(
-            current_span,
-            f"{current_span.operation}_START",
-            self._with_timestamp(live_details, "startTime", current_span.start_time),
-        )
+        start_details = self._with_timestamp(live_details, "startTime", current_span.start_time)
+        if current_span.parent_id is not None:
+            start_details["parentSpanId"] = current_span.parent_id
+        self._emit(current_span, f"{current_span.operation}_START", start_details)
         try:
             yield self
         except Exception:
@@ -176,6 +175,8 @@ class PlainPythonTraceProvider(SparkTraceProvider):
             end_details["totalTime"] = self._total_time(
                 current_span.start_time, current_span.end_time
             )
+            if current_span.parent_id is not None:
+                end_details["parentSpanId"] = current_span.parent_id
             self._emit(current_span, f"{current_span.operation}_END", end_details)
             self.current_span = parent
 
@@ -194,12 +195,12 @@ class PlainPythonTraceProvider(SparkTraceProvider):
             start_time=datetime.now(),
             traceId=self.current_span.traceId if self.current_span else uuid.uuid4(),
             reraise=False,
+            parent_id=self.current_span.id if self.current_span else None,
         )
-        self._emit(
-            span,
-            f"{span.operation}_START",
-            self._with_timestamp(live_details, "startTime", span.start_time),
-        )
+        start_details = self._with_timestamp(live_details, "startTime", span.start_time)
+        if span.parent_id is not None:
+            start_details["parentSpanId"] = span.parent_id
+        self._emit(span, f"{span.operation}_START", start_details)
         return span
 
     def add_event(

--- a/packages/kindling/plain_telemetry.py
+++ b/packages/kindling/plain_telemetry.py
@@ -230,4 +230,47 @@ class PlainPythonTraceProvider(SparkTraceProvider):
         end_details = self._with_timestamp({}, "startTime", span.start_time)
         end_details = self._with_timestamp(end_details, "endTime", span.end_time)
         end_details["totalTime"] = self._total_time(span.start_time, span.end_time)
+        if span.parent_id is not None:
+            end_details["parentSpanId"] = span.parent_id
+        self._emit(span, f"{span.operation}_END", end_details)
+
+    def record_span(
+        self,
+        operation: str,
+        component: str,
+        start_time: datetime,
+        end_time: datetime,
+        details: dict = None,
+        error: Optional[str] = None,
+    ) -> None:
+        """Emit START/END (and ERROR) for a completed span with the given timestamps."""
+        live_details = dict(details or {})
+        span = SparkSpan(
+            id=str(self._increment_activity()),
+            component=component,
+            operation=operation,
+            attributes=live_details,
+            start_time=start_time,
+            end_time=end_time,
+            traceId=self.current_span.traceId if self.current_span else uuid.uuid4(),
+            reraise=False,
+            parent_id=self.current_span.id if self.current_span else None,
+        )
+
+        start_details = self._with_timestamp(live_details, "startTime", start_time)
+        if span.parent_id is not None:
+            start_details["parentSpanId"] = span.parent_id
+        self._emit(span, f"{span.operation}_START", start_details)
+
+        if error:
+            error_details = self._with_timestamp(live_details, "startTime", start_time)
+            error_details = self._with_timestamp(error_details, "errorTime", end_time)
+            error_details["exception"] = error
+            self._emit(span, f"{span.operation}_ERROR", error_details)
+
+        end_details = self._with_timestamp(live_details, "startTime", start_time)
+        end_details = self._with_timestamp(end_details, "endTime", end_time)
+        end_details["totalTime"] = self._total_time(start_time, end_time)
+        if span.parent_id is not None:
+            end_details["parentSpanId"] = span.parent_id
         self._emit(span, f"{span.operation}_END", end_details)

--- a/packages/kindling/simple_read_persist_strategy.py
+++ b/packages/kindling/simple_read_persist_strategy.py
@@ -1,11 +1,10 @@
 import os
 import time
 import uuid
+from contextlib import nullcontext
 from functools import reduce
 from pathlib import Path
 from typing import Optional
-
-from pyspark.sql.functions import col
 
 from kindling.data_entities import *
 from kindling.data_pipes import *
@@ -16,8 +15,11 @@ from kindling.entity_provider_csv import (
 from kindling.entity_provider_registry import EntityProviderRegistry
 from kindling.injection import *
 from kindling.signaling import SignalEmitter, SignalProvider
+from kindling.spark_config import ConfigService
 from kindling.spark_log import *
+from kindling.trace_ops import COMPONENT_PIPES, tracing_gates
 from kindling.watermarking import *
+from pyspark.sql.functions import col
 
 
 def _is_local_execution() -> bool:
@@ -100,67 +102,86 @@ class SimpleReadPersistStrategy(EntityReadPersistStrategy, SignalEmitter):
         lp: PythonLoggerProvider,
         provider_registry: EntityProviderRegistry,
         signal_provider: Optional[SignalProvider] = None,
+        config: Optional[ConfigService] = None,
     ):
         self.der = der
         self.ep = ep  # Legacy EntityProvider for backward compatibility
         self.provider_registry = provider_registry  # New multi-provider registry
         self.tp = tp
         self.logger = lp.get_logger("SimpleReadPersistStrategy")
+        self._trace_gates = tracing_gates(config)
         self._init_signal_emitter(signal_provider)
 
     def create_pipe_entity_reader(self, pipe):
         strategy = self
 
         def entity_reader(entity, usewm):
-            # Interdiction point: a handler (e.g. WatermarkAspect) may take
-            # ownership of the read entirely — including deciding there is
-            # no new data (df=None). Distinct from read.after_read, which
-            # can only transform a DataFrame that was already read.
-            resolved = None
-            for _, retval in strategy.emit(
-                "read.resolve_read",
-                entity=entity,
-                entity_id=entity.entityid,
-                pipe=pipe,
-                pipe_id=pipe.pipeid,
-                use_watermark=usewm,
+            if not strategy._trace_gates.minimal:
+                return strategy._read_for_pipe(pipe, entity, usewm, details=None)
+            details = {
+                "entity_id": entity.entityid,
+                "pipe_id": pipe.pipeid,
+                "watermarked": bool(usewm),
+            }
+            with strategy.tp.span(
+                operation="read", component=COMPONENT_PIPES, details=details, reraise=True
             ):
-                if retval is not None and hasattr(retval, "df"):
-                    resolved = retval
-
-            if resolved is not None:
-                df = resolved.df
-            elif _is_local_execution():
-                # [implementer] tests/entities/ auto-discovery convention — ki-bsi
-                # Priority: explicit --source > kindling.yaml env mapping > fixture CSV > registry
-                # Fixture discovery applies only when running locally (standalone platform).
-                cwd = Path(os.getcwd())
-                fixture_path = resolve_fixture_csv_path(entity.entityid, cwd)
-                if fixture_path is not None:
-                    strategy.logger.info(
-                        f"Using fixture CSV for entity '{entity.entityid}': {fixture_path}"
-                    )
-                    df = FixtureCSVEntityProvider(fixture_path).read_entity(entity)
-                else:
-                    provider = strategy.provider_registry.get_provider_for_entity(entity)
-                    df = provider.read_entity(entity)
-            else:
-                provider = strategy.provider_registry.get_provider_for_entity(entity)
-                df = provider.read_entity(entity)
-
-            if df is not None:
-                results = strategy.emit(
-                    "read.after_read",
-                    df=df,
-                    entity_id=entity.entityid,
-                    pipe_id=pipe.pipeid,
-                    used_watermark=usewm,
-                )
-                df = _apply_df_transforms(results, df)
-
-            return df
+                return strategy._read_for_pipe(pipe, entity, usewm, details=details)
 
         return entity_reader
+
+    def _read_for_pipe(self, pipe, entity, usewm, details=None):
+        """One pipe-input read: resolve_read → provider/fixture read → after_read."""
+        # Interdiction point: a handler (e.g. WatermarkAspect) may take
+        # ownership of the read entirely — including deciding there is
+        # no new data (df=None). Distinct from read.after_read, which
+        # can only transform a DataFrame that was already read.
+        resolved = None
+        for _, retval in self.emit(
+            "read.resolve_read",
+            entity=entity,
+            entity_id=entity.entityid,
+            pipe=pipe,
+            pipe_id=pipe.pipeid,
+            use_watermark=usewm,
+        ):
+            if retval is not None and hasattr(retval, "df"):
+                resolved = retval
+
+        if details is not None:
+            details["resolved"] = resolved is not None
+
+        if resolved is not None:
+            df = resolved.df
+        elif _is_local_execution():
+            # [implementer] tests/entities/ auto-discovery convention — ki-bsi
+            # Priority: explicit --source > kindling.yaml env mapping > fixture CSV > registry
+            # Fixture discovery applies only when running locally (standalone platform).
+            cwd = Path(os.getcwd())
+            fixture_path = resolve_fixture_csv_path(entity.entityid, cwd)
+            if fixture_path is not None:
+                self.logger.info(
+                    f"Using fixture CSV for entity '{entity.entityid}': {fixture_path}"
+                )
+                df = FixtureCSVEntityProvider(fixture_path).read_entity(entity)
+            else:
+                provider = self.provider_registry.get_provider_for_entity(entity)
+                df = provider.read_entity(entity)
+        else:
+            provider = self.provider_registry.get_provider_for_entity(entity)
+            df = provider.read_entity(entity)
+
+        if df is not None:
+            results = self.emit(
+                "read.after_read",
+                df=df,
+                entity_id=entity.entityid,
+                pipe_id=pipe.pipeid,
+                used_watermark=usewm,
+            )
+            df = _apply_df_transforms(results, df)
+
+        return df
 
     def create_pipe_persist_activator(self, pipe):
         # Capture self for use in closure
@@ -186,157 +207,177 @@ class SimpleReadPersistStrategy(EntityReadPersistStrategy, SignalEmitter):
 
                 strategy.logger.debug(f"persist_lambda - pipe = {pipe.pipeid}")
 
-                try:
-                    # Emitted inside the failure boundary: a raising handler
-                    # is the supported write gate (e.g. a validation gate) —
-                    # the write must not happen AND the raise must pair with
-                    # persist.persist_failed, so observers like
-                    # WatermarkAspect treat it as a failed persist (pending
-                    # watermark discarded, retry re-reads the same slice).
-                    results = strategy.emit(
-                        "persist.before_persist",
-                        df=df,
-                        pipe_id=pipe.pipeid,
-                        source_entity_id=src_input_entity_id,
-                        output_entity_id=pipe.output_entity_id,
-                        persist_id=persist_id,
+                # One consolidated persist span — the provider-op tracer
+                # supplies the child op span (merge/append/write/replace).
+                # reraise=True is load-bearing: a swallowed merge failure
+                # would let persist.after_persist fire and the watermark
+                # advance past unpersisted data.
+                span_details = {
+                    "pipe_id": pipe.pipeid,
+                    "source_entity_id": src_input_entity_id,
+                    "output_entity_id": pipe.output_entity_id,
+                    "persist_id": persist_id,
+                }
+                persist_span = (
+                    strategy.tp.span(
+                        operation="persist",
+                        component=COMPONENT_PIPES,
+                        details=span_details,
+                        reraise=True,
                     )
-                    df = _apply_df_transforms(results, df)
-
-                    # Derived datasets (dataset.kind='derived') are replaced,
-                    # not evolved: the provider swaps the whole table — or
-                    # only the batch's slices when derived.replace_keys is
-                    # declared — atomically. The state-dataset write.mode
-                    # machinery below never applies (the combination is
-                    # rejected at entity registration).
-                    derived_config = derived_config_from_tags(output_entity)
-                    if derived_config.enabled:
-                        if not hasattr(output_provider, "replace_entity"):
-                            provider_type = (output_entity.tags or {}).get(
-                                "provider_type", "unknown"
-                            )
-                            raise ValueError(
-                                f"Entity '{output_entity.entityid}' is a derived dataset "
-                                f"but provider '{provider_type}' does not support "
-                                "replace writes"
-                            )
-                        with strategy.tp.span(
-                            component="data_utils", operation="replace_entity_table"
-                        ):
-                            output_provider.replace_entity(df, output_entity)
-
-                        duration = time.time() - start_time
-                        strategy.emit(
-                            "persist.after_persist",
-                            df=df,
-                            pipe_id=pipe.pipeid,
-                            source_entity_id=src_input_entity_id,
-                            output_entity_id=pipe.output_entity_id,
-                            duration_seconds=duration,
-                            persist_id=persist_id,
-                        )
-                        return
-
-                    # Sink write mode override, shared with the streaming path
-                    # (SimplePipeStreamStarter): "append" skips the merge even
-                    # when the provider supports it (e.g. append-only fact
-                    # tables); "merge" makes the merge requirement explicit —
-                    # no silent append fallback. Unset keeps the default:
-                    # merge when the provider can, append otherwise. The
-                    # static tag value is validated at entity-registration
-                    # time (data_entities._validate_write_mode_tag); checking
-                    # inside the try keeps any raise paired with
-                    # persist.persist_failed after persist.before_persist.
-                    write_mode = (
-                        str((output_entity.tags or {}).get("write.mode") or "").strip().lower()
+                    if strategy._trace_gates.minimal
+                    else nullcontext()
+                )
+                with persist_span:
+                    strategy._persist_output(
+                        pipe,
+                        df,
+                        src_input_entity_id,
+                        output_entity,
+                        output_provider,
+                        persist_id,
+                        start_time,
                     )
-                    if write_mode not in ("", "append", "merge", "insert"):
-                        raise ValueError(
-                            f"Entity '{output_entity.entityid}': invalid write.mode "
-                            f"'{write_mode}' (expected 'append', 'merge' or 'insert')"
-                        )
-                    if write_mode in ("merge", "insert") and not hasattr(
-                        output_provider, "merge_to_entity"
-                    ):
-                        provider_type = (output_entity.tags or {}).get("provider_type", "unknown")
-                        raise ValueError(
-                            f"Entity '{output_entity.entityid}': write.mode is "
-                            f"'{write_mode}' but provider '{provider_type}' does not "
-                            "support merge operations"
-                        )
-
-                    with strategy.tp.span(
-                        component="data_utils", operation="merge_and_watermark", reraise=False
-                    ):
-                        # Check if entity exists using provider
-                        if output_provider.check_entity_exists(output_entity):
-                            # Merge operation (Delta-specific, fallback to write for other providers)
-                            with strategy.tp.span(operation="merge_to_entity_table"):
-                                if write_mode != "append" and hasattr(
-                                    output_provider, "merge_to_entity"
-                                ):
-                                    output_provider.merge_to_entity(df, output_entity)
-                                else:
-                                    # Append mode, or provider doesn't support merge
-                                    from kindling.entity_provider import (
-                                        WritableEntityProvider,
-                                    )
-
-                                    if isinstance(output_provider, WritableEntityProvider):
-                                        if not write_mode:
-                                            provider_type = (output_entity.tags or {}).get(
-                                                "provider_type", "delta"
-                                            )
-                                            strategy.logger.info(
-                                                f"Provider '{provider_type}' does not support merge, using append"
-                                            )
-                                        output_provider.append_to_entity(df, output_entity)
-                                    else:
-                                        provider_type = (output_entity.tags or {}).get(
-                                            "provider_type", "unknown"
-                                        )
-                                        raise ValueError(
-                                            f"Provider '{provider_type}' does not support write operations"
-                                        )
-                        else:
-                            with strategy.tp.span(operation="write_to_entity_table", reraise=True):
-                                from kindling.entity_provider import (
-                                    WritableEntityProvider,
-                                )
-
-                                if isinstance(output_provider, WritableEntityProvider):
-                                    output_provider.write_to_entity(df, output_entity)
-                                else:
-                                    provider_type = (output_entity.tags or {}).get(
-                                        "provider_type", "unknown"
-                                    )
-                                    raise ValueError(
-                                        f"Provider '{provider_type}' does not support write operations"
-                                    )
-
-                    duration = time.time() - start_time
-                    strategy.emit(
-                        "persist.after_persist",
-                        df=df,
-                        pipe_id=pipe.pipeid,
-                        source_entity_id=src_input_entity_id,
-                        output_entity_id=pipe.output_entity_id,
-                        duration_seconds=duration,
-                        persist_id=persist_id,
-                    )
-
-                except Exception as e:
-                    duration = time.time() - start_time
-                    strategy.emit(
-                        "persist.persist_failed",
-                        pipe_id=pipe.pipeid,
-                        source_entity_id=src_input_entity_id,
-                        output_entity_id=pipe.output_entity_id,
-                        error=str(e),
-                        error_type=type(e).__name__,
-                        duration_seconds=duration,
-                        persist_id=persist_id,
-                    )
-                    raise
 
         return persist_lambda
+
+    def _persist_output(
+        self,
+        pipe,
+        df,
+        src_input_entity_id,
+        output_entity,
+        output_provider,
+        persist_id,
+        start_time,
+    ):
+        """Write one pipe output, pairing signals with the failure boundary.
+
+        Every raise pairs persist.persist_failed with the earlier
+        persist.before_persist and propagates — the enclosing persist span
+        uses reraise=True, so no failure is ever swallowed between
+        before_persist and after_persist.
+        """
+        try:
+            # Emitted inside the failure boundary: a raising handler
+            # is the supported write gate (e.g. a validation gate) —
+            # the write must not happen AND the raise must pair with
+            # persist.persist_failed, so observers like
+            # WatermarkAspect treat it as a failed persist (pending
+            # watermark discarded, retry re-reads the same slice).
+            results = self.emit(
+                "persist.before_persist",
+                df=df,
+                pipe_id=pipe.pipeid,
+                source_entity_id=src_input_entity_id,
+                output_entity_id=pipe.output_entity_id,
+                persist_id=persist_id,
+            )
+            df = _apply_df_transforms(results, df)
+
+            # Derived datasets (dataset.kind='derived') are replaced,
+            # not evolved: the provider swaps the whole table — or
+            # only the batch's slices when derived.replace_keys is
+            # declared — atomically. The state-dataset write.mode
+            # machinery below never applies (the combination is
+            # rejected at entity registration).
+            derived_config = derived_config_from_tags(output_entity)
+            if derived_config.enabled:
+                if not hasattr(output_provider, "replace_entity"):
+                    provider_type = (output_entity.tags or {}).get("provider_type", "unknown")
+                    raise ValueError(
+                        f"Entity '{output_entity.entityid}' is a derived dataset "
+                        f"but provider '{provider_type}' does not support "
+                        "replace writes"
+                    )
+                output_provider.replace_entity(df, output_entity)
+
+                duration = time.time() - start_time
+                self.emit(
+                    "persist.after_persist",
+                    df=df,
+                    pipe_id=pipe.pipeid,
+                    source_entity_id=src_input_entity_id,
+                    output_entity_id=pipe.output_entity_id,
+                    duration_seconds=duration,
+                    persist_id=persist_id,
+                )
+                return
+
+            # Sink write mode override, shared with the streaming path
+            # (SimplePipeStreamStarter): "append" skips the merge even
+            # when the provider supports it (e.g. append-only fact
+            # tables); "merge" makes the merge requirement explicit —
+            # no silent append fallback. Unset keeps the default:
+            # merge when the provider can, append otherwise. The
+            # static tag value is validated at entity-registration
+            # time (data_entities._validate_write_mode_tag); checking
+            # inside the try keeps any raise paired with
+            # persist.persist_failed after persist.before_persist.
+            write_mode = str((output_entity.tags or {}).get("write.mode") or "").strip().lower()
+            if write_mode not in ("", "append", "merge", "insert"):
+                raise ValueError(
+                    f"Entity '{output_entity.entityid}': invalid write.mode "
+                    f"'{write_mode}' (expected 'append', 'merge' or 'insert')"
+                )
+            if write_mode in ("merge", "insert") and not hasattr(
+                output_provider, "merge_to_entity"
+            ):
+                provider_type = (output_entity.tags or {}).get("provider_type", "unknown")
+                raise ValueError(
+                    f"Entity '{output_entity.entityid}': write.mode is "
+                    f"'{write_mode}' but provider '{provider_type}' does not "
+                    "support merge operations"
+                )
+
+            from kindling.entity_provider import WritableEntityProvider
+
+            if output_provider.check_entity_exists(output_entity):
+                # Merge (Delta-specific), fall back to append for other providers
+                if write_mode != "append" and hasattr(output_provider, "merge_to_entity"):
+                    output_provider.merge_to_entity(df, output_entity)
+                elif isinstance(output_provider, WritableEntityProvider):
+                    if not write_mode:
+                        provider_type = (output_entity.tags or {}).get("provider_type", "delta")
+                        self.logger.info(
+                            f"Provider '{provider_type}' does not support merge, using append"
+                        )
+                    output_provider.append_to_entity(df, output_entity)
+                else:
+                    provider_type = (output_entity.tags or {}).get("provider_type", "unknown")
+                    raise ValueError(
+                        f"Provider '{provider_type}' does not support write operations"
+                    )
+            else:
+                if isinstance(output_provider, WritableEntityProvider):
+                    output_provider.write_to_entity(df, output_entity)
+                else:
+                    provider_type = (output_entity.tags or {}).get("provider_type", "unknown")
+                    raise ValueError(
+                        f"Provider '{provider_type}' does not support write operations"
+                    )
+
+            duration = time.time() - start_time
+            self.emit(
+                "persist.after_persist",
+                df=df,
+                pipe_id=pipe.pipeid,
+                source_entity_id=src_input_entity_id,
+                output_entity_id=pipe.output_entity_id,
+                duration_seconds=duration,
+                persist_id=persist_id,
+            )
+
+        except Exception as e:
+            duration = time.time() - start_time
+            self.emit(
+                "persist.persist_failed",
+                pipe_id=pipe.pipeid,
+                source_entity_id=src_input_entity_id,
+                output_entity_id=pipe.output_entity_id,
+                error=str(e),
+                error_type=type(e).__name__,
+                duration_seconds=duration,
+                persist_id=persist_id,
+            )
+            raise

--- a/packages/kindling/simple_stage_processor.py
+++ b/packages/kindling/simple_stage_processor.py
@@ -5,15 +5,15 @@ from typing import Dict, Optional
 
 from delta.tables import *
 from injector import Binder, Injector, inject, singleton
-from pyspark.sql.functions import current_timestamp, lit, row_number, when
-from pyspark.sql.window import Window
-
 from kindling.data_entities import *
 from kindling.data_pipes import *
 from kindling.injection import *
 from kindling.signaling import SignalEmitter, SignalProvider
 from kindling.spark_config import *
 from kindling.spark_trace import *
+from kindling.trace_ops import COMPONENT_PIPES
+from pyspark.sql.functions import current_timestamp, lit, row_number, when
+from pyspark.sql.window import Window
 
 from .simple_read_persist_strategy import *
 
@@ -85,10 +85,17 @@ class StageProcessor(StageProcessingService, SignalEmitter):
         )
 
         try:
+            # Structured, whitelisted attributes: stage_details is caller-
+            # supplied free-form data and must not be exported wholesale.
             with self.tp.span(
-                component=stage_description,
-                operation=stage_description,
-                details=stage_details,
+                component=COMPONENT_PIPES,
+                operation="stage",
+                details={
+                    "stage": stage,
+                    "layer": layer,
+                    "execution_id": execution_id,
+                    "pipe_count": len(stage_pipe_ids),
+                },
                 reraise=True,
             ):
                 if any(self.dpr.get_pipe_definition(pid).use_watermark for pid in stage_pipe_ids):

--- a/packages/kindling/spark_config.py
+++ b/packages/kindling/spark_config.py
@@ -330,6 +330,30 @@ class DynaconfConfig(ConfigService):
             raise AttributeError(f"No configuration found for '{name}'")
         return value
 
+    def _reload_trace_span(self):
+        """Standard-tier span for hot reloads.
+
+        Resolved lazily: the trace providers inject ConfigService, so the
+        config service cannot hold one from construction. Reloads are rare;
+        per-call resolution is fine. Never lets tracing break a reload.
+        """
+        try:
+            from contextlib import nullcontext
+
+            from kindling.trace_ops import COMPONENT_CONFIG, tracing_gates
+
+            if not tracing_gates(self).standard:
+                return nullcontext()
+            from kindling.injection import GlobalInjector
+            from kindling.spark_trace import SparkTraceProvider
+
+            tp = GlobalInjector.get(SparkTraceProvider)
+            return tp.span(operation="reload", component=COMPONENT_CONFIG, reraise=True)
+        except Exception:
+            from contextlib import nullcontext
+
+            return nullcontext()
+
     def reload(self) -> Dict[str, Any]:
         """Hot-reload configuration from storage.
 
@@ -339,6 +363,10 @@ class DynaconfConfig(ConfigService):
         Raises:
             ConfigReloadError: If reload fails and cannot rollback
         """
+        with self._reload_trace_span():
+            return self._reload()
+
+    def _reload(self) -> Dict[str, Any]:
         with self._config_lock:
             old_config = self.get_all()
             old_dynaconf = self.dynaconf

--- a/packages/kindling/spark_trace.py
+++ b/packages/kindling/spark_trace.py
@@ -9,12 +9,11 @@ from datetime import datetime
 from typing import Any, Callable, Dict, Optional
 
 from injector import Binder, Injector, inject, singleton
-from py4j.java_gateway import JavaObject
-from py4j.protocol import Py4JError
-
 from kindling.injection import *
 from kindling.spark_config import *
 from kindling.spark_session import *
+from py4j.java_gateway import JavaObject
+from py4j.protocol import Py4JError
 
 from .spark_log_provider import *
 
@@ -178,6 +177,9 @@ class SparkSpan:
     reraise: bool
     start_time: datetime = None
     end_time: datetime = None
+    # Id of the enclosing span at open time (None for roots). Appended with a
+    # default so existing positional constructions keep working.
+    parent_id: Optional[str] = None
 
 
 class SparkTraceProvider(ABC):
@@ -220,6 +222,28 @@ class SparkTraceProvider(ABC):
         """End a manually started span. Optionally record an error."""
         pass
 
+    def record_span(
+        self,
+        operation: str,
+        component: str,
+        start_time: datetime,
+        end_time: datetime,
+        details: dict = None,
+        error: Optional[str] = None,
+    ) -> None:
+        """Record an already-completed span with explicit timestamps.
+
+        Concrete default so third-party/duck-typed providers keep working:
+        routes through start_span/end_span and carries the true timestamps in
+        the details. Built-in providers override to honor the given
+        timestamps natively.
+        """
+        recorded_details = dict(details or {})
+        recorded_details["recordedStartTime"] = start_time.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        recorded_details["recordedEndTime"] = end_time.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        span = self.start_span(operation, component, details=recorded_details)
+        self.end_span(span, error=error)
+
 
 @GlobalInjector.singleton_autobind()
 class EventBasedSparkTrace(SparkTraceProvider):
@@ -260,18 +284,20 @@ class EventBasedSparkTrace(SparkTraceProvider):
         id = str(self._increment_activity())
         live_details = details if details is not None else {}
 
+        parent_span = self.current_span
         current_span = SparkSpan(
             id=id,
-            component=component or (self.current_span.component if self.current_span else None),
-            operation=operation or (self.current_span.operation if self.current_span else None),
+            component=component or (parent_span.component if parent_span else None),
+            operation=operation or (parent_span.operation if parent_span else None),
             attributes=(
                 live_details
                 if details is not None
-                else (self.current_span.attributes if self.current_span else None)
+                else (parent_span.attributes if parent_span else None)
             ),
             start_time=datetime.now(),
-            traceId=self.current_span.traceId if self.current_span else uuid.uuid4(),
-            reraise=reraise or (self.current_span.reraise if self.current_span else None),
+            traceId=parent_span.traceId if parent_span else uuid.uuid4(),
+            reraise=reraise or (parent_span.reraise if parent_span else None),
+            parent_id=parent_span.id if parent_span else None,
         )
 
         self.current_span = current_span
@@ -285,6 +311,8 @@ class EventBasedSparkTrace(SparkTraceProvider):
             start_details = self._add_timestamp_to_dict(
                 live_details, "startTime", current_span.start_time
             )
+            if current_span.parent_id is not None:
+                start_details["parentSpanId"] = current_span.parent_id
             try:
                 self.emitter.emit_custom_event(
                     current_span.component,
@@ -323,6 +351,8 @@ class EventBasedSparkTrace(SparkTraceProvider):
                 end_details["totalTime"] = self._calculate_time_diff(
                     current_span.start_time, current_span.end_time
                 )
+                if current_span.parent_id is not None:
+                    end_details["parentSpanId"] = current_span.parent_id
                 self.emitter.emit_custom_event(
                     current_span.component,
                     f"{current_span.operation}_END",
@@ -330,6 +360,9 @@ class EventBasedSparkTrace(SparkTraceProvider):
                     current_span.id,
                     current_span.traceId,
                 )
+                # Restore the enclosing span so sibling spans and subsequent
+                # runs in the same session do not blur into one tree.
+                self.current_span = parent_span
 
     def start_span(
         self,
@@ -348,9 +381,12 @@ class EventBasedSparkTrace(SparkTraceProvider):
             start_time=datetime.now(),
             traceId=self.current_span.traceId if self.current_span else uuid.uuid4(),
             reraise=False,
+            parent_id=self.current_span.id if self.current_span else None,
         )
 
         start_details = self._add_timestamp_to_dict(live_details, "startTime", span.start_time)
+        if span.parent_id is not None:
+            start_details["parentSpanId"] = span.parent_id
         self.emitter.emit_custom_event(
             span.component,
             f"{span.operation}_START",
@@ -401,10 +437,61 @@ class EventBasedSparkTrace(SparkTraceProvider):
         end_details = self._add_timestamp_to_dict({}, "startTime", span.start_time)
         end_details = self._add_timestamp_to_dict(end_details, "endTime", span.end_time)
         end_details["totalTime"] = self._calculate_time_diff(span.start_time, span.end_time)
+        if span.parent_id is not None:
+            end_details["parentSpanId"] = span.parent_id
         self.emitter.emit_custom_event(
             span.component,
             f"{span.operation}_END",
             end_details,
             span.id,
             span.traceId,
+        )
+
+    def record_span(
+        self,
+        operation: str,
+        component: str,
+        start_time: datetime,
+        end_time: datetime,
+        details: dict = None,
+        error: Optional[str] = None,
+    ) -> None:
+        """Emit START/END (and ERROR) for a completed span with the given timestamps."""
+        span_id = str(self._increment_activity())
+        live_details = dict(details or {})
+
+        span = SparkSpan(
+            id=span_id,
+            component=component,
+            operation=operation,
+            attributes=live_details,
+            start_time=start_time,
+            end_time=end_time,
+            traceId=self.current_span.traceId if self.current_span else uuid.uuid4(),
+            reraise=False,
+            parent_id=self.current_span.id if self.current_span else None,
+        )
+
+        start_details = self._add_timestamp_to_dict(live_details, "startTime", start_time)
+        if span.parent_id is not None:
+            start_details["parentSpanId"] = span.parent_id
+        self.emitter.emit_custom_event(
+            span.component, f"{span.operation}_START", start_details, span.id, span.traceId
+        )
+
+        if error:
+            error_details = self._add_timestamp_to_dict(live_details, "startTime", start_time)
+            error_details = self._add_timestamp_to_dict(error_details, "errorTime", end_time)
+            error_details["exception"] = error
+            self.emitter.emit_custom_event(
+                span.component, f"{span.operation}_ERROR", error_details, span.id, span.traceId
+            )
+
+        end_details = self._add_timestamp_to_dict(live_details, "startTime", start_time)
+        end_details = self._add_timestamp_to_dict(end_details, "endTime", end_time)
+        end_details["totalTime"] = self._calculate_time_diff(start_time, end_time)
+        if span.parent_id is not None:
+            end_details["parentSpanId"] = span.parent_id
+        self.emitter.emit_custom_event(
+            span.component, f"{span.operation}_END", end_details, span.id, span.traceId
         )

--- a/packages/kindling/spark_trace.py
+++ b/packages/kindling/spark_trace.py
@@ -330,39 +330,51 @@ class EventBasedSparkTrace(SparkTraceProvider):
                 )
                 error_details = self._add_timestamp_to_dict(error_base, "errorTime", error_time)
                 error_details["exception"] = traceback.format_exc()
-                self.emitter.emit_custom_event(
-                    current_span.component,
-                    f"{current_span.operation}_ERROR",
-                    error_details,
-                    current_span.id,
-                    current_span.traceId,
-                )
+                try:
+                    self.emitter.emit_custom_event(
+                        current_span.component,
+                        f"{current_span.operation}_ERROR",
+                        error_details,
+                        current_span.id,
+                        current_span.traceId,
+                    )
+                except Exception:
+                    # A failing emitter must not replace the span's own
+                    # exception on the reraise path.
+                    pass
                 if reraise:
                     raise
 
             finally:
-                current_span.end_time = datetime.now()
-                end_base = self._add_timestamp_to_dict(
-                    live_details, "startTime", current_span.start_time
-                )
-                end_details = self._add_timestamp_to_dict(
-                    end_base, "endTime", current_span.end_time
-                )
-                end_details["totalTime"] = self._calculate_time_diff(
-                    current_span.start_time, current_span.end_time
-                )
-                if current_span.parent_id is not None:
-                    end_details["parentSpanId"] = current_span.parent_id
-                self.emitter.emit_custom_event(
-                    current_span.component,
-                    f"{current_span.operation}_END",
-                    end_details,
-                    current_span.id,
-                    current_span.traceId,
-                )
-                # Restore the enclosing span so sibling spans and subsequent
-                # runs in the same session do not blur into one tree.
-                self.current_span = parent_span
+                try:
+                    current_span.end_time = datetime.now()
+                    end_base = self._add_timestamp_to_dict(
+                        live_details, "startTime", current_span.start_time
+                    )
+                    end_details = self._add_timestamp_to_dict(
+                        end_base, "endTime", current_span.end_time
+                    )
+                    end_details["totalTime"] = self._calculate_time_diff(
+                        current_span.start_time, current_span.end_time
+                    )
+                    if current_span.parent_id is not None:
+                        end_details["parentSpanId"] = current_span.parent_id
+                    self.emitter.emit_custom_event(
+                        current_span.component,
+                        f"{current_span.operation}_END",
+                        end_details,
+                        current_span.id,
+                        current_span.traceId,
+                    )
+                except Exception:
+                    # A failing END emission must not break caller control
+                    # flow (or clobber an in-flight exception).
+                    pass
+                finally:
+                    # Restore the enclosing span so sibling spans and
+                    # subsequent runs in the same session do not blur into
+                    # one tree — even when the END emission fails.
+                    self.current_span = parent_span
 
     def start_span(
         self,

--- a/packages/kindling/streaming_listener.py
+++ b/packages/kindling/streaming_listener.py
@@ -42,12 +42,12 @@ from enum import Enum
 from typing import Any, Dict, Optional
 
 from injector import inject
-from pyspark.sql.streaming import StreamingQueryListener
-
 from kindling.injection import GlobalInjector
 from kindling.signaling import SignalEmitter, SignalProvider
 from kindling.spark_log_provider import PythonLoggerProvider
 from kindling.spark_trace import SparkTraceProvider
+from kindling.trace_ops import COMPONENT_STREAMING
+from pyspark.sql.streaming import StreamingQueryListener
 
 # =============================================================================
 # Event Data Structures
@@ -463,14 +463,18 @@ class KindlingStreamingListener(StreamingQueryListener, SignalEmitter):
             f"(query_id={event.query_id}, run_id={event.run_id})"
         )
 
-        # Open a trace span for this query's lifecycle
+        # Open a trace span for this query's lifecycle. Long-lived queries
+        # stay one manual span with batch_progress events — batches are
+        # events, never spans. The query label is an attribute, not part of
+        # the component name (span-name cardinality stays bounded).
         span = self._trace_provider.start_span(
-            operation="streaming_query",
-            component=f"query-{query_label}",
+            operation="query",
+            component=COMPONENT_STREAMING,
             details={
                 "query_id": event.query_id,
                 "run_id": event.run_id,
                 "name": event.name or "",
+                "query_label": query_label,
             },
         )
         self._query_spans[event.query_id] = span

--- a/packages/kindling/streaming_orchestrator.py
+++ b/packages/kindling/streaming_orchestrator.py
@@ -12,12 +12,12 @@ from __future__ import annotations
 
 import time
 import uuid
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, Optional
 
 from injector import inject
-
 from kindling.execution_strategy import ExecutionPlan
 from kindling.generation_executor import (
     ErrorStrategy,
@@ -28,7 +28,9 @@ from kindling.generation_executor import (
 from kindling.injection import GlobalInjector
 from kindling.pipe_streaming import PipeStreamStarter
 from kindling.signaling import SignalEmitter, SignalProvider
+from kindling.spark_config import ConfigService
 from kindling.spark_log_provider import PythonLoggerProvider
+from kindling.spark_trace import SparkTraceProvider
 from kindling.streaming_health_monitor import StreamingHealthMonitor
 from kindling.streaming_listener import KindlingStreamingListener
 from kindling.streaming_query_manager import (
@@ -37,6 +39,7 @@ from kindling.streaming_query_manager import (
     StreamingQueryState,
 )
 from kindling.streaming_recovery_manager import StreamingRecoveryManager
+from kindling.trace_ops import COMPONENT_STREAMING, tracing_gates
 
 
 @dataclass
@@ -77,6 +80,8 @@ class StreamingOrchestrator(SignalEmitter):
         recovery_manager: StreamingRecoveryManager,
         logger_provider: PythonLoggerProvider,
         signal_provider: SignalProvider = None,
+        tp: Optional[SparkTraceProvider] = None,
+        config: Optional[ConfigService] = None,
     ):
         self.pipe_stream_starter = pipe_stream_starter
         self.query_manager = query_manager
@@ -84,11 +89,21 @@ class StreamingOrchestrator(SignalEmitter):
         self.health_monitor = health_monitor
         self.recovery_manager = recovery_manager
         self.logger = logger_provider.get_logger("StreamingOrchestrator")
+        self.tp = tp
+        self._trace_gates = tracing_gates(config)
         self._init_signal_emitter(signal_provider)
 
         self._current_result: Optional[ExecutionResult] = None
         self._query_ids_by_pipe: Dict[str, str] = {}
         self._listener_registered = False
+
+    def _trace(self, operation: str, details: Optional[Dict[str, Any]] = None):
+        """Standard-tier streaming-lifecycle span, or a no-op CM."""
+        if self.tp is None or not self._trace_gates.standard:
+            return nullcontext()
+        return self.tp.span(
+            operation=operation, component=COMPONENT_STREAMING, details=details, reraise=True
+        )
 
     def start(
         self,
@@ -97,6 +112,18 @@ class StreamingOrchestrator(SignalEmitter):
         error_strategy: ErrorStrategy = ErrorStrategy.FAIL_FAST,
     ) -> ExecutionResult:
         """Start all streaming pipes in a plan and return immediately."""
+        details = {"pipe_count": plan.total_pipes()}
+        with self._trace("start", details):
+            result = self._start(plan, streaming_options, error_strategy)
+            details["run_id"] = result.run_id
+            return result
+
+    def _start(
+        self,
+        plan: ExecutionPlan,
+        streaming_options: Optional[Dict[str, Any]] = None,
+        error_strategy: ErrorStrategy = ErrorStrategy.FAIL_FAST,
+    ) -> ExecutionResult:
         if self._current_result is not None and self.get_status().active_query_count > 0:
             raise RuntimeError("StreamingOrchestrator already has active queries")
 
@@ -239,19 +266,20 @@ class StreamingOrchestrator(SignalEmitter):
 
     def stop(self, await_termination: bool = True) -> None:
         """Stop all managed streaming queries and monitoring components."""
-        for query_id in reversed(list(self._query_ids_by_pipe.values())):
-            try:
-                query_info = self.query_manager.get_query_status(query_id)
-            except Exception:
-                continue
+        with self._trace("stop", {"query_count": len(self._query_ids_by_pipe)}):
+            for query_id in reversed(list(self._query_ids_by_pipe.values())):
+                try:
+                    query_info = self.query_manager.get_query_status(query_id)
+                except Exception:
+                    continue
 
-            if query_info.spark_query is None:
-                continue
+                if query_info.spark_query is None:
+                    continue
 
-            if getattr(query_info.spark_query, "isActive", False):
-                self.query_manager.stop_query(query_id, await_termination=await_termination)
+                if getattr(query_info.spark_query, "isActive", False):
+                    self.query_manager.stop_query(query_id, await_termination=await_termination)
 
-        self.stop_runtime()
+            self.stop_runtime()
 
         self.emit(
             "streaming.orchestrator_stopped",

--- a/packages/kindling/streaming_recovery_manager.py
+++ b/packages/kindling/streaming_recovery_manager.py
@@ -46,17 +46,20 @@ Example:
 
 import threading
 import time
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from typing import Callable, Dict, Optional
 
 from injector import inject
-
 from kindling.injection import GlobalInjector
 from kindling.signaling import SignalEmitter, SignalProvider
+from kindling.spark_config import ConfigService
 from kindling.spark_log_provider import PythonLoggerProvider
+from kindling.spark_trace import SparkTraceProvider
 from kindling.streaming_query_manager import StreamingQueryManager
+from kindling.trace_ops import COMPONENT_STREAMING, tracing_gates
 
 # =============================================================================
 # Data Structures
@@ -199,6 +202,8 @@ class StreamingRecoveryManager(SignalEmitter):
         initial_backoff=1.0,
         max_backoff=300.0,
         check_interval=5.0,
+        tp: Optional[SparkTraceProvider] = None,
+        config: Optional[ConfigService] = None,
     ):
         """
         Initialize the streaming recovery manager.
@@ -217,6 +222,8 @@ class StreamingRecoveryManager(SignalEmitter):
         self.logger = logger_provider.get_logger("StreamingRecoveryManager")
         self.signal_provider = signal_provider
         self.query_manager = query_manager
+        self.tp = tp
+        self._trace_gates = tracing_gates(config)
         # No type annotations on primitives — injector only resolves annotated params
         self.max_retries = max_retries
         self.initial_backoff = initial_backoff
@@ -558,10 +565,27 @@ class StreamingRecoveryManager(SignalEmitter):
             attempt_time=attempt_time,
         )
 
+        recovery_span = (
+            self.tp.span(
+                operation="recover",
+                component=COMPONENT_STREAMING,
+                details={
+                    "query_id": query_id,
+                    "query_name": query_name,
+                    "retry": retry_count,
+                },
+                reraise=True,
+            )
+            if self.tp is not None and self._trace_gates.standard
+            else nullcontext()
+        )
         try:
             # Execute restart outside the state lock to avoid lock contention.
-            if restart_function:
-                restart_function()
+            # The span reraises so the existing failure handling below still
+            # runs; recovery itself never dies to tracing.
+            with recovery_span:
+                if restart_function:
+                    restart_function()
 
             with self._state_lock:
                 current_state = self._recovery_states.get(state.query_id)

--- a/packages/kindling/test_framework.py
+++ b/packages/kindling/test_framework.py
@@ -17,6 +17,169 @@ try:
 except ImportError:
     pytest = None  # Will be checked before use in test functions
 
+from kindling.spark_trace import SparkSpan, SparkTraceProvider
+
+# ==============================================================================
+# Recording trace provider (test support)
+# ==============================================================================
+
+
+@dataclass
+class RecordedSpan:
+    """One span captured by RecordingTraceProvider."""
+
+    component: Optional[str]
+    operation: Optional[str]
+    details: Dict[str, Any]
+    span_id: str
+    trace_id: Any
+    parent_id: Optional[str]
+    open_index: int
+    close_index: Optional[int] = None
+    start_time: Optional[datetime] = None
+    end_time: Optional[datetime] = None
+    error: Optional[str] = None
+    events: List[Dict[str, Any]] = field(default_factory=list)
+    children: List["RecordedSpan"] = field(default_factory=list)
+
+    @property
+    def closed(self) -> bool:
+        return self.close_index is not None
+
+
+class RecordingTraceProvider(SparkTraceProvider):
+    """In-memory SparkTraceProvider for asserting span structure in tests.
+
+    Records every span with open/close order, component, operation, details,
+    parent_id, events, and errors. ``find()`` filters spans; ``tree()``
+    reconstructs the parent/child hierarchy from parent_id links. Matches the
+    built-in providers' semantics: nested spans inherit component/operation/
+    trace id, exceptions are swallowed unless ``reraise=True``, and
+    ``record_span`` honors explicit timestamps.
+    """
+
+    def __init__(self, logger_provider=None):
+        # logger_provider accepted (and ignored) for constructor
+        # compatibility with the notebook test-environment shims.
+        self.spans: List[RecordedSpan] = []
+        self.current_span: Optional[SparkSpan] = None
+        self._id_counter = 0
+        self._order_counter = 0
+        self._records_by_span: Dict[str, RecordedSpan] = {}
+
+    def _next_id(self) -> str:
+        self._id_counter += 1
+        return str(self._id_counter)
+
+    def _next_order(self) -> int:
+        self._order_counter += 1
+        return self._order_counter
+
+    def _open(self, operation, component, details, reraise) -> SparkSpan:
+        parent = self.current_span
+        span = SparkSpan(
+            id=self._next_id(),
+            component=component or (parent.component if parent else None),
+            operation=operation or (parent.operation if parent else None),
+            attributes=details if details is not None else {},
+            start_time=datetime.now(),
+            traceId=parent.traceId if parent else uuid.uuid4(),
+            reraise=reraise,
+            parent_id=parent.id if parent else None,
+        )
+        record = RecordedSpan(
+            component=span.component,
+            operation=span.operation,
+            details=span.attributes,
+            span_id=span.id,
+            trace_id=span.traceId,
+            parent_id=span.parent_id,
+            open_index=self._next_order(),
+            start_time=span.start_time,
+        )
+        self.spans.append(record)
+        self._records_by_span[span.id] = record
+        return span
+
+    def _close(self, span: SparkSpan, error: Optional[str] = None) -> None:
+        record = self._records_by_span[span.id]
+        record.close_index = self._next_order()
+        span.end_time = span.end_time or datetime.now()
+        record.end_time = span.end_time
+        if error:
+            record.error = error
+
+    @contextmanager
+    def span(self, operation=None, component=None, details=None, reraise=False):
+        span = self._open(operation, component, details, reraise)
+        parent = self.current_span
+        self.current_span = span
+        try:
+            yield self
+        except Exception as span_error:
+            self._records_by_span[span.id].error = str(span_error)
+            if reraise:
+                raise
+        finally:
+            self._close(span)
+            self.current_span = parent
+
+    def start_span(self, operation, component, details=None) -> SparkSpan:
+        return self._open(operation, component, details, reraise=False)
+
+    def add_event(self, span: SparkSpan, name: str, attributes=None) -> None:
+        self._records_by_span[span.id].events.append(
+            {"name": name, "attributes": dict(attributes) if attributes else {}}
+        )
+
+    def end_span(self, span: SparkSpan, error: Optional[str] = None) -> None:
+        span.end_time = datetime.now()
+        self._close(span, error=error)
+
+    def record_span(
+        self, operation, component, start_time, end_time, details=None, error=None
+    ) -> None:
+        parent = self.current_span
+        record = RecordedSpan(
+            component=component,
+            operation=operation,
+            details=dict(details or {}),
+            span_id=self._next_id(),
+            trace_id=parent.traceId if parent else uuid.uuid4(),
+            parent_id=parent.id if parent else None,
+            open_index=self._next_order(),
+            close_index=self._next_order(),
+            start_time=start_time,
+            end_time=end_time,
+            error=error,
+        )
+        self.spans.append(record)
+        self._records_by_span[record.span_id] = record
+
+    def find(self, component=None, operation=None) -> List[RecordedSpan]:
+        """Spans matching the given component and/or operation, in open order."""
+        return [
+            record
+            for record in self.spans
+            if (component is None or record.component == component)
+            and (operation is None or record.operation == operation)
+        ]
+
+    def tree(self) -> List[RecordedSpan]:
+        """Root spans with children rebuilt from parent_id links."""
+        for record in self.spans:
+            record.children = []
+        by_id = {record.span_id: record for record in self.spans}
+        roots = []
+        for record in self.spans:
+            parent = by_id.get(record.parent_id) if record.parent_id else None
+            if parent is not None:
+                parent.children.append(record)
+            else:
+                roots.append(record)
+        return roots
+
+
 # ==============================================================================
 # Service Wrapper for Dependency Injection
 # ==============================================================================
@@ -650,30 +813,9 @@ class NotebookTestEnvironment:
             globals()["WatermarkService"] = MockWatermarkManager
             globals()["MockWatermarkService"] = MockWatermarkManager
 
-        if "SparkTraceProvider" not in globals():
-
-            class MockSparkTraceProvider:
-                def __init__(self, logger_provider=None):
-                    if logger_provider:
-                        self.logger = logger_provider.get_logger("SparkTraceProvider")
-                    else:
-                        self.logger = MagicMock()
-
-                    self.create_span = MagicMock(return_value=self._create_mock_span())
-                    self.get_current_trace_id = MagicMock(return_value="test-trace-id")
-                    self.set_trace_context = MagicMock()
-                    self.create_spark_span = MagicMock(return_value=self._create_mock_span())
-                    self.span = MagicMock(return_value=self._create_mock_span())
-
-                def _create_mock_span(self):
-                    span = MagicMock()
-                    span.id = "test-span-id"
-                    span.trace_id = "test-trace-id"
-                    span.__enter__ = MagicMock(return_value=span)
-                    span.__exit__ = MagicMock(return_value=None)
-                    return span
-
-            globals()["SparkTraceProvider"] = MockSparkTraceProvider
+        # The ad-hoc MockSparkTraceProvider shim is gone: SparkTraceProvider
+        # is now imported at module scope, and RecordingTraceProvider is the
+        # public, constructible provider for tests.
 
         if "DataPipesExecution" not in globals():
 

--- a/packages/kindling/trace_ops.py
+++ b/packages/kindling/trace_ops.py
@@ -18,6 +18,7 @@ un-register tracing.
 """
 
 import functools
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Tuple
 
 from kindling.features import _coerce_bool
@@ -95,6 +96,42 @@ def read_tracing_settings(config_service) -> Tuple[bool, str]:
     if level not in _LEVEL_ORDER:
         level = LEVEL_STANDARD
     return enabled, level
+
+
+@dataclass(frozen=True)
+class TracingGates:
+    """Cached per-service span gates (read once at construction; config-first).
+
+    ``minimal`` spans emit whenever tracing is enabled; ``standard`` and
+    ``verbose`` require the corresponding level. A config reload does not
+    re-gate a constructed service.
+    """
+
+    enabled: bool
+    level: str
+
+    @property
+    def minimal(self) -> bool:
+        return self.enabled
+
+    @property
+    def standard(self) -> bool:
+        return self.enabled and level_at_least(self.level, LEVEL_STANDARD)
+
+    @property
+    def verbose(self) -> bool:
+        return self.enabled and level_at_least(self.level, LEVEL_VERBOSE)
+
+
+def tracing_gates(config_service=None) -> TracingGates:
+    """Gates from config; defaults (enabled, standard) when no config exists.
+
+    Accepting ``None`` keeps directly-constructed services (tests, shims)
+    working without a ConfigService.
+    """
+    if config_service is None:
+        return TracingGates(True, LEVEL_STANDARD)
+    return TracingGates(*read_tracing_settings(config_service))
 
 
 def whitelist_details(mapping: Optional[Dict[str, Any]], keys) -> Dict[str, Any]:

--- a/packages/kindling/trace_ops.py
+++ b/packages/kindling/trace_ops.py
@@ -1,0 +1,208 @@
+"""Provider-operation tracing at the entity-provider registry chokepoint.
+
+Every entity provider resolution funnels through
+``EntityProviderRegistry.get_provider``; wrapping the resolved instance's op
+methods there yields provider-wide span coverage without editing any provider.
+Wrappers are installed as instance attributes shadowing the bound methods —
+the object identity is unchanged, so ``isinstance`` capability probes,
+``hasattr`` checks, and cached-singleton semantics all still hold.
+
+Also home to the tracing config keys, level ordering, and span naming
+constants shared by the direct instrumentation seams (component =
+``kindling.<area>``; operation = short stable verb; ids/counts go in span
+attributes, never in names, keeping the exported span-name set small).
+
+Wiring is registration-gated at bootstrap (like WatermarkAspect): the config
+keys are read once at initialization and a later config reload does not
+un-register tracing.
+"""
+
+import functools
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from kindling.features import _coerce_bool
+
+# Config keys (kindling.telemetry.* family; read once at bootstrap wiring).
+TRACING_ENABLED_KEY = "kindling.telemetry.tracing.enabled"
+TRACING_LEVEL_KEY = "kindling.telemetry.tracing.level"
+
+# Tracing levels: each level includes everything below it.
+LEVEL_MINIMAL = "minimal"
+LEVEL_STANDARD = "standard"
+LEVEL_VERBOSE = "verbose"
+_LEVEL_ORDER = {LEVEL_MINIMAL: 0, LEVEL_STANDARD: 1, LEVEL_VERBOSE: 2}
+
+# Span component names (component = kindling.<area>; see docs/contributing/
+# logging_tracing.md). Entity-provider ops use COMPONENT_ENTITY_PREFIX plus
+# the provider_type, e.g. "kindling.entity.delta".
+COMPONENT_ENTITY_PREFIX = "kindling.entity"
+COMPONENT_PIPES = "kindling.pipes"
+COMPONENT_WATERMARK = "kindling.watermark"
+COMPONENT_CONFIG = "kindling.config"
+COMPONENT_MIGRATION = "kindling.migration"
+COMPONENT_BOOTSTRAP = "kindling.bootstrap"
+COMPONENT_STREAMING = "kindling.streaming"
+COMPONENT_ORCHESTRATOR = "kindling.orchestrator"
+COMPONENT_INGESTION = "kindling.ingestion"
+COMPONENT_APPS = "kindling.apps"
+COMPONENT_DEPLOY = "kindling.deploy"
+COMPONENT_CLI = "kindling.cli"
+
+# Provider op methods wrapped when present on a resolved instance: the
+# capability-ABC methods plus the de-facto delta ops callers probe with
+# hasattr (merge_to_entity is in no ABC). Cheap existence/version probes are
+# deliberately untraced.
+TRACED_PROVIDER_OPS = (
+    "read_entity",
+    "read_entity_as_stream",
+    "read_entity_changes",
+    "read_entity_since_version",
+    "read_entity_as_of",
+    "write_to_entity",
+    "append_to_entity",
+    "merge_to_entity",
+    "replace_entity",
+    "ensure_entity_table",
+    "ensure_destination",
+    "append_as_stream",
+    "merge_as_stream",
+)
+UNTRACED_PROVIDER_OPS = (
+    "check_entity_exists",
+    "get_entity_version",
+)
+
+_WRAP_MARKER = "_kindling_op_tracing_wrapped"
+
+
+def level_at_least(level: str, minimum: str) -> bool:
+    """True when `level` enables spans gated at `minimum` (unknown → standard)."""
+    return (
+        _LEVEL_ORDER.get(str(level).lower(), _LEVEL_ORDER[LEVEL_STANDARD]) >= _LEVEL_ORDER[minimum]
+    )
+
+
+def read_tracing_settings(config_service) -> Tuple[bool, str]:
+    """Read (enabled, level) with features-style bool coercion.
+
+    ConfigService.get does no type coercion and the SparkConf path returns
+    strings, so "false"/"0" must coerce like kindling.features values do.
+    """
+    enabled = _coerce_bool(config_service.get(TRACING_ENABLED_KEY, True))
+    if enabled is None:
+        enabled = True
+    level = str(config_service.get(TRACING_LEVEL_KEY, LEVEL_STANDARD) or LEVEL_STANDARD).lower()
+    if level not in _LEVEL_ORDER:
+        level = LEVEL_STANDARD
+    return enabled, level
+
+
+def whitelist_details(mapping: Optional[Dict[str, Any]], keys) -> Dict[str, Any]:
+    """Copy only whitelisted keys into span details.
+
+    Span attributes are whitelisted per seam (ids, provider_type, durations,
+    counts, booleans, cursors) — never entity/pipe tags wholesale, which may
+    carry credential references.
+    """
+    if not mapping:
+        return {}
+    return {key: mapping[key] for key in keys if key in mapping}
+
+
+def _entity_id_from_args(args, kwargs) -> Optional[str]:
+    """Best-effort entity id: first argument shaped like EntityMetadata."""
+    for value in list(args) + list(kwargs.values()):
+        entity_id = getattr(value, "entityid", None)
+        if entity_id is not None:
+            return entity_id
+    return None
+
+
+def _make_op_wrapper(
+    original: Callable, trace_provider, component: str, op_name: str, provider_type: str
+) -> Callable:
+    @functools.wraps(original)
+    def traced_op(*args, **kwargs):
+        details = {"provider_type": provider_type}
+        entity_id = _entity_id_from_args(args, kwargs)
+        if entity_id is not None:
+            details["entity_id"] = entity_id
+        with trace_provider.span(
+            operation=op_name, component=component, details=details, reraise=True
+        ):
+            return original(*args, **kwargs)
+
+    return traced_op
+
+
+def wrap_provider_ops(instance, trace_provider, provider_type: str):
+    """Shadow the instance's op methods with tracing wrappers.
+
+    Idempotent (marker attribute); returns the same object. Streaming ops
+    span only the stream *setup* call — the query they return runs on after
+    the span closes, and per-micro-batch work must never produce spans (see
+    DeltaEntityProvider._merge_batch's deliberate wrapper bypass).
+    """
+    if getattr(instance, _WRAP_MARKER, False):
+        return instance
+    try:
+        setattr(instance, _WRAP_MARKER, True)
+    except AttributeError:
+        # Instances that reject attribute writes (__slots__/proxies) stay
+        # unwrapped; tracing must never break provider resolution.
+        return instance
+    component = f"{COMPONENT_ENTITY_PREFIX}.{provider_type}"
+    for op_name in TRACED_PROVIDER_OPS:
+        original = getattr(instance, op_name, None)
+        if original is None or not callable(original):
+            continue
+        wrapper = _make_op_wrapper(original, trace_provider, component, op_name, provider_type)
+        setattr(instance, op_name, wrapper)
+    return instance
+
+
+def configure_op_tracing(
+    config_service,
+    logger=None,
+    registry=None,
+    trace_provider=None,
+    legacy_provider=None,
+) -> bool:
+    """Bootstrap wiring: enable provider-op tracing when config allows.
+
+    Provider ops are standard-level spans: nothing is wrapped at
+    ``minimal``. The keyword seams exist for tests; production resolves
+    everything via GlobalInjector.
+    """
+    enabled, level = read_tracing_settings(config_service)
+    if not enabled or not level_at_least(level, LEVEL_STANDARD):
+        if logger is not None:
+            logger.debug(f"Provider op tracing not enabled (enabled={enabled}, level={level})")
+        return False
+
+    from kindling.injection import GlobalInjector
+
+    if trace_provider is None:
+        from kindling.spark_trace import SparkTraceProvider
+
+        trace_provider = GlobalInjector.get(SparkTraceProvider)
+    if registry is None:
+        from kindling.entity_provider_registry import EntityProviderRegistry
+
+        registry = GlobalInjector.get(EntityProviderRegistry)
+
+    registry.enable_op_tracing(trace_provider, level)
+
+    # The legacy EntityProvider singleton reaches consumers (self.ep in the
+    # stage processor, watermark manager, and file ingestion) via DI without
+    # passing through the registry. It is the same delta instance the
+    # registry would serve; wrapping is idempotent either way.
+    if legacy_provider is None:
+        from kindling.data_entities import EntityProvider
+
+        legacy_provider = GlobalInjector.get(EntityProvider)
+    wrap_provider_ops(legacy_provider, trace_provider, provider_type="delta")
+
+    if logger is not None:
+        logger.info(f"Provider op tracing enabled (level={level})")
+    return True

--- a/packages/kindling/watermarking.py
+++ b/packages/kindling/watermarking.py
@@ -1,6 +1,7 @@
 import time
 import uuid
 from abc import ABC, abstractmethod
+from contextlib import nullcontext
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -15,6 +16,8 @@ from kindling.signaling import SignalEmitter, SignalProvider
 from kindling.spark_config import *
 from kindling.spark_log_provider import *
 from kindling.spark_session import *
+from kindling.spark_trace import SparkTraceProvider
+from kindling.trace_ops import COMPONENT_WATERMARK, tracing_gates
 from pyspark.errors import AnalysisException
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.functions import col, current_timestamp, date_format, lit
@@ -181,15 +184,33 @@ class WatermarkManager(WatermarkService, SignalEmitter):
         lp: PythonLoggerProvider,
         signal_provider: Optional[SignalProvider] = None,
         provider_registry: Optional[EntityProviderRegistry] = None,
+        tp: Optional[SparkTraceProvider] = None,
+        config: Optional[ConfigService] = None,
     ):
         self.wef = wef
         self.ep = ep
         self.provider_registry = provider_registry
         self.logger = lp.get_logger("watermark")
         self.spark = get_or_create_spark_session()
+        self.tp = tp
+        self._trace_gates = tracing_gates(config)
         self._init_signal_emitter(signal_provider)
 
+    def _trace(self, operation: str, details: Dict[str, Any]):
+        """Standard-tier watermark span, or a no-op CM when not traced."""
+        if self.tp is None or not self._trace_gates.standard:
+            return nullcontext()
+        return self.tp.span(
+            operation=operation, component=COMPONENT_WATERMARK, details=details, reraise=True
+        )
+
     def get_cursor(self, source_entity_id: str, reader_id: str) -> Optional[str]:
+        with self._trace(
+            "get_cursor", {"source_entity_id": source_entity_id, "reader_id": reader_id}
+        ):
+            return self._get_cursor(source_entity_id, reader_id)
+
+    def _get_cursor(self, source_entity_id: str, reader_id: str) -> Optional[str]:
         self.logger.debug(f"Getting watermark cursor for {source_entity_id}-{reader_id}")
 
         self.emit("watermark.before_get", source_entity_id=source_entity_id, reader_id=reader_id)
@@ -247,6 +268,19 @@ class WatermarkManager(WatermarkService, SignalEmitter):
         return cursor
 
     def save_cursor(
+        self,
+        source_entity_id: str,
+        reader_id: str,
+        cursor: str,
+        last_execution_id: str,
+    ) -> DataFrame:
+        with self._trace(
+            "save_cursor",
+            {"source_entity_id": source_entity_id, "reader_id": reader_id, "cursor": cursor},
+        ):
+            return self._save_cursor(source_entity_id, reader_id, cursor, last_execution_id)
+
+    def _save_cursor(
         self,
         source_entity_id: str,
         reader_id: str,
@@ -314,6 +348,10 @@ class WatermarkManager(WatermarkService, SignalEmitter):
             raise
 
     def read_changes(self, entity, pipe) -> Tuple[Optional[DataFrame], Optional[str]]:
+        with self._trace("read_changes", {"entity_id": entity.entityid, "pipe_id": pipe.pipeid}):
+            return self._read_changes(entity, pipe)
+
+    def _read_changes(self, entity, pipe) -> Tuple[Optional[DataFrame], Optional[str]]:
         self.logger.debug(f"read_changes - {entity.entityid} for {pipe.name}")
 
         self.emit(

--- a/packages/kindling_cli/kindling_cli/_tracing.py
+++ b/packages/kindling_cli/kindling_cli/_tracing.py
@@ -1,0 +1,104 @@
+"""Design-time CLI tracing (gh#210).
+
+The CLI is a separate process with no injector or ConfigService — the SDK
+deliberately has zero kindling-core imports, and the CLI populates the
+injector only when it loads the user's app. Spans here come from a lazily
+built PlainPythonTraceProvider over a tiny dict-config shim, gated by
+environment variables since no ConfigService exists pre-app-load:
+
+- ``KINDLING_TRACE=1`` enables CLI spans.
+- ``KINDLING_KINDLING__TELEMETRY__TRACING__PRINT=true`` prints them (the
+  same env override Dynaconf applies to kindling.telemetry.tracing.print
+  once an app loads).
+
+CLI migrate/pipeline commands get real tracing for free via the app's
+initialize(); this module only brackets design-time operations (package/
+app/runtime deploys, workspace uploads, run submission) with kindling.cli
+spans. Tracing must never break a CLI command: any import or provider
+failure degrades to a no-op.
+"""
+
+import functools
+import os
+from contextlib import nullcontext
+
+# Hardcoded rather than imported from kindling.trace_ops: the constant is
+# not worth importing the core (and transitively pyspark) for at CLI start.
+CLI_COMPONENT = "kindling.cli"
+
+_TRACE_ENV = "KINDLING_TRACE"
+_PRINT_ENV = "KINDLING_KINDLING__TELEMETRY__TRACING__PRINT"
+
+# Whitelisted command kwargs promoted to span attributes.
+_DETAIL_KEYS = ("app_name", "platform", "env", "environment", "job_name", "package_name")
+
+_provider = None
+
+
+class _EnvConfigShim:
+    """Just enough ConfigService surface for PlainPythonTraceProvider."""
+
+    def __init__(self, values):
+        self._values = values
+
+    def get(self, key, default=None):
+        return self._values.get(key, default)
+
+
+def _truthy(value) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def cli_tracing_enabled() -> bool:
+    return _truthy(os.environ.get(_TRACE_ENV))
+
+
+def _get_provider():
+    global _provider
+    if _provider is None:
+        from kindling.plain_telemetry import (
+            PlainPythonLoggerProvider,
+            PlainPythonTraceProvider,
+        )
+
+        values = {}
+        if _truthy(os.environ.get(_PRINT_ENV)):
+            values["print_trace"] = True
+        shim = _EnvConfigShim(values)
+        _provider = PlainPythonTraceProvider(PlainPythonLoggerProvider(shim), shim)
+    return _provider
+
+
+def cli_span(operation: str, details=None):
+    """A kindling.cli span, or a no-op CM when KINDLING_TRACE is unset."""
+    if not cli_tracing_enabled():
+        return nullcontext()
+    try:
+        return _get_provider().span(
+            operation=operation, component=CLI_COMPONENT, details=details, reraise=True
+        )
+    except Exception:
+        return nullcontext()
+
+
+def traced_command(operation: str):
+    """Bracket a click command callback with a kindling.cli span.
+
+    Place immediately above ``def`` (below the click decorators) so the
+    span wraps the raw callback. Whitelisted kwargs become attributes.
+    """
+
+    def decorate(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            details = {
+                key: str(value)
+                for key, value in kwargs.items()
+                if key in _DETAIL_KEYS and value is not None
+            }
+            with cli_span(operation, details):
+                return fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorate

--- a/packages/kindling_cli/kindling_cli/cli.py
+++ b/packages/kindling_cli/kindling_cli/cli.py
@@ -21,6 +21,7 @@ from urllib.parse import quote, urlparse
 
 import click
 import yaml
+from kindling_cli._tracing import traced_command
 from kindling_cli.test_runner import SUPPORTED_PLATFORMS
 from kindling_sdk.artifact_store import (
     AbfssArtifactStore,
@@ -2280,6 +2281,7 @@ def workspace_group() -> None:
     is_flag=True,
     help="Overwrite existing config and notebooks in storage.",
 )
+@traced_command("workspace.init")
 def workspace_init(
     platform: Optional[str],
     artifacts_path: Optional[str],
@@ -3181,6 +3183,7 @@ def notebook_push(
     is_flag=True,
     help="Do not fail if the selected settings file cannot be found.",
 )
+@traced_command("workspace.deploy")
 def workspace_deploy(
     platform: Optional[str],
     config_path: Path,
@@ -3552,6 +3555,7 @@ def app_package(
     help="Target environment overlay to include.",
 )
 @click.option("--json", "json_output", is_flag=True, help="Emit machine-readable JSON.")
+@traced_command("app.deploy")
 def app_deploy(
     app_name: str,
     local_folder: Optional[Path],
@@ -3917,6 +3921,7 @@ def _run_standalone_app(
         "locally. By default, locally installed packages are used without contacting the lake."
     ),
 )
+@traced_command("app.run")
 def app_run(
     app: str,
     app_name: Optional[str],
@@ -5977,6 +5982,7 @@ def package_init(
     help="Base path within container (overrides AZURE_BASE_PATH env var).",
 )
 @click.option("--json", "json_output", is_flag=True, help="Emit machine-readable JSON.")
+@traced_command("package.deploy")
 def package_deploy(
     package_name: str,
     local_folder: Optional[Path],
@@ -6227,6 +6233,7 @@ def runtime_group() -> None:
         "scripts are skipped if already present."
     ),
 )
+@traced_command("runtime.deploy")
 def runtime_deploy(
     source: str,
     dest: str,

--- a/tests/integration/test_data_pipes_integration.py
+++ b/tests/integration/test_data_pipes_integration.py
@@ -10,9 +10,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from pyspark.sql import DataFrame, SparkSession
-from pyspark.sql.types import IntegerType, StringType, StructField, StructType
-
 from kindling.data_entities import (
     DataEntities,
     DataEntityManager,
@@ -26,6 +23,8 @@ from kindling.data_pipes import (
     EntityReadPersistStrategy,
     PipeMetadata,
 )
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
 
 @pytest.fixture(scope="module")
@@ -652,16 +651,19 @@ class TestTraceIntegration:
         # Verify trace spans were created
         assert mock_trace_provider.span.call_count >= 2, "Should create at least 2 spans"
 
-        # Verify outer span for overall execution
+        # Verify outer span for overall execution (kindling.<area> convention)
         first_call = mock_trace_provider.span.call_args_list[0]
-        assert first_call[1]["component"] == "data_pipes_executer"
-        assert first_call[1]["operation"] == "execute_datapipes"
+        assert first_call[1]["component"] == "kindling.pipes"
+        assert first_call[1]["operation"] == "run"
+        assert first_call[1]["details"]["pipe_count"] == 1
 
-        # Verify inner span for specific pipe
+        # Verify inner span for specific pipe: ids are whitelisted
+        # attributes, and pipe.tags are never exported wholesale.
         second_call = mock_trace_provider.span.call_args_list[1]
-        assert second_call[1]["operation"] == "execute_datapipe"
-        assert second_call[1]["component"] == "pipe-test_pipe"
-        assert second_call[1]["details"] == {"env": "test"}
+        assert second_call[1]["operation"] == "pipe.run"
+        assert second_call[1]["component"] == "kindling.pipes"
+        assert second_call[1]["details"]["pipe_id"] == "test_pipe"
+        assert "env" not in second_call[1]["details"]
 
 
 class TestComplexTransformations:

--- a/tests/integration/test_tracing_tree.py
+++ b/tests/integration/test_tracing_tree.py
@@ -1,0 +1,346 @@
+"""End-to-end span-tree assertions for gh#210 comprehensive tracing.
+
+Drives real pipe runs through DataPipesExecuter + SimpleReadPersistStrategy
+with a RecordingTraceProvider and asserts the acceptance tree:
+
+    run → pipe.run → read×N / persist → provider-op children
+
+plus, in the delta variant, watermark read/save spans from the
+WatermarkAspect flow (the local reproduction of cloud pipe behavior).
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from kindling.data_entities import (
+    DataEntityManager,
+    EntityNameMapper,
+    EntityPathLocator,
+)
+from kindling.data_pipes import DataPipesExecuter, DataPipesManager
+from kindling.entity_provider import BaseEntityProvider, WritableEntityProvider
+from kindling.signaling import BlinkerSignalProvider
+from kindling.simple_read_persist_strategy import SimpleReadPersistStrategy
+from kindling.spark_config import ConfigService
+from kindling.spark_log_provider import PythonLoggerProvider
+from kindling.test_framework import RecordingTraceProvider
+from kindling.trace_ops import wrap_provider_ops
+from pyspark.sql import SparkSession
+from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+
+SOURCE_SCHEMA = StructType(
+    [
+        StructField("id", IntegerType(), False),
+        StructField("label", StringType(), True),
+    ]
+)
+
+
+@pytest.fixture
+def mock_logger_provider():
+    provider = MagicMock(spec=PythonLoggerProvider)
+    provider.get_logger.return_value = MagicMock()
+    return provider
+
+
+def _register_entities(registry, *entityids):
+    for entityid in entityids:
+        registry.register_entity(
+            entityid,
+            name=entityid.split(".")[-1],
+            partition_columns=[],
+            merge_columns=["id"],
+            tags={"provider_type": "delta"},
+            schema=SOURCE_SCHEMA,
+        )
+
+
+def _child_ops(span):
+    return [(child.component, child.operation) for child in span.children]
+
+
+class _InMemoryBatchProvider(BaseEntityProvider, WritableEntityProvider):
+    """Minimal real provider: serves and stores DataFrames in a dict."""
+
+    def __init__(self, data):
+        self.data = data
+        self.written = {}
+
+    def read_entity(self, entity_metadata):
+        return self.data[entity_metadata.entityid]
+
+    def check_entity_exists(self, entity_metadata):
+        return False
+
+    def write_to_entity(self, df, entity_metadata):
+        self.written[entity_metadata.entityid] = df
+        df.count()
+
+    def append_to_entity(self, df, entity_metadata):
+        self.written[entity_metadata.entityid] = df
+
+
+class TestPipeRunSpanTree:
+    """Acceptance: standalone run_datapipes yields run → pipe → read → persist."""
+
+    @pytest.fixture(scope="class")
+    def spark(self):
+        spark = (
+            SparkSession.builder.appName("TracingTreeTest")
+            .master("local[2]")
+            .config("spark.sql.shuffle.partitions", "2")
+            .getOrCreate()
+        )
+        yield spark
+
+    def test_run_datapipes_produces_expected_tree(self, spark, mock_logger_provider):
+        tp = RecordingTraceProvider()
+
+        entity_registry = DataEntityManager()
+        _register_entities(entity_registry, "bronze.readings", "silver.readings")
+
+        source_df = spark.createDataFrame([(1, "A"), (2, "B")], SOURCE_SCHEMA)
+        provider = _InMemoryBatchProvider({"bronze.readings": source_df})
+        wrap_provider_ops(provider, tp, provider_type="memory")
+
+        provider_registry = Mock()
+        provider_registry.get_provider_for_entity.return_value = provider
+
+        strategy = SimpleReadPersistStrategy(
+            ep=provider,
+            der=entity_registry,
+            tp=tp,
+            lp=mock_logger_provider,
+            provider_registry=provider_registry,
+            signal_provider=None,
+        )
+
+        pipes_registry = DataPipesManager(mock_logger_provider)
+        pipes_registry.register_pipe(
+            "pipe.readings",
+            name="readings",
+            execute=lambda bronze_readings: bronze_readings,
+            tags={},
+            input_entity_ids=["bronze.readings"],
+            output_entity_id="silver.readings",
+            output_type="delta",
+        )
+
+        executer = DataPipesExecuter(
+            lp=mock_logger_provider,
+            dpe=entity_registry,
+            dpr=pipes_registry,
+            erps=strategy,
+            tp=tp,
+            signal_provider=None,
+        )
+
+        with patch("kindling.simple_read_persist_strategy._is_local_execution", return_value=False):
+            executer.run_datapipes(["pipe.readings"])
+
+        roots = tp.tree()
+        assert len(roots) == 1, f"Expected one root, got {[r.operation for r in roots]}"
+        run_span = roots[0]
+        assert (run_span.component, run_span.operation) == ("kindling.pipes", "run")
+
+        assert _child_ops(run_span) == [("kindling.pipes", "pipe.run")]
+        pipe_span = run_span.children[0]
+        assert pipe_span.details["pipe_id"] == "pipe.readings"
+
+        pipe_children = _child_ops(pipe_span)
+        assert ("kindling.pipes", "read") in pipe_children
+        assert ("kindling.pipes", "persist") in pipe_children
+
+        read_span = next(c for c in pipe_span.children if c.operation == "read")
+        assert _child_ops(read_span) == [("kindling.entity.memory", "read_entity")]
+        assert read_span.details["resolved"] is False
+
+        persist_span = next(c for c in pipe_span.children if c.operation == "persist")
+        assert ("kindling.entity.memory", "write_to_entity") in _child_ops(persist_span)
+
+        assert "silver.readings" in provider.written
+        assert all(span.closed for span in tp.spans), "Every span must be closed"
+
+
+def _teardown_existing_spark_jvm():
+    """See test_watermark_incremental_correctness: the Delta jars are only
+    honored at JVM launch, so any prior plain session must be torn down."""
+    from pyspark import SparkContext
+
+    active = SparkSession.getActiveSession()
+    if active is not None:
+        active.stop()
+    if SparkContext._gateway is not None:
+        try:
+            SparkContext._gateway.shutdown()
+        except Exception:
+            pass
+        SparkContext._gateway = None
+        SparkContext._jvm = None
+
+
+class TestDeltaWatermarkedSpanTree:
+    """Delta variant: provider-op child spans plus the watermark save span."""
+
+    @pytest.fixture(scope="class")
+    def spark(self):
+        from delta import configure_spark_with_delta_pip
+
+        _teardown_existing_spark_jvm()
+        builder = (
+            SparkSession.builder.appName("TracingTreeDeltaTest")
+            .master("local[2]")
+            .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+            .config(
+                "spark.sql.catalog.spark_catalog",
+                "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+            )
+            .config("spark.databricks.delta.properties.defaults.enableChangeDataFeed", "true")
+            .config("spark.sql.shuffle.partitions", "2")
+            .config("spark.ui.enabled", "false")
+        )
+        spark = configure_spark_with_delta_pip(builder).getOrCreate()
+        spark.sparkContext.setLogLevel("ERROR")
+        yield spark
+        spark.stop()
+
+    @pytest.fixture
+    def temp_dir(self):
+        temp_path = tempfile.mkdtemp(prefix="kindling-tracing-tree-")
+        yield Path(temp_path)
+        shutil.rmtree(temp_path, ignore_errors=True)
+
+    @pytest.fixture
+    def delta_provider(self, spark, temp_dir, mock_logger_provider, monkeypatch):
+        from kindling.entity_provider_delta import DeltaEntityProvider
+
+        monkeypatch.setattr(
+            "kindling.entity_provider_delta.get_or_create_spark_session", lambda: spark
+        )
+        config = MagicMock(spec=ConfigService)
+        config.get.side_effect = lambda key, default=None: (
+            "storage" if key == "kindling.delta.access_mode" else default
+        )
+        name_mapper = MagicMock(spec=EntityNameMapper)
+        name_mapper.get_table_name.side_effect = lambda entity: entity.entityid.replace(".", "_")
+        path_locator = MagicMock(spec=EntityPathLocator)
+        path_locator.get_table_path.side_effect = lambda entity: str(
+            Path(str(temp_dir)) / entity.entityid
+        )
+        return DeltaEntityProvider(
+            config=config,
+            entity_name_mapper=name_mapper,
+            path_locator=path_locator,
+            tp=mock_logger_provider,
+            signal_provider=None,
+        )
+
+    def test_watermarked_delta_run_spans_provider_ops_and_watermark_save(
+        self, spark, delta_provider, mock_logger_provider, monkeypatch
+    ):
+        from kindling.watermarking import (
+            SimpleWatermarkEntityFinder,
+            WatermarkAspect,
+            WatermarkManager,
+        )
+
+        monkeypatch.setattr("kindling.watermarking.get_or_create_spark_session", lambda: spark)
+
+        tp = RecordingTraceProvider()
+        wrap_provider_ops(delta_provider, tp, provider_type="delta")
+
+        entity_registry = DataEntityManager()
+        _register_entities(entity_registry, "bronze.tracing_src", "silver.tracing_out")
+
+        provider_registry = Mock()
+        provider_registry.get_provider_for_entity.return_value = delta_provider
+
+        watermark_manager = WatermarkManager(
+            ep=delta_provider,
+            wef=SimpleWatermarkEntityFinder(),
+            lp=mock_logger_provider,
+            signal_provider=None,
+            provider_registry=provider_registry,
+            tp=tp,
+        )
+
+        signal_provider = BlinkerSignalProvider()
+        strategy = SimpleReadPersistStrategy(
+            ep=delta_provider,
+            der=entity_registry,
+            tp=tp,
+            lp=mock_logger_provider,
+            provider_registry=provider_registry,
+            signal_provider=signal_provider,
+        )
+        aspect = WatermarkAspect(
+            wms=watermark_manager,
+            lp=mock_logger_provider,
+            signal_provider=signal_provider,
+        )
+        aspect.register()
+
+        pipes_registry = DataPipesManager(mock_logger_provider)
+        pipes_registry.register_pipe(
+            "pipe.tracing",
+            name="tracing",
+            execute=lambda bronze_tracing_src: bronze_tracing_src,
+            tags={},
+            input_entity_ids=["bronze.tracing_src"],
+            output_entity_id="silver.tracing_out",
+            output_type="delta",
+            use_watermark=True,
+        )
+
+        executer = DataPipesExecuter(
+            lp=mock_logger_provider,
+            dpe=entity_registry,
+            dpr=pipes_registry,
+            erps=strategy,
+            tp=tp,
+            signal_provider=signal_provider,
+        )
+
+        # Seed the source table with one commit.
+        source_def = entity_registry.get_entity_definition("bronze.tracing_src")
+        delta_provider.write_to_entity(
+            spark.createDataFrame([(1, "A"), (2, "B")], SOURCE_SCHEMA), source_def
+        )
+        tp.spans.clear()  # only the pipe run's spans matter below
+
+        with patch("kindling.simple_read_persist_strategy._is_local_execution", return_value=False):
+            executer.run_datapipes(["pipe.tracing"])
+
+        run_span = next(s for s in tp.tree() if s.operation == "run")
+        pipe_span = run_span.children[0]
+        assert pipe_span.operation == "pipe.run"
+
+        read_span = next(c for c in pipe_span.children if c.operation == "read")
+        assert read_span.details["resolved"] is True, "WatermarkAspect owned the read"
+        read_ops = _child_ops(read_span)
+        assert ("kindling.watermark", "read_changes") in read_ops
+
+        read_changes_span = next(c for c in read_span.children if c.operation == "read_changes")
+        nested_ops = _child_ops(read_changes_span)
+        assert ("kindling.watermark", "get_cursor") in nested_ops
+
+        persist_span = next(c for c in pipe_span.children if c.operation == "persist")
+        persist_ops = _child_ops(persist_span)
+        assert ("kindling.entity.delta", "write_to_entity") in persist_ops
+        assert (
+            "kindling.watermark",
+            "save_cursor",
+        ) in persist_ops, "Watermark save must appear under the persist span"
+
+        save_span = next(c for c in persist_span.children if c.operation == "save_cursor")
+        assert ("kindling.entity.delta", "merge_to_entity") in _child_ops(save_span)
+
+        out_path = delta_provider.read_entity(
+            entity_registry.get_entity_definition("silver.tracing_out")
+        )
+        assert out_path.count() == 2
+        assert all(span.closed for span in tp.spans)

--- a/tests/unit/test_bootstrap_tracing.py
+++ b/tests/unit/test_bootstrap_tracing.py
@@ -1,0 +1,158 @@
+"""Bootstrap span-tree tests for gh#210 Phase 3.
+
+The bootstrap phases predate a usable trace provider, so timings are
+recorded by _BootstrapPhaseRecorder and retro-flushed as one span tree
+(root kindling.bootstrap/initialize + one record_span child per phase).
+"""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import kindling.bootstrap as bootstrap_module
+import pytest
+from kindling.bootstrap import _bootstrap_phase, _flush_bootstrap_trace
+from kindling.injection import GlobalInjector
+from kindling.test_framework import RecordingTraceProvider
+
+
+class _Config:
+    def __init__(self, values=None):
+        self.values = values or {}
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_recorder():
+    from datetime import datetime
+
+    bootstrap_module._PHASE_RECORDER.reset(start_time=datetime.now())
+    yield
+    bootstrap_module._PHASE_RECORDER.phases = []
+    bootstrap_module._PHASE_RECORDER.start_time = None
+
+
+def _flush_into(config=None, error=None):
+    tp = RecordingTraceProvider()
+    with patch.object(GlobalInjector, "get", return_value=tp):
+        _flush_bootstrap_trace(config or _Config(), error=error)
+    return tp
+
+
+class TestBootstrapPhaseRecorder:
+    def test_phases_record_name_and_window(self):
+        with _bootstrap_phase("config_download"):
+            time.sleep(0.01)
+        with _bootstrap_phase("platform_init"):
+            pass
+
+        phases = bootstrap_module._PHASE_RECORDER.phases
+        assert [p["name"] for p in phases] == ["config_download", "platform_init"]
+        assert all(p["start"] is not None and p["end"] is not None for p in phases)
+        assert phases[0]["end"] >= phases[0]["start"]
+        assert all(p["error"] is None for p in phases)
+
+    def test_phase_error_recorded_and_reraised(self):
+        with pytest.raises(RuntimeError, match="download exploded"):
+            with _bootstrap_phase("config_download"):
+                raise RuntimeError("download exploded")
+
+        entry = bootstrap_module._PHASE_RECORDER.phases[0]
+        assert entry["error"] == "download exploded"
+        assert entry["end"] is not None
+
+
+class TestFlushBootstrapTrace:
+    def test_flush_yields_root_plus_phase_children(self):
+        with _bootstrap_phase("config_download"):
+            pass
+        with _bootstrap_phase("platform_init"):
+            pass
+
+        tp = _flush_into()
+
+        roots = tp.tree()
+        assert len(roots) == 1
+        root = roots[0]
+        assert root.component == "kindling.bootstrap"
+        assert root.operation == "initialize"
+        assert root.details["phase_count"] == 2
+        assert "error" not in root.details
+        assert [child.operation for child in root.children] == [
+            "config_download",
+            "platform_init",
+        ]
+        assert all(child.component == "kindling.bootstrap" for child in root.children)
+
+    def test_flush_honors_recorded_timestamps(self):
+        with _bootstrap_phase("dependency_install"):
+            time.sleep(0.01)
+        entry = bootstrap_module._PHASE_RECORDER.phases[0]
+
+        tp = _flush_into()
+
+        child = tp.find(operation="dependency_install")[0]
+        assert child.start_time == entry["start"]
+        assert child.end_time == entry["end"]
+
+    def test_flush_error_path_marks_failing_phase_and_root(self):
+        with _bootstrap_phase("config_overlay"):
+            pass
+        with pytest.raises(RuntimeError):
+            with _bootstrap_phase("workspace_packages"):
+                raise RuntimeError("load failed")
+
+        tp = _flush_into(error="load failed")
+
+        root = tp.tree()[0]
+        assert root.details["error"] == "load failed"
+        failing = tp.find(operation="workspace_packages")[0]
+        assert failing.error == "load failed"
+        healthy = tp.find(operation="config_overlay")[0]
+        assert healthy.error is None
+
+    def test_flush_disabled_by_config(self):
+        with _bootstrap_phase("config_download"):
+            pass
+
+        tp = _flush_into(config=_Config({"kindling.telemetry.tracing.enabled": "false"}))
+
+        assert tp.spans == []
+
+    def test_flush_is_one_shot(self):
+        with _bootstrap_phase("config_download"):
+            pass
+
+        first = _flush_into()
+        second = _flush_into()
+
+        assert len(first.spans) == 2  # root + one phase
+        assert second.spans == [], "A second flush must not re-emit the tree"
+
+    def test_flush_with_no_recorded_phases_is_noop(self):
+        tp = _flush_into()
+        assert tp.spans == []
+
+    def test_flush_never_breaks_bootstrap(self):
+        with _bootstrap_phase("config_download"):
+            pass
+
+        with patch.object(GlobalInjector, "get", side_effect=RuntimeError("no provider")):
+            _flush_bootstrap_trace(_Config())  # must not raise
+
+
+class TestShortCircuitedReinit:
+    def test_short_circuited_reinit_records_nothing(self):
+        bootstrap_module._PHASE_RECORDER.phases = []
+        bootstrap_module._PHASE_RECORDER.start_time = None
+
+        with patch.object(bootstrap_module, "is_framework_initialized", return_value=True):
+            with patch.object(bootstrap_module, "get_kindling_service", MagicMock()):
+                with patch.object(bootstrap_module, "_import_local_package_registrations"):
+                    with patch.object(bootstrap_module, "_flush_bootstrap_trace") as flush:
+                        bootstrap_module.initialize_framework({})
+
+        assert bootstrap_module._PHASE_RECORDER.phases == []
+        assert bootstrap_module._PHASE_RECORDER.start_time is None
+        flush.assert_not_called()

--- a/tests/unit/test_cli_tracing.py
+++ b/tests/unit/test_cli_tracing.py
@@ -1,0 +1,112 @@
+"""Design-time CLI tracing tests (gh#210 Phase 4)."""
+
+from contextlib import nullcontext
+from unittest.mock import patch
+
+import kindling_cli._tracing as cli_tracing
+import pytest
+from kindling_cli._tracing import cli_span, cli_tracing_enabled, traced_command
+
+
+@pytest.fixture(autouse=True)
+def _reset_provider(monkeypatch):
+    monkeypatch.delenv("KINDLING_TRACE", raising=False)
+    monkeypatch.delenv("KINDLING_KINDLING__TELEMETRY__TRACING__PRINT", raising=False)
+    cli_tracing._provider = None
+    yield
+    cli_tracing._provider = None
+
+
+class TestCliSpanGating:
+    def test_disabled_without_env(self):
+        assert cli_tracing_enabled() is False
+        assert isinstance(cli_span("app.deploy"), nullcontext)
+
+    def test_enabled_by_env_flag(self, monkeypatch):
+        monkeypatch.setenv("KINDLING_TRACE", "1")
+        assert cli_tracing_enabled() is True
+
+    def test_span_emits_through_plain_provider(self, monkeypatch):
+        monkeypatch.setenv("KINDLING_TRACE", "true")
+
+        with cli_span("app.deploy", {"app_name": "demo"}):
+            provider = cli_tracing._provider
+            assert provider is not None
+            assert provider.current_span.component == "kindling.cli"
+            assert provider.current_span.operation == "app.deploy"
+            assert provider.current_span.attributes["app_name"] == "demo"
+
+        assert provider.current_span is None
+
+    def test_print_env_is_honored(self, monkeypatch):
+        monkeypatch.setenv("KINDLING_TRACE", "1")
+        monkeypatch.setenv("KINDLING_KINDLING__TELEMETRY__TRACING__PRINT", "true")
+
+        with patch("builtins.print") as mock_print:
+            with cli_span("package.deploy"):
+                pass
+
+        printed = [c[0][0] for c in mock_print.call_args_list]
+        assert any("package.deploy_START" in line for line in printed)
+        assert any("package.deploy_END" in line for line in printed)
+
+    def test_provider_failure_degrades_to_noop(self, monkeypatch):
+        monkeypatch.setenv("KINDLING_TRACE", "1")
+
+        with patch.object(cli_tracing, "_get_provider", side_effect=ImportError("no core")):
+            cm = cli_span("app.deploy")
+
+        assert isinstance(cm, nullcontext)
+
+
+class TestTracedCommand:
+    def test_wraps_callback_and_whitelists_kwargs(self, monkeypatch):
+        monkeypatch.setenv("KINDLING_TRACE", "1")
+        seen = {}
+
+        @traced_command("app.run")
+        def command(app_name, secret_token, wait):
+            provider = cli_tracing._provider
+            seen["operation"] = provider.current_span.operation
+            seen["attrs"] = dict(provider.current_span.attributes)
+            return "ran"
+
+        result = command(app_name="demo", secret_token="hunter2", wait=True)
+
+        assert result == "ran"
+        assert seen["operation"] == "app.run"
+        assert seen["attrs"] == {"app_name": "demo"}, "Only whitelisted kwargs become attrs"
+
+    def test_untraced_invocation_passes_through(self):
+        @traced_command("app.run")
+        def command(app_name):
+            return f"ran {app_name}"
+
+        assert command(app_name="demo") == "ran demo"
+        assert cli_tracing._provider is None, "Provider must stay unbuilt when disabled"
+
+    def test_errors_propagate_when_traced(self, monkeypatch):
+        monkeypatch.setenv("KINDLING_TRACE", "1")
+
+        @traced_command("app.deploy")
+        def command():
+            raise ValueError("deploy failed")
+
+        with pytest.raises(ValueError, match="deploy failed"):
+            command()
+
+
+class TestCliCommandsAreDecorated:
+    def test_deploy_and_run_commands_carry_span_wrappers(self):
+        from kindling_cli import cli as cli_module
+
+        for group, name in [
+            ("workspace", "init"),
+            ("workspace", "deploy"),
+            ("app", "deploy"),
+            ("app", "run"),
+            ("package", "deploy"),
+            ("runtime", "deploy"),
+        ]:
+            command = cli_module.cli.commands[group].commands[name]
+            assert command.callback.__wrapped__ is not None, f"{group} {name} must be traced"

--- a/tests/unit/test_data_pipes.py
+++ b/tests/unit/test_data_pipes.py
@@ -8,7 +8,6 @@ from typing import Callable, Dict, List
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
-
 from kindling.data_entities import KindlingNotInitializedError
 from kindling.data_pipes import (
     DataPipes,
@@ -618,6 +617,35 @@ class TestDataPipesExecuter:
 
         # Verify trace spans were created
         assert self.mock_trace_provider.span.call_count >= 2
+
+    def test_run_datapipes_disabled_tracing_emits_no_spans(self):
+        """kindling.telemetry.tracing.enabled=false suppresses run/pipe.run spans."""
+        config = Mock()
+        config.get.side_effect = lambda key, default=None: (
+            "false" if key == "kindling.telemetry.tracing.enabled" else default
+        )
+        executer = DataPipesExecuter(
+            self.mock_logger_provider,
+            self.mock_entity_registry,
+            self.mock_pipes_registry,
+            self.mock_erps,
+            self.mock_trace_provider,
+            config=config,
+        )
+
+        mock_pipe = Mock(spec=PipeMetadata)
+        mock_pipe.pipeid = "test_pipe"
+        mock_pipe.name = "Test Pipe"
+        mock_pipe.tags = {"env": "test"}
+        mock_pipe.input_entity_ids = ["entity1"]
+        mock_pipe.execute = Mock(return_value=Mock())
+        self.mock_pipes_registry.get_pipe_definition.return_value = mock_pipe
+        self.mock_erps.create_pipe_entity_reader.return_value = Mock(return_value=Mock())
+        self.mock_erps.create_pipe_persist_activator.return_value = Mock()
+
+        executer.run_datapipes(["test_pipe"])
+
+        self.mock_trace_provider.span.assert_not_called()
 
     def test_run_datapipes_multiple_pipes(self):
         """Test running multiple data pipes"""

--- a/tests/unit/test_delta_stream_merge.py
+++ b/tests/unit/test_delta_stream_merge.py
@@ -129,8 +129,13 @@ class TestDeltaMergeAsStream:
     def test_each_micro_batch_runs_batch_merge(self, provider, monkeypatch):
         entity = self._make_entity()
         merge_calls = []
+        # Patch the class, not the instance: _merge_batch calls
+        # type(self).merge_to_entity(self, ...) so per-instance tracing
+        # wrappers (trace_ops) never span the micro-batch hot loop.
         monkeypatch.setattr(
-            provider, "merge_to_entity", lambda df, ent: merge_calls.append((df, ent))
+            type(provider),
+            "merge_to_entity",
+            lambda self, df, ent: merge_calls.append((df, ent)),
         )
         df = MagicMock()
         writer = df.writeStream.outputMode.return_value.option.return_value

--- a/tests/unit/test_entity_fixture_convention.py
+++ b/tests/unit/test_entity_fixture_convention.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from kindling.data_entities import EntityMetadata
 from kindling.entity_provider_csv import (
     FixtureCSVEntityProvider,
@@ -207,6 +206,8 @@ class TestCreatePipeEntityReaderFixtureConvention:
         provider_registry = MagicMock()
         signal_provider = MagicMock()
 
+        from kindling.trace_ops import tracing_gates
+
         strategy = SimpleReadPersistStrategy.__new__(SimpleReadPersistStrategy)
         strategy.wms = wms
         strategy.ep = ep
@@ -216,6 +217,7 @@ class TestCreatePipeEntityReaderFixtureConvention:
         strategy.provider_registry = provider_registry
         strategy._signal_provider = signal_provider
         strategy._listeners = {}
+        strategy._trace_gates = tracing_gates(None)
         return strategy
 
     def test_fixture_csv_used_when_present_and_local(self, tmp_path):

--- a/tests/unit/test_file_ingestion.py
+++ b/tests/unit/test_file_ingestion.py
@@ -207,3 +207,23 @@ def test_entry_decorator_omitting_static_values_stores_none():
 
     entry = mgr.get_entry_definition("e2")
     assert entry.static_values is None
+
+
+def test_process_path_disabled_tracing_emits_no_spans():
+    """kindling.telemetry.tracing.enabled=false suppresses the process span."""
+    from kindling.file_ingestion import ParallelizingFileIngestionProcessor
+    from kindling.trace_ops import TracingGates
+
+    proc = object.__new__(ParallelizingFileIngestionProcessor)
+    proc.logger = MagicMock()
+    proc.tp = MagicMock()
+    proc._trace_gates = TracingGates(False, "standard")
+    proc.emit = MagicMock()
+    proc.config = MagicMock()
+    proc.config.get.return_value = 3
+    proc.env = MagicMock()
+    proc.env.list.return_value = []
+
+    proc.process_path("/data")
+
+    proc.tp.span.assert_not_called()

--- a/tests/unit/test_job_deployment.py
+++ b/tests/unit/test_job_deployment.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, Mock
 
 import pytest
+from kindling.trace_ops import tracing_gates
 
 
 class TestDataAppDeployer:
@@ -33,6 +34,8 @@ class TestDataAppDeployer:
         deployer = DataAppDeployer.__new__(DataAppDeployer)
         deployer.platform = mock_platform
         deployer.logger = mock_logger
+        deployer.tp = None
+        deployer._trace_gates = tracing_gates(None)
 
         # Initialize utilities
         deployer.packager = AppPackager()
@@ -70,6 +73,8 @@ class TestDataAppDeployer:
             deployer = DataAppDeployer.__new__(DataAppDeployer)
             deployer.platform = mock_platform
             deployer.logger = mock_logger
+            deployer.tp = None
+            deployer._trace_gates = tracing_gates(None)
             deployer.packager = AppPackager()
             deployer.validator = JobConfigValidator()
 
@@ -110,6 +115,8 @@ class TestDataAppDeployer:
             deployer = DataAppDeployer.__new__(DataAppDeployer)
             deployer.platform = mock_platform
             deployer.logger = Mock()
+            deployer.tp = None
+            deployer._trace_gates = tracing_gates(None)
             deployer.packager = AppPackager()
             deployer.validator = JobConfigValidator()
 
@@ -135,6 +142,8 @@ class TestDataAppDeployer:
         deployer = DataAppDeployer.__new__(DataAppDeployer)
         deployer.platform = mock_platform
         deployer.logger = mock_logger
+        deployer.tp = None
+        deployer._trace_gates = tracing_gates(None)
         deployer.validator = JobConfigValidator()
 
         result = deployer.create_job({"job_name": "test-job", "app_name": "my-app"})
@@ -168,6 +177,8 @@ class TestDataAppDeployer:
             deployer = DataAppDeployer.__new__(DataAppDeployer)
             deployer.platform = mock_platform
             deployer.logger = mock_logger
+            deployer.tp = None
+            deployer._trace_gates = tracing_gates(None)
             deployer.packager = AppPackager()
             deployer.validator = JobConfigValidator()
 
@@ -208,6 +219,8 @@ class TestDataAppDeployer:
         deployer = DataAppDeployer.__new__(DataAppDeployer)
         deployer.platform = mock_platform
         deployer.logger = mock_logger
+        deployer.tp = None
+        deployer._trace_gates = tracing_gates(None)
 
         # Run job
         run_id = deployer.run_job("job-123", {"param1": "value1"})
@@ -250,6 +263,8 @@ class TestDataAppDeployer:
         deployer = DataAppDeployer.__new__(DataAppDeployer)
         deployer.platform = mock_platform
         deployer.logger = mock_logger
+        deployer.tp = None
+        deployer._trace_gates = tracing_gates(None)
 
         # Cancel job
         result = deployer.cancel_job("run-123")
@@ -270,6 +285,8 @@ class TestDataAppDeployer:
         deployer = DataAppDeployer.__new__(DataAppDeployer)
         deployer.platform = mock_platform
         deployer.logger = mock_logger
+        deployer.tp = None
+        deployer._trace_gates = tracing_gates(None)
 
         result = deployer.cleanup_app("my-app")
 

--- a/tests/unit/test_otel_trace_provider.py
+++ b/tests/unit/test_otel_trace_provider.py
@@ -1,0 +1,155 @@
+"""Unit tests for AzureMonitorTraceProvider (kindling_ext_otel_azure).
+
+Skipped when the opentelemetry API is not importable (the extension's test
+environment installs it; the core unit environment may not).
+
+The extension package ``__init__`` force-rebinds the GlobalInjector telemetry
+providers at import time, which must not leak into the unit suite. The
+fixture below loads ``trace_provider`` as a package submodule without
+executing the package ``__init__``, and stubs ``azure.monitor.opentelemetry``
+when absent — only ``AzureMonitorConfig.initialize`` touches it, and these
+tests never call that.
+"""
+
+import importlib
+import sys
+import types
+import uuid
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+opentelemetry = pytest.importorskip("opentelemetry")
+from opentelemetry.trace import StatusCode  # noqa: E402
+
+EXTENSION_PACKAGE_ROOT = (
+    Path(__file__).resolve().parents[2] / "packages" / "extensions" / "kindling_ext_otel_azure"
+)
+
+_PACKAGE_NAME = "kindling_ext_otel_azure"
+
+
+@pytest.fixture(scope="module")
+def trace_provider_module():
+    """Import kindling_ext_otel_azure.trace_provider without package side effects."""
+    if "azure.monitor.opentelemetry" not in sys.modules:
+        try:
+            importlib.import_module("azure.monitor.opentelemetry")
+        except ImportError:
+            azure_pkg = sys.modules.setdefault("azure", types.ModuleType("azure"))
+            monitor_pkg = types.ModuleType("azure.monitor")
+            stub = types.ModuleType("azure.monitor.opentelemetry")
+            stub.configure_azure_monitor = lambda **kwargs: None
+            azure_pkg.monitor = monitor_pkg
+            monitor_pkg.opentelemetry = stub
+            sys.modules["azure.monitor"] = monitor_pkg
+            sys.modules["azure.monitor.opentelemetry"] = stub
+
+    if _PACKAGE_NAME not in sys.modules:
+        package_stub = types.ModuleType(_PACKAGE_NAME)
+        package_stub.__path__ = [str(EXTENSION_PACKAGE_ROOT / _PACKAGE_NAME)]
+        sys.modules[_PACKAGE_NAME] = package_stub
+
+    return importlib.import_module(f"{_PACKAGE_NAME}.trace_provider")
+
+
+class _Config:
+    def get(self, key, default=None):
+        return default
+
+
+def _provider(trace_provider_module, tracer=None):
+    provider = trace_provider_module.AzureMonitorTraceProvider.__new__(
+        trace_provider_module.AzureMonitorTraceProvider
+    )
+    provider.config = _Config()
+    provider._tracer = tracer
+    return provider
+
+
+def _fake_otel_span(trace_id=0):
+    span = MagicMock()
+    span.get_span_context.return_value = SimpleNamespace(trace_id=trace_id)
+    return span
+
+
+class TestStartSpan:
+    def test_start_span_without_tracer_returns_span_with_trace_id(self, trace_provider_module):
+        """Regression: SparkSpan construction previously omitted required traceId."""
+        provider = _provider(trace_provider_module, tracer=None)
+
+        span = provider.start_span(operation="op", component="comp")
+
+        assert span.id == "noop"
+        assert isinstance(span.traceId, uuid.UUID)
+
+    def test_start_span_adopts_otel_trace_id(self, trace_provider_module):
+        tracer = MagicMock()
+        otel_span = _fake_otel_span(trace_id=12345)
+        tracer.start_span.return_value = otel_span
+        provider = _provider(trace_provider_module, tracer=tracer)
+
+        span = provider.start_span(operation="op", component="comp", details={"k": "v"})
+
+        assert span.traceId == uuid.UUID(int=12345)
+        assert span._otel_span is otel_span
+        tracer.start_span.assert_called_once_with("comp.op")
+
+    def test_start_span_mints_trace_id_when_context_has_none(self, trace_provider_module):
+        tracer = MagicMock()
+        tracer.start_span.return_value = _fake_otel_span(trace_id=0)
+        provider = _provider(trace_provider_module, tracer=tracer)
+
+        span = provider.start_span(operation="op", component="comp")
+
+        assert isinstance(span.traceId, uuid.UUID)
+
+
+class TestRecordSpan:
+    def test_record_span_honors_given_timestamps(self, trace_provider_module):
+        tracer = MagicMock()
+        otel_span = _fake_otel_span()
+        tracer.start_span.return_value = otel_span
+        provider = _provider(trace_provider_module, tracer=tracer)
+        start = datetime(2026, 1, 1, 12, 0, 0)
+        end = datetime(2026, 1, 1, 12, 0, 2)
+
+        provider.record_span("phase", "kindling.bootstrap", start, end, details={"k": "v"})
+
+        tracer.start_span.assert_called_once_with(
+            "kindling.bootstrap.phase", start_time=int(start.timestamp() * 1_000_000_000)
+        )
+        otel_span.end.assert_called_once_with(end_time=int(end.timestamp() * 1_000_000_000))
+        otel_span.set_attribute.assert_any_call("k", "v")
+        status = otel_span.set_status.call_args[0][0]
+        assert status.status_code == StatusCode.OK
+
+    def test_record_span_with_error_sets_error_status(self, trace_provider_module):
+        tracer = MagicMock()
+        otel_span = _fake_otel_span()
+        tracer.start_span.return_value = otel_span
+        provider = _provider(trace_provider_module, tracer=tracer)
+        start = datetime(2026, 1, 1, 12, 0, 0)
+        end = datetime(2026, 1, 1, 12, 0, 1)
+
+        provider.record_span("phase", "kindling.bootstrap", start, end, error="boom")
+
+        status = otel_span.set_status.call_args[0][0]
+        assert status.status_code == StatusCode.ERROR
+        otel_span.add_event.assert_called_once_with(
+            "error", attributes={"exception.message": "boom"}
+        )
+        otel_span.end.assert_called_once()
+
+    def test_record_span_without_tracer_is_noop(self, trace_provider_module):
+        provider = _provider(trace_provider_module, tracer=None)
+
+        provider.record_span(
+            "phase",
+            "kindling.bootstrap",
+            datetime(2026, 1, 1),
+            datetime(2026, 1, 2),
+        )

--- a/tests/unit/test_plain_telemetry.py
+++ b/tests/unit/test_plain_telemetry.py
@@ -1,11 +1,13 @@
 """Unit tests for the JVM-free telemetry providers (kindling.plain_telemetry)."""
 
+import json
 import logging
+import re
 import uuid
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from kindling.plain_telemetry import (
     PlainPythonLogger,
     PlainPythonLoggerProvider,
@@ -182,3 +184,125 @@ class TestPlainPythonTraceProvider:
 
         standalone = trace.start_span(operation="Solo", component="Comp")
         assert isinstance(standalone.traceId, uuid.UUID)
+
+
+def _emitted(logger, event):
+    """Return (line, details) pairs for a given emitted event name."""
+    results = []
+    for c in logger.debug.call_args_list:
+        line = c[0][0]
+        if f"Op: {event} " not in line:
+            continue
+        match = re.search(r"Msg: (\{.*\}|None) Id:", line)
+        details = json.loads(match.group(1)) if match and match.group(1) != "None" else {}
+        results.append((line, details))
+    return results
+
+
+class TestPlainTraceParenting:
+    """Parent restore and parentSpanId emission (gh#210 Phase 0)."""
+
+    def test_parent_restored_after_nested_exit(self):
+        trace, _ = _trace_provider()
+
+        with trace.span(operation="Outer", component="Comp"):
+            outer_span = trace.current_span
+            with trace.span(operation="Inner", component="Comp"):
+                assert trace.current_span is not outer_span
+            assert trace.current_span is outer_span
+
+        assert trace.current_span is None
+
+    def test_consecutive_top_level_spans_get_distinct_trace_ids(self):
+        trace, _ = _trace_provider()
+
+        with trace.span(operation="Op1", component="Comp"):
+            first_trace_id = trace.current_span.traceId
+        with trace.span(operation="Op2", component="Comp"):
+            second_trace_id = trace.current_span.traceId
+
+        assert first_trace_id != second_trace_id
+
+    def test_child_events_carry_parent_span_id(self):
+        trace, logger = _trace_provider()
+
+        with trace.span(operation="Outer", component="Comp"):
+            outer_id = trace.current_span.id
+            with trace.span(operation="Inner", component="Comp"):
+                pass
+
+        for event in ("Inner_START", "Inner_END"):
+            emitted = _emitted(logger, event)
+            assert len(emitted) == 1
+            assert emitted[0][1].get("parentSpanId") == outer_id
+
+    def test_root_span_events_have_no_parent_span_id(self):
+        trace, logger = _trace_provider()
+
+        with trace.span(operation="Op", component="Comp"):
+            pass
+
+        for event in ("Op_START", "Op_END"):
+            emitted = _emitted(logger, event)
+            assert len(emitted) == 1
+            assert "parentSpanId" not in emitted[0][1]
+
+    def test_manual_span_events_carry_parent_span_id(self):
+        trace, logger = _trace_provider()
+
+        with trace.span(operation="Outer", component="Comp"):
+            outer_id = trace.current_span.id
+            manual = trace.start_span(operation="Inner", component="Comp")
+            assert manual.parent_id == outer_id
+            trace.end_span(manual)
+
+        for event in ("Inner_START", "Inner_END"):
+            emitted = _emitted(logger, event)
+            assert len(emitted) == 1
+            assert emitted[0][1].get("parentSpanId") == outer_id
+
+
+class TestPlainRecordSpan:
+    """record_span: retroactive spans with explicit timestamps (gh#210 Phase 0)."""
+
+    def test_record_span_honors_given_timestamps(self):
+        trace, logger = _trace_provider()
+        start = datetime(2026, 1, 1, 12, 0, 0)
+        end = datetime(2026, 1, 1, 12, 0, 2, 500000)
+
+        trace.record_span("phase", "kindling.bootstrap", start, end, details={"k": "v"})
+
+        start_emitted = _emitted(logger, "phase_START")
+        end_emitted = _emitted(logger, "phase_END")
+        assert len(start_emitted) == 1 and len(end_emitted) == 1
+        assert start_emitted[0][1]["startTime"] == "2026-01-01 12:00:00.000"
+        assert start_emitted[0][1]["k"] == "v"
+        assert end_emitted[0][1]["endTime"] == "2026-01-01 12:00:02.500"
+        assert end_emitted[0][1]["totalTime"] == "2.500"
+
+    def test_record_span_with_error_emits_error_event(self):
+        trace, logger = _trace_provider()
+        start = datetime(2026, 1, 1, 12, 0, 0)
+        end = datetime(2026, 1, 1, 12, 0, 1)
+
+        trace.record_span("phase", "kindling.bootstrap", start, end, error="boom")
+
+        error_emitted = _emitted(logger, "phase_ERROR")
+        assert len(error_emitted) == 1
+        assert error_emitted[0][1]["exception"] == "boom"
+        assert error_emitted[0][1]["errorTime"] == "2026-01-01 12:00:01.000"
+
+    def test_record_span_parents_to_current_span(self):
+        trace, logger = _trace_provider()
+        start = datetime(2026, 1, 1, 12, 0, 0)
+        end = datetime(2026, 1, 1, 12, 0, 1)
+
+        with trace.span(operation="Outer", component="Comp"):
+            outer_id = trace.current_span.id
+            expected_trace_id = str(trace.current_span.traceId)
+            trace.record_span("phase", "kindling.bootstrap", start, end)
+
+        for event in ("phase_START", "phase_END"):
+            line, details = _emitted(logger, event)[0]
+            assert details.get("parentSpanId") == outer_id
+            assert f"trace_id:{expected_trace_id}" in line

--- a/tests/unit/test_seam_tracing.py
+++ b/tests/unit/test_seam_tracing.py
@@ -1,0 +1,334 @@
+"""Structural-seam span tests for gh#210 Phase 2.
+
+Covers the persist reraise fix (data correctness), the consolidated
+kindling.pipes read/persist span shapes, watermark manager spans, migration
+service spans, and the config reload span — all asserted through
+RecordingTraceProvider.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from kindling.entity_provider import BaseEntityProvider, WritableEntityProvider
+from kindling.injection import GlobalInjector
+from kindling.simple_read_persist_strategy import SimpleReadPersistStrategy
+from kindling.test_framework import RecordingTraceProvider
+from kindling.trace_ops import COMPONENT_PIPES, TracingGates
+
+
+class _MergeWritableProvider(BaseEntityProvider, WritableEntityProvider):
+    """Spec class: batch-writable provider that also supports merge."""
+
+    def merge_to_entity(self, df, entity): ...
+
+
+def _make_strategy(dst_entity, out_provider, tp=None):
+    der = Mock()
+    src_entity = Mock(entityid="entity.src", tags={})
+    der.get_entity_definition.side_effect = lambda eid: {
+        "entity.src": src_entity,
+        "entity.dst": dst_entity,
+    }[eid]
+
+    provider_registry = Mock()
+    provider_registry.get_provider_for_entity.return_value = out_provider
+
+    lp = Mock()
+    lp.get_logger.return_value = Mock()
+
+    strategy = SimpleReadPersistStrategy(
+        ep=Mock(),
+        der=der,
+        tp=tp if tp is not None else RecordingTraceProvider(),
+        lp=lp,
+        provider_registry=provider_registry,
+        signal_provider=None,
+    )
+    pipe = Mock(
+        pipeid="pipe1",
+        input_entity_ids=["entity.src"],
+        output_entity_id="entity.dst",
+    )
+    return strategy, pipe
+
+
+def _spy_signals(strategy, resolve_read_result=None):
+    emitted = []
+
+    def _spy(signal_name, **kwargs):
+        emitted.append(signal_name)
+        if signal_name == "read.resolve_read" and resolve_read_result is not None:
+            return [("handler", resolve_read_result)]
+        return []
+
+    strategy.emit = _spy
+    return emitted
+
+
+class TestPersistReraiseFix:
+    """A failed merge must never look like a successful persist (gh#210)."""
+
+    def test_merge_failure_propagates_and_never_emits_after_persist(self):
+        dst_entity = Mock(entityid="entity.dst", tags={})
+        out_provider = Mock(spec=_MergeWritableProvider)
+        out_provider.check_entity_exists.return_value = True
+        out_provider.merge_to_entity.side_effect = RuntimeError("merge exploded")
+
+        tp = RecordingTraceProvider()
+        strategy, pipe = _make_strategy(dst_entity, out_provider, tp=tp)
+        emitted = _spy_signals(strategy)
+        persist = strategy.create_pipe_persist_activator(pipe)
+
+        with pytest.raises(RuntimeError, match="merge exploded"):
+            persist(Mock(name="df"))
+
+        assert "persist.before_persist" in emitted
+        assert "persist.persist_failed" in emitted
+        assert "persist.after_persist" not in emitted, (
+            "after_persist for unpersisted data advances the watermark past "
+            "rows that were never written"
+        )
+
+        span = tp.find(component=COMPONENT_PIPES, operation="persist")[0]
+        assert span.closed
+        assert "merge exploded" in span.error
+
+    def test_successful_persist_is_a_single_consolidated_span(self):
+        dst_entity = Mock(entityid="entity.dst", tags={})
+        out_provider = Mock(spec=_MergeWritableProvider)
+        out_provider.check_entity_exists.return_value = True
+
+        tp = RecordingTraceProvider()
+        strategy, pipe = _make_strategy(dst_entity, out_provider, tp=tp)
+        _spy_signals(strategy)
+        persist = strategy.create_pipe_persist_activator(pipe)
+
+        persist(Mock(name="df"))
+
+        persist_spans = tp.find(component=COMPONENT_PIPES, operation="persist")
+        assert len(persist_spans) == 1
+        assert persist_spans[0].details["pipe_id"] == "pipe1"
+        assert persist_spans[0].details["source_entity_id"] == "entity.src"
+        assert persist_spans[0].details["output_entity_id"] == "entity.dst"
+        assert "persist_id" in persist_spans[0].details
+
+        legacy = [s for s in tp.spans if s.component == "data_utils"]
+        assert legacy == [], "Inner data_utils spans were consolidated away"
+        out_provider.merge_to_entity.assert_called_once()
+
+    def test_persist_span_disabled_when_tracing_off(self):
+        dst_entity = Mock(entityid="entity.dst", tags={})
+        out_provider = Mock(spec=_MergeWritableProvider)
+        out_provider.check_entity_exists.return_value = True
+
+        tp = RecordingTraceProvider()
+        strategy, pipe = _make_strategy(dst_entity, out_provider, tp=tp)
+        strategy._trace_gates = TracingGates(enabled=False, level="standard")
+        _spy_signals(strategy)
+
+        strategy.create_pipe_persist_activator(pipe)(Mock(name="df"))
+
+        assert tp.spans == []
+        out_provider.merge_to_entity.assert_called_once()
+
+
+class TestReadSpan:
+    def test_resolved_read_marks_short_circuit(self):
+        dst_entity = Mock(entityid="entity.dst", tags={})
+        tp = RecordingTraceProvider()
+        strategy, pipe = _make_strategy(dst_entity, Mock(), tp=tp)
+        resolved = SimpleNamespace(df=Mock(name="resolved_df"))
+        _spy_signals(strategy, resolve_read_result=resolved)
+        reader = strategy.create_pipe_entity_reader(pipe)
+
+        entity = Mock(entityid="entity.src", tags={})
+        df = reader(entity, True)
+
+        assert df is resolved.df
+        span = tp.find(component=COMPONENT_PIPES, operation="read")[0]
+        assert span.details["entity_id"] == "entity.src"
+        assert span.details["pipe_id"] == "pipe1"
+        assert span.details["watermarked"] is True
+        assert span.details["resolved"] is True
+
+    def test_provider_fallback_read_is_spanned(self):
+        dst_entity = Mock(entityid="entity.dst", tags={})
+        out_provider = Mock()
+        out_provider.read_entity.return_value = Mock(name="df")
+        tp = RecordingTraceProvider()
+        strategy, pipe = _make_strategy(dst_entity, out_provider, tp=tp)
+        _spy_signals(strategy)
+        reader = strategy.create_pipe_entity_reader(pipe)
+
+        entity = Mock(entityid="entity.src", tags={})
+        with patch("kindling.simple_read_persist_strategy._is_local_execution", return_value=False):
+            reader(entity, False)
+
+        span = tp.find(component=COMPONENT_PIPES, operation="read")[0]
+        assert span.details["resolved"] is False
+        assert span.details["watermarked"] is False
+        out_provider.read_entity.assert_called_once_with(entity)
+
+    def test_read_failure_propagates_with_span_error(self):
+        dst_entity = Mock(entityid="entity.dst", tags={})
+        out_provider = Mock()
+        out_provider.read_entity.side_effect = ValueError("storage offline")
+        tp = RecordingTraceProvider()
+        strategy, pipe = _make_strategy(dst_entity, out_provider, tp=tp)
+        _spy_signals(strategy)
+        reader = strategy.create_pipe_entity_reader(pipe)
+
+        with patch("kindling.simple_read_persist_strategy._is_local_execution", return_value=False):
+            with pytest.raises(ValueError, match="storage offline"):
+                reader(Mock(entityid="entity.src", tags={}), False)
+
+        span = tp.find(component=COMPONENT_PIPES, operation="read")[0]
+        assert span.closed
+        assert "storage offline" in span.error
+
+
+class TestWatermarkSpans:
+    def _manager(self, tp):
+        from kindling.watermarking import WatermarkManager
+
+        lp = Mock()
+        lp.get_logger.return_value = Mock()
+        with patch("kindling.watermarking.get_or_create_spark_session", return_value=MagicMock()):
+            manager = WatermarkManager(
+                ep=Mock(),
+                wef=Mock(),
+                lp=lp,
+                signal_provider=None,
+                provider_registry=None,
+                tp=tp,
+                config=None,
+            )
+        return manager
+
+    def test_get_cursor_emits_span_with_ids(self):
+        tp = RecordingTraceProvider()
+        manager = self._manager(tp)
+        df = MagicMock()
+        df.isEmpty.return_value = True
+        manager.ep.read_entity.return_value.filter.return_value.limit.return_value = df
+
+        cursor = manager.get_cursor("entity.src", "pipe1")
+
+        assert cursor is None
+        span = tp.find(component="kindling.watermark", operation="get_cursor")[0]
+        assert span.details == {"source_entity_id": "entity.src", "reader_id": "pipe1"}
+        assert span.closed
+
+    def test_save_cursor_emits_span_with_cursor_attr(self):
+        tp = RecordingTraceProvider()
+        manager = self._manager(tp)
+
+        manager.save_cursor("entity.src", "pipe1", "42", "exec-1")
+
+        span = tp.find(component="kindling.watermark", operation="save_cursor")[0]
+        assert span.details["cursor"] == "42"
+        manager.ep.merge_to_entity.assert_called_once()
+
+    def test_save_cursor_failure_propagates_and_errors_span(self):
+        tp = RecordingTraceProvider()
+        manager = self._manager(tp)
+        manager.ep.merge_to_entity.side_effect = RuntimeError("merge failed")
+
+        with pytest.raises(RuntimeError, match="merge failed"):
+            manager.save_cursor("entity.src", "pipe1", "42", "exec-1")
+
+        span = tp.find(component="kindling.watermark", operation="save_cursor")[0]
+        assert span.closed
+        assert "merge failed" in span.error
+
+    def test_no_spans_when_tp_absent(self):
+        manager = self._manager(None)
+        df = MagicMock()
+        df.isEmpty.return_value = True
+        manager.ep.read_entity.return_value.filter.return_value.limit.return_value = df
+
+        assert manager.get_cursor("entity.src", "pipe1") is None
+
+
+class TestMigrationSpans:
+    def _service_with_tracing(self, tp):
+        import kindling.migration as migration_module
+
+        class _Config:
+            def get(self, key, default=None):
+                return default
+
+        class _Injector:
+            @staticmethod
+            def get(iface):
+                from kindling.spark_config import ConfigService
+                from kindling.spark_trace import SparkTraceProvider
+
+                if iface is ConfigService:
+                    return _Config()
+                if iface is SparkTraceProvider:
+                    return tp
+                raise AssertionError(f"unexpected resolution: {iface}")
+
+        service = migration_module.MigrationService(planner=Mock(), applier=Mock(), manager=Mock())
+        return service, patch.object(migration_module, "GlobalInjector", _Injector)
+
+    def test_plan_and_apply_emit_migration_spans(self):
+        from kindling.migration import BackupStrategy
+
+        tp = RecordingTraceProvider()
+        service, injector_patch = self._service_with_tracing(tp)
+        plan = Mock(statuses=[])
+        service._planner.plan.return_value = plan
+
+        with injector_patch:
+            service.plan()
+            service.apply(plan, allow_destructive=True, backup=BackupStrategy.SNAPSHOT)
+
+        plan_span = tp.find(component="kindling.migration", operation="plan")[0]
+        assert plan_span.details["entity_count"] == 0
+        apply_span = tp.find(component="kindling.migration", operation="apply")[0]
+        assert apply_span.details["allow_destructive"] is True
+        assert apply_span.details["backup"] == "snapshot"
+
+    def test_migration_spans_never_break_the_operation(self):
+        """GlobalInjector resolution failure must degrade to a no-op span."""
+        service = __import__("kindling.migration", fromlist=["MigrationService"]).MigrationService(
+            planner=Mock(), applier=Mock(), manager=Mock()
+        )
+        service._planner.plan.return_value = Mock(statuses=[])
+
+        with patch("kindling.migration.GlobalInjector") as broken:
+            broken.get.side_effect = RuntimeError("no injector")
+            plan = service.plan()
+
+        assert plan is not None
+
+
+class TestConfigReloadSpan:
+    @patch("kindling.spark_config.Dynaconf")
+    @patch("kindling.spark_config.get_or_create_spark_session")
+    def test_reload_emits_config_span(self, mock_spark_fn, mock_dynaconf_class):
+        from kindling.spark_config import DynaconfConfig
+        from kindling.trace_ops import TracingGates
+
+        mock_spark_fn.return_value = MagicMock()
+        mock_dynaconf = MagicMock()
+        mock_dynaconf.to_dict.return_value = {"test_value": "original"}
+        mock_dynaconf_class.return_value = mock_dynaconf
+
+        config = DynaconfConfig()
+        config.initialize(reload_context=None)
+
+        tp = RecordingTraceProvider()
+        with patch(
+            "kindling.trace_ops.tracing_gates",
+            return_value=TracingGates(enabled=True, level="standard"),
+        ):
+            with patch.object(GlobalInjector, "get", return_value=tp):
+                result = config.reload()
+
+        assert result["status"] == "success"
+        span = tp.find(component="kindling.config", operation="reload")[0]
+        assert span.closed

--- a/tests/unit/test_spark_trace.py
+++ b/tests/unit/test_spark_trace.py
@@ -1377,3 +1377,36 @@ class TestManualSpanLifecycle:
         span = trace.start_span(operation="TestOp", component="TestComp")
 
         assert isinstance(span.traceId, uuid.UUID)
+
+
+class TestSpanEmitterRobustness:
+    """A failing telemetry backend must never break caller control flow."""
+
+    def test_failing_end_emission_does_not_break_caller_or_span_stack(self, mock_emitter):
+        def emit(component, operation, *args, **kwargs):
+            if operation.endswith("_END"):
+                raise RuntimeError("telemetry backend down")
+
+        mock_emitter.emit_custom_event.side_effect = emit
+        trace = EventBasedSparkTrace(mock_emitter)
+
+        ran = False
+        with trace.span(operation="Op", component="Comp"):
+            ran = True
+
+        assert ran
+        assert trace.current_span is None
+
+    def test_failing_error_emission_preserves_original_exception(self, mock_emitter):
+        def emit(component, operation, *args, **kwargs):
+            if operation.endswith("_ERROR") or operation.endswith("_END"):
+                raise RuntimeError("telemetry backend down")
+
+        mock_emitter.emit_custom_event.side_effect = emit
+        trace = EventBasedSparkTrace(mock_emitter)
+
+        with pytest.raises(ValueError, match="user failure"):
+            with trace.span(operation="Op", component="Comp", reraise=True):
+                raise ValueError("user failure")
+
+        assert trace.current_span is None

--- a/tests/unit/test_spark_trace.py
+++ b/tests/unit/test_spark_trace.py
@@ -6,9 +6,8 @@ import uuid
 from datetime import datetime
 from unittest.mock import MagicMock, Mock, call, patch
 
-import pytest
-
 import kindling.spark_trace as spark_trace_module
+import pytest
 from kindling.spark_trace import (
     AzureEventEmitter,
     CustomEventEmitter,
@@ -959,6 +958,203 @@ class TestEdgeCases:
             assert isinstance(args[2], dict), "Details should be dict"
             assert isinstance(args[3], str), "Event ID should be string"
             assert isinstance(args[4], uuid.UUID), "Trace ID should be UUID"
+
+
+class TestSpanParenting:
+    """Parent restore and parentSpanId emission (gh#210 Phase 0)."""
+
+    def test_parent_restored_after_nested_exit(self, mock_emitter):
+        """Exiting a nested span should restore the enclosing span as current."""
+        trace = EventBasedSparkTrace(mock_emitter)
+
+        with trace.span(operation="Outer", component="Comp"):
+            outer_span = trace.current_span
+
+            with trace.span(operation="Inner", component="Comp"):
+                assert trace.current_span is not outer_span
+
+            assert trace.current_span is outer_span, "Inner exit should restore outer span"
+
+        assert trace.current_span is None, "Top-level exit should restore None"
+
+    def test_parent_restored_after_exception(self, mock_emitter):
+        """Parent restore must happen even when the span body raises."""
+        trace = EventBasedSparkTrace(mock_emitter)
+
+        with pytest.raises(ValueError):
+            with trace.span(operation="Op", component="Comp", reraise=True):
+                raise ValueError("boom")
+
+        assert trace.current_span is None, "current_span should be restored after error exit"
+
+    def test_consecutive_top_level_spans_get_distinct_trace_ids(self, mock_emitter):
+        """Each top-level span should start its own trace."""
+        trace = EventBasedSparkTrace(mock_emitter)
+
+        with trace.span(operation="Op1", component="Comp"):
+            first_trace_id = trace.current_span.traceId
+
+        with trace.span(operation="Op2", component="Comp"):
+            second_trace_id = trace.current_span.traceId
+
+        assert first_trace_id != second_trace_id, "Consecutive runs must not share a trace"
+
+    def test_child_events_carry_parent_span_id(self, mock_emitter):
+        """Nested span START/END events should emit parentSpanId."""
+        trace = EventBasedSparkTrace(mock_emitter)
+
+        with trace.span(operation="Outer", component="Comp"):
+            outer_id = trace.current_span.id
+            with trace.span(operation="Inner", component="Comp"):
+                pass
+
+        inner_calls = [
+            c for c in mock_emitter.emit_custom_event.call_args_list if c[0][1].startswith("Inner")
+        ]
+        assert len(inner_calls) == 2, "Inner span should emit START and END"
+        for c in inner_calls:
+            assert c[0][2].get("parentSpanId") == outer_id
+
+    def test_root_span_events_have_no_parent_span_id(self, mock_emitter):
+        """Top-level span events should not carry parentSpanId."""
+        trace = EventBasedSparkTrace(mock_emitter)
+
+        with trace.span(operation="Op", component="Comp"):
+            pass
+
+        for c in mock_emitter.emit_custom_event.call_args_list:
+            assert "parentSpanId" not in c[0][2]
+
+    def test_start_span_parents_to_current_span(self, mock_emitter):
+        """Manual spans opened inside a CM span should record it as parent."""
+        trace = EventBasedSparkTrace(mock_emitter)
+
+        with trace.span(operation="Outer", component="Comp"):
+            outer_id = trace.current_span.id
+            manual = trace.start_span(operation="Inner", component="Comp")
+
+        assert manual.parent_id == outer_id
+        start_call = [
+            c for c in mock_emitter.emit_custom_event.call_args_list if c[0][1] == "Inner_START"
+        ][0]
+        assert start_call[0][2].get("parentSpanId") == outer_id
+
+        trace.end_span(manual)
+        end_call = [
+            c for c in mock_emitter.emit_custom_event.call_args_list if c[0][1] == "Inner_END"
+        ][0]
+        assert end_call[0][2].get("parentSpanId") == outer_id
+
+
+class TestRecordSpan:
+    """record_span: retroactive spans with explicit timestamps (gh#210 Phase 0)."""
+
+    def test_record_span_emits_start_and_end_with_given_timestamps(self, mock_emitter):
+        """record_span should honor the provided timestamps, not the wall clock."""
+        trace = EventBasedSparkTrace(mock_emitter)
+        start = datetime(2026, 1, 1, 12, 0, 0)
+        end = datetime(2026, 1, 1, 12, 0, 2, 500000)
+
+        trace.record_span("phase", "kindling.bootstrap", start, end, details={"k": "v"})
+
+        calls = mock_emitter.emit_custom_event.call_args_list
+        operations = [c[0][1] for c in calls]
+        assert operations == ["phase_START", "phase_END"]
+
+        start_details = calls[0][0][2]
+        end_details = calls[1][0][2]
+        assert start_details["startTime"] == "2026-01-01 12:00:00.000"
+        assert start_details["k"] == "v"
+        assert end_details["endTime"] == "2026-01-01 12:00:02.500"
+        assert end_details["totalTime"] == "2.500"
+
+    def test_record_span_with_error_emits_error_event(self, mock_emitter):
+        """record_span with an error should emit ERROR between START and END."""
+        trace = EventBasedSparkTrace(mock_emitter)
+        start = datetime(2026, 1, 1, 12, 0, 0)
+        end = datetime(2026, 1, 1, 12, 0, 1)
+
+        trace.record_span("phase", "kindling.bootstrap", start, end, error="boom")
+
+        calls = mock_emitter.emit_custom_event.call_args_list
+        operations = [c[0][1] for c in calls]
+        assert operations == ["phase_START", "phase_ERROR", "phase_END"]
+        error_details = calls[1][0][2]
+        assert error_details["exception"] == "boom"
+        assert error_details["errorTime"] == "2026-01-01 12:00:01.000"
+
+    def test_record_span_parents_to_current_span(self, mock_emitter):
+        """record_span inside an active span should join its trace and parent to it."""
+        trace = EventBasedSparkTrace(mock_emitter)
+        start = datetime(2026, 1, 1, 12, 0, 0)
+        end = datetime(2026, 1, 1, 12, 0, 1)
+
+        with trace.span(operation="Outer", component="Comp"):
+            outer_id = trace.current_span.id
+            outer_trace_id = trace.current_span.traceId
+            trace.record_span("phase", "kindling.bootstrap", start, end)
+
+        recorded_calls = [
+            c for c in mock_emitter.emit_custom_event.call_args_list if c[0][1].startswith("phase")
+        ]
+        assert len(recorded_calls) == 2
+        for c in recorded_calls:
+            assert c[0][2].get("parentSpanId") == outer_id
+            assert c[0][4] == outer_trace_id
+
+    def test_record_span_without_context_gets_own_trace_id(self, mock_emitter):
+        """record_span with no active span should mint a fresh trace id."""
+        trace = EventBasedSparkTrace(mock_emitter)
+        start = datetime(2026, 1, 1, 12, 0, 0)
+        end = datetime(2026, 1, 1, 12, 0, 1)
+
+        trace.record_span("phase", "kindling.bootstrap", start, end)
+
+        calls = mock_emitter.emit_custom_event.call_args_list
+        assert isinstance(calls[0][0][4], uuid.UUID)
+        assert "parentSpanId" not in calls[0][0][2]
+
+    def test_default_record_span_routes_through_start_and_end(self):
+        """The ABC default should serve providers that only implement the abstract API."""
+
+        class MinimalProvider(SparkTraceProvider):
+            def __init__(self):
+                self.started = []
+                self.ended = []
+
+            def span(self, operation=None, component=None, details=None, reraise=False):
+                raise NotImplementedError
+
+            def start_span(self, operation, component, details=None):
+                self.started.append((operation, component, details))
+                return SparkSpan(
+                    id="1",
+                    component=component,
+                    operation=operation,
+                    attributes=details or {},
+                    traceId=uuid.uuid4(),
+                    reraise=False,
+                    start_time=datetime.now(),
+                )
+
+            def add_event(self, span, name, attributes=None):
+                raise NotImplementedError
+
+            def end_span(self, span, error=None):
+                self.ended.append((span, error))
+
+        provider = MinimalProvider()
+        start = datetime(2026, 1, 1, 12, 0, 0)
+        end = datetime(2026, 1, 1, 12, 0, 2)
+
+        provider.record_span("phase", "kindling.bootstrap", start, end, error="late failure")
+
+        assert len(provider.started) == 1
+        operation, component, details = provider.started[0]
+        assert (operation, component) == ("phase", "kindling.bootstrap")
+        assert details["recordedStartTime"] == "2026-01-01 12:00:00.000"
+        assert details["recordedEndTime"] == "2026-01-01 12:00:02.000"
+        assert provider.ended[0][1] == "late failure"
 
 
 class TestManualSpanLifecycle:

--- a/tests/unit/test_streaming_listener.py
+++ b/tests/unit/test_streaming_listener.py
@@ -13,7 +13,6 @@ import time
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
-
 from kindling.streaming_listener import (
     KindlingStreamingListener,
     StreamingEvent,
@@ -575,10 +574,9 @@ class TestTracing:
 
         mock_trace_provider.start_span.assert_called_once()
         call_kwargs = mock_trace_provider.start_span.call_args
-        assert (
-            call_kwargs[1]["operation"] == "streaming_query"
-            or call_kwargs[0][0] == "streaming_query"
-        )
+        assert call_kwargs[1]["operation"] == "query"
+        assert call_kwargs[1]["component"] == "kindling.streaming"
+        assert call_kwargs[1]["details"]["query_label"] == "test_query"
 
     def test_query_progress_adds_span_event(self, started_listener, mock_trace_provider):
         """onQueryProgress should add an event to the query's trace span."""

--- a/tests/unit/test_trace_ops.py
+++ b/tests/unit/test_trace_ops.py
@@ -1,0 +1,291 @@
+"""Unit tests for provider-op tracing (kindling.trace_ops)."""
+
+import inspect
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from kindling.data_entities import EntityMetadata
+from kindling.entity_provider import BaseEntityProvider, WritableEntityProvider
+from kindling.entity_provider_registry import EntityProviderRegistry
+from kindling.injection import GlobalInjector
+from kindling.test_framework import RecordingTraceProvider
+from kindling.trace_ops import (
+    LEVEL_MINIMAL,
+    LEVEL_STANDARD,
+    LEVEL_VERBOSE,
+    TRACED_PROVIDER_OPS,
+    UNTRACED_PROVIDER_OPS,
+    configure_op_tracing,
+    level_at_least,
+    read_tracing_settings,
+    whitelist_details,
+    wrap_provider_ops,
+)
+
+
+class _Config:
+    def __init__(self, values=None):
+        self.values = values or {}
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+
+class FakeProvider(BaseEntityProvider, WritableEntityProvider):
+    """Provider double implementing two capability ABCs plus a de-facto op."""
+
+    def __init__(self, *args, **kwargs):
+        self.read_calls = 0
+        self.merge_calls = 0
+
+    def read_entity(self, entity_metadata):
+        self.read_calls += 1
+        return "df"
+
+    def check_entity_exists(self, entity_metadata):
+        return True
+
+    def write_to_entity(self, df, entity_metadata):
+        return None
+
+    def append_to_entity(self, df, entity_metadata):
+        return None
+
+    def merge_to_entity(self, df, entity):
+        self.merge_calls += 1
+        return None
+
+
+def _entity(entityid="silver.orders"):
+    return EntityMetadata(
+        entityid=entityid,
+        name=entityid.split(".")[-1],
+        partition_columns=[],
+        merge_columns=[],
+        tags={},
+        schema=None,
+    )
+
+
+def _registry():
+    logger_provider = MagicMock()
+    logger_provider.get_logger.return_value = MagicMock()
+    with patch("kindling.entity_provider_registry.GlobalInjector"):
+        return EntityProviderRegistry(logger_provider)
+
+
+class TestWrapProviderOps:
+    def test_wrapped_op_emits_span_with_whitelisted_details(self):
+        provider = FakeProvider()
+        tp = RecordingTraceProvider()
+
+        wrap_provider_ops(provider, tp, provider_type="fake")
+        result = provider.read_entity(_entity())
+
+        assert result == "df", "Return value must pass through the wrapper"
+        spans = tp.find(component="kindling.entity.fake", operation="read_entity")
+        assert len(spans) == 1
+        assert spans[0].details["entity_id"] == "silver.orders"
+        assert spans[0].details["provider_type"] == "fake"
+        assert spans[0].closed
+
+    def test_entity_id_found_in_keyword_arguments(self):
+        provider = FakeProvider()
+        tp = RecordingTraceProvider()
+
+        wrap_provider_ops(provider, tp, provider_type="fake")
+        provider.write_to_entity(df="rows", entity_metadata=_entity("gold.facts"))
+
+        spans = tp.find(operation="write_to_entity")
+        assert spans[0].details["entity_id"] == "gold.facts"
+
+    def test_identity_isinstance_hasattr_preserved(self):
+        provider = FakeProvider()
+        tp = RecordingTraceProvider()
+
+        wrapped = wrap_provider_ops(provider, tp, provider_type="fake")
+
+        assert wrapped is provider, "Wrapping must not replace the instance"
+        assert isinstance(provider, BaseEntityProvider)
+        assert isinstance(provider, WritableEntityProvider)
+        assert hasattr(provider, "merge_to_entity"), "hasattr capability probes must still hold"
+        assert not hasattr(provider, "replace_entity"), "Absent ops must stay absent"
+
+    def test_rewrap_is_idempotent(self):
+        provider = FakeProvider()
+        tp = RecordingTraceProvider()
+
+        wrap_provider_ops(provider, tp, provider_type="fake")
+        wrap_provider_ops(provider, tp, provider_type="fake")
+        provider.read_entity(_entity())
+
+        assert len(tp.find(operation="read_entity")) == 1, "Re-wrap must not double-span"
+
+    def test_exceptions_propagate_and_span_records_error(self):
+        class FailingProvider(FakeProvider):
+            def read_entity(self, entity_metadata):
+                raise ValueError("storage offline")
+
+        provider = FailingProvider()
+        tp = RecordingTraceProvider()
+        wrap_provider_ops(provider, tp, provider_type="fake")
+
+        with pytest.raises(ValueError, match="storage offline"):
+            provider.read_entity(_entity())
+
+        span = tp.find(operation="read_entity")[0]
+        assert span.closed
+        assert "storage offline" in span.error
+
+    def test_class_attribute_call_bypasses_wrapper(self):
+        """The delta _merge_batch pattern: type(self).op(self, ...) skips tracing."""
+        provider = FakeProvider()
+        tp = RecordingTraceProvider()
+        wrap_provider_ops(provider, tp, provider_type="fake")
+
+        type(provider).merge_to_entity(provider, "batch_df", _entity())
+
+        assert provider.merge_calls == 1
+        assert tp.find(operation="merge_to_entity") == [], "Class-attr call must not span"
+
+        provider.merge_to_entity("df", _entity())
+        assert len(tp.find(operation="merge_to_entity")) == 1, "Instance call must span"
+
+    def test_delta_merge_batch_uses_class_attribute_bypass(self):
+        """Source guard: the foreachBatch closure must keep the wrapper bypass."""
+        from kindling.entity_provider_delta import DeltaEntityProvider
+
+        source = inspect.getsource(DeltaEntityProvider.merge_as_stream)
+        assert "type(self).merge_to_entity(self" in source
+
+
+class TestRegistryOpTracing:
+    def test_registry_resolved_provider_emits_op_spans(self):
+        registry = _registry()
+        registry.register_provider("fake", FakeProvider)
+        tp = RecordingTraceProvider()
+        registry.enable_op_tracing(tp, LEVEL_STANDARD)
+
+        instance = FakeProvider()
+        with patch.object(GlobalInjector, "get", return_value=instance):
+            provider = registry.get_provider("fake")
+
+        assert provider is instance, "Registry must serve the same (wrapped) instance"
+        provider.read_entity(_entity())
+        spans = tp.find(component="kindling.entity.fake", operation="read_entity")
+        assert len(spans) == 1
+
+    def test_enable_after_resolution_wraps_cached_instances(self):
+        registry = _registry()
+        registry.register_provider("fake", FakeProvider)
+        instance = FakeProvider()
+        with patch.object(GlobalInjector, "get", return_value=instance):
+            provider = registry.get_provider("fake")
+
+        tp = RecordingTraceProvider()
+        registry.enable_op_tracing(tp, LEVEL_STANDARD)
+
+        provider.read_entity(_entity())
+        assert len(tp.find(operation="read_entity")) == 1
+
+    def test_without_enable_no_wrapping_happens(self):
+        registry = _registry()
+        registry.register_provider("fake", FakeProvider)
+        instance = FakeProvider()
+        with patch.object(GlobalInjector, "get", return_value=instance):
+            provider = registry.get_provider("fake")
+
+        provider.read_entity(_entity())
+        assert not hasattr(provider, "_kindling_op_tracing_wrapped")
+
+
+class TestConfigureOpTracing:
+    def test_disabled_config_does_not_enable(self):
+        registry = MagicMock()
+        enabled = configure_op_tracing(
+            _Config({"kindling.telemetry.tracing.enabled": "false"}),
+            registry=registry,
+            trace_provider=RecordingTraceProvider(),
+            legacy_provider=FakeProvider(),
+        )
+
+        assert enabled is False
+        registry.enable_op_tracing.assert_not_called()
+
+    def test_minimal_level_does_not_enable_op_tracing(self):
+        registry = MagicMock()
+        enabled = configure_op_tracing(
+            _Config({"kindling.telemetry.tracing.level": LEVEL_MINIMAL}),
+            registry=registry,
+            trace_provider=RecordingTraceProvider(),
+            legacy_provider=FakeProvider(),
+        )
+
+        assert enabled is False
+        registry.enable_op_tracing.assert_not_called()
+
+    def test_default_config_enables_and_wraps_legacy_singleton(self):
+        registry = MagicMock()
+        tp = RecordingTraceProvider()
+        legacy = FakeProvider()
+
+        enabled = configure_op_tracing(
+            _Config(), registry=registry, trace_provider=tp, legacy_provider=legacy
+        )
+
+        assert enabled is True
+        registry.enable_op_tracing.assert_called_once_with(tp, LEVEL_STANDARD)
+        assert getattr(legacy, "_kindling_op_tracing_wrapped", False) is True
+
+        legacy.read_entity(_entity())
+        assert tp.find(component="kindling.entity.delta", operation="read_entity")
+
+
+class TestTracingSettings:
+    def test_defaults_are_enabled_standard(self):
+        assert read_tracing_settings(_Config()) == (True, LEVEL_STANDARD)
+
+    def test_string_false_coerces(self):
+        enabled, _ = read_tracing_settings(_Config({"kindling.telemetry.tracing.enabled": "false"}))
+        assert enabled is False
+
+    def test_level_is_normalized_and_validated(self):
+        _, level = read_tracing_settings(_Config({"kindling.telemetry.tracing.level": "VERBOSE"}))
+        assert level == LEVEL_VERBOSE
+
+        _, level = read_tracing_settings(_Config({"kindling.telemetry.tracing.level": "bogus"}))
+        assert level == LEVEL_STANDARD
+
+    def test_level_at_least_ordering(self):
+        assert level_at_least(LEVEL_VERBOSE, LEVEL_STANDARD)
+        assert level_at_least(LEVEL_STANDARD, LEVEL_STANDARD)
+        assert not level_at_least(LEVEL_MINIMAL, LEVEL_STANDARD)
+        assert not level_at_least(LEVEL_STANDARD, LEVEL_VERBOSE)
+
+    def test_whitelist_details_filters_keys(self):
+        details = whitelist_details({"pipe_id": "p1", "secret_ref": "nope"}, ("pipe_id",))
+        assert details == {"pipe_id": "p1"}
+        assert whitelist_details(None, ("pipe_id",)) == {}
+
+
+class TestOpListDriftGuard:
+    def test_op_list_covers_capability_abc_methods(self):
+        """Every capability-ABC method must be classified traced or untraced."""
+        import kindling.entity_provider as entity_provider_module
+
+        abc_ops = set()
+        for name in dir(entity_provider_module):
+            obj = getattr(entity_provider_module, name)
+            if inspect.isclass(obj) and getattr(obj, "__abstractmethods__", None):
+                abc_ops |= set(obj.__abstractmethods__)
+
+        classified = set(TRACED_PROVIDER_OPS) | set(UNTRACED_PROVIDER_OPS)
+        missing = {op for op in abc_ops if not op.startswith("_")} - classified
+        assert not missing, (
+            f"Capability-ABC methods not classified in trace_ops: {sorted(missing)}. "
+            "Add them to TRACED_PROVIDER_OPS or UNTRACED_PROVIDER_OPS."
+        )
+
+    def test_traced_and_untraced_do_not_overlap(self):
+        assert not set(TRACED_PROVIDER_OPS) & set(UNTRACED_PROVIDER_OPS)


### PR DESCRIPTION
## Summary

Comprehensive built-in tracing instrumentation across kindling (#210), built up in 7 commits (41 files, +3702/−468):

- **Span parenting and `record_span` groundwork** (`spark_trace.py`): parent tracking restored in `finally` on both success and exception paths; backward-compatible optional `parent_id` field; `record_span` gets a concrete ABC default with an `EventBased` override so providers can record spans with faithful timestamps
- **Provider-op tracing at the registry chokepoint** (`trace_ops.py`, `entity_provider_registry.py`): instance-attribute bound-method shadowing wraps provider data ops with spans at `get_provider()` — idempotent (`_kindling_op_tracing_wrapped` marker), transparent to `isinstance`/`hasattr`, with read-only ops (`check_entity_exists`, `get_entity_version`) excluded and a drift guard test pinning the op list
- **Structural seam spans and naming normalization** across the pipe/entity execution path, including a **data-correctness fix** in `simple_read_persist_strategy.py`: the persist span now uses `reraise=True` so merge failures are no longer swallowed (regression-tested), and redundant inner per-op spans are dropped in favor of the op tracer's child spans
- **Retro-recorded bootstrap span tree** (`bootstrap.py`): `_BootstrapPhaseRecorder` is a plain list recorder (no DI/JVM imports at module scope) that replays bootstrap phases as spans once tracing is up; flush is try/except-guarded and gated on tracing being enabled with usable config; short-circuited re-init returns before the recorder resets
- **Design-time CLI tracing** via an env-gated plain provider, plus `AzureMonitorTraceProvider.start_span` traceId `TypeError` fixed via the OTel span context
- **Span-tree integration tests and docs**: `tests/integration/test_tracing_tree.py` asserts real parent/child span trees from pipe execution

## Test plan

- `poe test-unit`: **2295 passed**, 2 skipped
- `poe test-integration`: **125 passed**, 1 skipped — includes `TestTraceIntegration::test_pipe_execution_creates_trace_spans` and the new span-tree assertions
- Internal review: APPROVE — every design item (Approach A–E, Findings 1–9) verified with independent spot-checks; bound-method shadowing idempotency, ABC transparency, and the persist `reraise=True` fix each pinned by dedicated tests
- gitleaks scan of the 7-commit push range: clean

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)
