### PR TITLE
fix(sdk): use jobs.submit instead of jobs.runs.submit for ad-hoc runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,12 @@ All notable changes to spark-kindling are documented here.
   the required `traceId` (TypeError on first manual span under the otel
   provider); it now adopts the OTel trace id when available.
 - File ingestion's trace component no longer names a nonexistent class.
+- **Databricks ad-hoc app runs no longer raise `AttributeError`** (gh#214).
+  `DatabricksAPI._submit_one_time_run` called
+  `self.client.jobs.runs.submit(...)`, but `WorkspaceClient.jobs` has no
+  `.runs` sub-namespace — `submit` is a direct method on `jobs`, matching
+  every other call site in the file. This broke `kindling app run
+  --platform databricks` for every ad-hoc run.
 
 ## [0.12.1] - 2026-07-29
 

--- a/packages/kindling_sdk/kindling_sdk/platform_databricks.py
+++ b/packages/kindling_sdk/kindling_sdk/platform_databricks.py
@@ -389,7 +389,7 @@ class DatabricksAPI(PlatformAPI):
         environment: Optional[str] = None,
         parameters: Optional[Dict[str, Any]] = None,
     ) -> str:
-        """Submit a one-time app run via runs.submit() — no persistent job definition."""
+        """Submit a one-time app run via jobs.submit() — no persistent job definition."""
         config_overrides: Dict[str, Any] = dict(parameters or {})
         if environment:
             config_overrides["environment"] = environment
@@ -521,7 +521,7 @@ class DatabricksAPI(PlatformAPI):
         }
 
     def _submit_one_time_run(self, app_name: str, job_config: Dict[str, Any]) -> str:
-        """Submit a one-time Databricks run via runs.submit() — no persistent job created."""
+        """Submit a one-time Databricks run via jobs.submit() — no persistent job created."""
         try:
             from databricks.sdk.service.jobs import SparkPythonTask, SubmitTask
         except ImportError:
@@ -545,7 +545,7 @@ class DatabricksAPI(PlatformAPI):
                 libraries=spec["libraries"] or None,
             )
 
-        run_response = self.client.jobs.runs.submit(
+        run_response = self.client.jobs.submit(
             run_name=f"kindling-adhoc-{app_name}",
             tasks=[task],
         )

--- a/tests/unit/test_platform_databricks_sdk_job_config.py
+++ b/tests/unit/test_platform_databricks_sdk_job_config.py
@@ -219,3 +219,33 @@ def test_create_job_sets_cluster_log_conf_when_uc_volume_provided():
     assert cluster.cluster_log_conf is not None
     assert "test-job" in cluster.cluster_log_conf.volumes.destination
     assert cluster.data_security_mode == DataSecurityMode.SINGLE_USER
+
+
+# --- Bug fix: _submit_one_time_run calls jobs.submit, not jobs.runs.submit ---
+
+
+def test_submit_one_time_run_calls_jobs_submit_not_runs_submit():
+    """WorkspaceClient.jobs has no .runs sub-namespace; submit() is a direct method."""
+    api = _make_api_for_create_job()
+    api._client.jobs.submit.return_value = MagicMock(run_id=12345)
+
+    run_id = api._submit_one_time_run("myapp", {})
+
+    submit_call = api._client.jobs.submit.call_args
+    assert submit_call.kwargs["run_name"] == "kindling-adhoc-myapp"
+    tasks = submit_call.kwargs["tasks"]
+    assert len(tasks) == 1
+    assert tasks[0].task_key == "main"
+    assert run_id == "12345"
+
+
+def test_submit_app_run_delegates_to_one_time_run():
+    """submit_app_run (the CLI's ad-hoc run entry point) reaches jobs.submit."""
+    api = _make_api_for_create_job()
+    api._client.jobs.submit.return_value = MagicMock(run_id=67890)
+
+    run_id = api.submit_app_run("myapp", environment="dev", parameters={"foo": "bar"})
+
+    submit_call = api._client.jobs.submit.call_args
+    assert submit_call.kwargs["run_name"] == "kindling-adhoc-myapp"
+    assert run_id == "67890"


### PR DESCRIPTION
## Summary

Fixes the `AttributeError` that broke every ad-hoc Databricks app run (#214): `DatabricksAPI._submit_one_time_run` called `self.client.jobs.runs.submit(...)`, but `WorkspaceClient.jobs` has no `.runs` sub-namespace — `submit` is a direct method on `jobs`, matching every other sibling call site in the file (`jobs.create`, `run_now`, `get_run`, `get_run_output`, `cancel_run`, `delete`, `list`).

- `packages/kindling_sdk/kindling_sdk/platform_databricks.py`: `self.client.jobs.runs.submit(` → `self.client.jobs.submit(`; two docstrings corrected from "via `runs.submit()`" to "via `jobs.submit()`"
- Two regression tests assert directly on `api._client.jobs.submit.call_args` (`run_name`/`tasks` kwargs), pinning the call shape — a plain MagicMock would otherwise silently auto-vivify `.runs.submit` and mask the regression

## Test plan

- `poe test-unit`: **2325 passed**, 2 skipped (clean environment, post-rebase onto main)
- Internal review: APPROVE, no blocking findings — fix verified against the `WorkspaceClient` property and every sibling call site
- gitleaks scan of push range: clean

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)
