### PR TITLE
feat(temporal): auto-collapse per-declaration pipes into the chain lowering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to spark-kindling are documented here.
 
+## [Unreleased]
+
+### Added
+
+- **`collapse_temporal_chain()`** (`kindling_ext_temporal`): supersedes
+  `declare_temporal_chain()` for the common case. `declare_temporal_chain`
+  only ever added the two composite chain pipes, leaving the per-declaration
+  base-event/condition-engine/episode/episode-event pipes still registered
+  alongside them; `collapse_temporal_chain` additionally unregisters those
+  superseded pipes and returns the corrected pipe id list.
+- New `kindling.temporal.autocollapse` config key (default `true`): any
+  `run_datapipes`/`run_datapipes_dag` call whose requested pipes reference a
+  per-declaration temporal pipe is automatically collapsed before execution
+  starts, so most apps never need to call `collapse_temporal_chain()`
+  directly. Disable with `kindling.temporal.autocollapse: false` to run one
+  granular per-declaration pipe standalone (e.g. for debugging).
+- Every temporal pipe now carries a `temporal.lowering` tag (`declared` for
+  per-declaration pipes, `chain` for the composite chain pipes), exported as
+  `TEMPORAL_LOWERING_TAG`/`TEMPORAL_LOWERING_DECLARED`/`TEMPORAL_LOWERING_CHAIN`
+  — the reliable way to distinguish the two lowerings, since `pipeid` itself
+  is user-overridable.
+- `DataPipesRegistry.unregister_pipe()` (`kindling.data_pipes`): the registry
+  previously had no removal primitive at all.
+
 ## [0.12.2] - 2026-07-29
 
 ### Added

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/__init__.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/__init__.py
@@ -1,9 +1,11 @@
 """Temporal event, condition, and episode primitives for Kindling."""
 
 from .chain import (
+    AUTOCOLLAPSE_CONFIG_KEY,
     MAX_GENERATIONS_CONFIG_KEY,
     chain_episodes_pipe_id,
     chain_events_pipe_id,
+    collapse_temporal_chain,
     declare_temporal_chain,
 )
 from .conditions import (
@@ -33,7 +35,12 @@ from .registry import (
     TemporalEventRegistry,
     TemporalEventRegistryManager,
 )
-from .translation import TemporalPipeTranslator
+from .translation import (
+    TEMPORAL_LOWERING_CHAIN,
+    TEMPORAL_LOWERING_DECLARED,
+    TEMPORAL_LOWERING_TAG,
+    TemporalPipeTranslator,
+)
 from .validation import (
     ActiveSparkSqlExpressionParser,
     ConditionRule,
@@ -45,10 +52,12 @@ from .validation import (
 
 __all__ = [
     "ActiveSparkSqlExpressionParser",
+    "AUTOCOLLAPSE_CONFIG_KEY",
     "BaseEventMetadata",
     "MAX_GENERATIONS_CONFIG_KEY",
     "chain_episodes_pipe_id",
     "chain_events_pipe_id",
+    "collapse_temporal_chain",
     "conditions_entity_schema",
     "declare_temporal_chain",
     "ConditionEngineRunner",
@@ -64,6 +73,9 @@ __all__ = [
     "EpisodeRunner",
     "InvalidCondition",
     "SimpleTemporalEntityResolver",
+    "TEMPORAL_LOWERING_CHAIN",
+    "TEMPORAL_LOWERING_DECLARED",
+    "TEMPORAL_LOWERING_TAG",
     "TemporalConditionValidator",
     "TemporalEntityResolver",
     "TemporalEpisodeRegistry",
@@ -85,6 +97,7 @@ __version__ = "0.1.0"
 def _register_services():
     """Register extension services with Kindling's DI container."""
     from injector import singleton
+
     from kindling.injection import GlobalInjector
 
     injector = GlobalInjector.get_injector()

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/chain.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/chain.py
@@ -38,6 +38,16 @@ declarations; the per-declaration pipes stay registered and independently
 executable — the chain is an alternative lowering over the same metadata,
 not a replacement.
 
+``collapse_temporal_chain`` (below) is the one apps should reach for in
+practice: it does everything ``declare_temporal_chain`` does, then also
+unregisters the per-declaration pipes the chain supersedes, so a run over
+"every registered pipe" doesn't execute both lowerings at once. It runs
+automatically before every ``run_datapipes`` call that touches a
+per-declaration temporal pipe — see ``kindling.temporal.autocollapse`` —
+so most apps never need to call either function directly; keep
+``declare_temporal_chain`` around when you deliberately want both
+lowerings registered side by side (e.g. inspecting one hop in isolation).
+
 Phase-1 constraint: all base events must share one input entity (the
 chain's driving source). Heterogeneous bronze sources should normalize
 into a shared staging entity first; native multi-source chaining is a
@@ -53,12 +63,21 @@ from kindling.injection import GlobalInjector
 
 from .entities import TemporalEntityResolver
 from .registry import TemporalEpisodeRegistry, TemporalEventRegistry
-from .translation import TemporalPipeTranslator
+from .translation import (
+    TEMPORAL_LOWERING_CHAIN,
+    TEMPORAL_LOWERING_DECLARED,
+    TEMPORAL_LOWERING_TAG,
+    TemporalPipeTranslator,
+    parse_bool_config,
+)
 
 CHAIN_EVENTS_PIPE_PREFIX = "temporal.chain.events."
 CHAIN_EPISODES_PIPE_PREFIX = "temporal.chain.episodes."
 MAX_GENERATIONS_CONFIG_KEY = "kindling.temporal.max_generations"
 DEFAULT_MAX_GENERATIONS = 10
+
+AUTOCOLLAPSE_CONFIG_KEY = "kindling.temporal.autocollapse"
+DEFAULT_AUTOCOLLAPSE = True
 
 
 def chain_events_pipe_id(chainid: str) -> str:
@@ -281,6 +300,7 @@ def declare_temporal_chain(chainid: str = "default") -> List[str]:
         tags={
             "pipe_type": "temporal.chain_events",
             "temporal.kind": "chain_events",
+            TEMPORAL_LOWERING_TAG: TEMPORAL_LOWERING_CHAIN,
             "temporal.chain_id": chainid,
             "temporal.reads_prior_state": "true",
         },
@@ -302,6 +322,7 @@ def declare_temporal_chain(chainid: str = "default") -> List[str]:
             tags={
                 "pipe_type": "temporal.chain_episodes",
                 "temporal.kind": "chain_episodes",
+                TEMPORAL_LOWERING_TAG: TEMPORAL_LOWERING_CHAIN,
                 "temporal.chain_id": chainid,
                 "temporal.reads_prior_state": "true",
             },
@@ -313,3 +334,153 @@ def declare_temporal_chain(chainid: str = "default") -> List[str]:
         pipe_ids.append(episodes_pipe)
 
     return pipe_ids
+
+
+def _pipe_tags(pipe_registry: DataPipesRegistry, pipeid: str) -> Dict[str, str]:
+    definition = pipe_registry.get_pipe_definition(pipeid)
+    return (definition.tags or {}) if definition is not None else {}
+
+
+def _pipe_ids_tagged(pipe_registry: DataPipesRegistry, lowering: str) -> List[str]:
+    """Every currently-registered pipe tagged ``temporal.lowering=<lowering>``.
+
+    Never by pipeid prefix: a declaration's ``pipeid`` is user-overridable
+    (``BaseEventMetadata.pipeid`` etc.), so the tag set in translation.py/
+    chain.py is the only reliable signal. Registry order preserved (Python
+    dicts are insertion-ordered) so callers that care about relative order
+    -- e.g. the events chain pipe must run before the episodes chain pipe
+    -- can rely on it; never route this through a ``set``.
+    """
+    return [
+        pipeid
+        for pipeid in pipe_registry.get_pipe_ids()
+        if _pipe_tags(pipe_registry, pipeid).get(TEMPORAL_LOWERING_TAG) == lowering
+    ]
+
+
+def collapse_temporal_chain(chainid: str = "default") -> List[str]:
+    """Lower the registered temporal declarations into the chain pipes AND
+    retire the per-declaration pipes they supersede.
+
+    ``declare_temporal_chain`` only ever adds the two composite chain pipes,
+    leaving every base-event/condition-engine/episode/episode-event pipe
+    ``DataEvents``/``DataEpisodes`` registered eagerly still sitting in the
+    registry -- so a naive "run everything registered" ends up executing
+    both lowerings over the same declarations. That combination is never
+    wanted: the per-declaration pipes are the broken, cyclic, multi-writer
+    lowering the chain exists to replace (see the module docstring).
+
+    This collapses: every pipe tagged ``temporal.lowering=declared`` is
+    unregistered, and the two chain pipes take their place. Returns every
+    pipe id left in the registry afterward (untouched pipes + the chain
+    pipes), in registry order -- pass it straight to ``run_datapipes``.
+
+    Idempotent: a second call finds nothing left tagged ``declared`` and
+    just re-confirms the chain pipes.
+    """
+    pipe_registry = GlobalInjector.get(DataPipesRegistry)
+    superseded = _pipe_ids_tagged(pipe_registry, TEMPORAL_LOWERING_DECLARED)
+
+    declare_temporal_chain(chainid)
+
+    for pipeid in superseded:
+        pipe_registry.unregister_pipe(pipeid)
+
+    return list(pipe_registry.get_pipe_ids())
+
+
+def _autocollapse_enabled() -> bool:
+    try:
+        from kindling.spark_config import ConfigService
+
+        value = GlobalInjector.get(ConfigService).get(AUTOCOLLAPSE_CONFIG_KEY, None)
+    except Exception:  # noqa: BLE001 - config service unavailable in bare tests
+        return DEFAULT_AUTOCOLLAPSE
+    return parse_bool_config(value, default=DEFAULT_AUTOCOLLAPSE)
+
+
+def _autocollapse_before_run(sender, *, pipe_ids=None, **kwargs) -> None:
+    """``datapipes.before_run`` handler: auto-collapse a run that touches
+    per-declaration temporal pipes, in place, before execution starts.
+
+    Scoped to the run at hand: only fires when THIS run's requested
+    ``pipe_ids`` actually reference a ``declared`` pipe -- an unrelated run
+    (some other pipe entirely) is left untouched even if temporal
+    declarations exist elsewhere in the process. ``pipe_ids`` is the exact
+    list object the emitting call site is about to iterate; mutating it in
+    place (rather than returning a new list, which a signal receiver's
+    return value can't feed back in) is what makes the swap land before
+    that iteration starts -- see ``run_datapipes``/``run_datapipes_dag`` in
+    ``kindling.data_pipes``, both of which now emit this signal before
+    handing ``pipes`` to their respective execution path.
+
+    ``collapse_temporal_chain`` can raise (e.g. episodes/condition-engines
+    declared with zero base events) -- caught here so a declaration gap
+    elsewhere never crashes an otherwise-unrelated run; the requested pipes
+    just execute uncollapsed, same as if autocollapse were off.
+
+    Disable with ``kindling.temporal.autocollapse: false`` (e.g. to run one
+    granular per-declaration pipe standalone for debugging).
+    """
+    if pipe_ids is None or not _autocollapse_enabled():
+        return
+
+    pipe_registry = GlobalInjector.get(DataPipesRegistry)
+    requested = list(pipe_ids)
+    if not any(
+        _pipe_tags(pipe_registry, pipeid).get(TEMPORAL_LOWERING_TAG) == TEMPORAL_LOWERING_DECLARED
+        for pipeid in requested
+    ):
+        return
+
+    try:
+        remaining_ordered = collapse_temporal_chain()
+    except Exception:  # noqa: BLE001 - a declaration gap must not crash an unrelated run
+        return
+
+    remaining = set(remaining_ordered)
+    survivors = [pipeid for pipeid in requested if pipeid in remaining]
+    # Iterate remaining_ordered (registry/insertion order), not the `remaining`
+    # set, so the events-chain pipe always lands before the episodes-chain
+    # pipe -- a set would scramble that via hash randomization.
+    chain_additions = [
+        pipeid
+        for pipeid in remaining_ordered
+        if pipeid not in requested
+        and _pipe_tags(pipe_registry, pipeid).get(TEMPORAL_LOWERING_TAG) == TEMPORAL_LOWERING_CHAIN
+    ]
+    pipe_ids[:] = survivors + chain_additions
+
+
+_autocollapse_connected_provider = None
+
+
+def ensure_autocollapse_connected() -> None:
+    """Wire the autocollapse handler onto ``datapipes.before_run``. Idempotent.
+
+    Called from every ``DataEvents``/``DataEpisodes`` declaration (see
+    registry.py) rather than at module import time: by the time any
+    temporal primitive has been successfully declared, the DI container and
+    signal provider are guaranteed configured, so there's no bootstrap-
+    ordering risk to reason about.
+
+    Tracks the specific ``SignalProvider`` instance connected, not just
+    whether a connection has ever happened -- a test or app that rebuilds
+    the DI container (``GlobalInjector`` reset) gets a new provider, and
+    this reconnects to it rather than silently staying attached to the old
+    (now-orphaned) one.
+    """
+    global _autocollapse_connected_provider
+    from kindling.signaling import SignalProvider
+
+    try:
+        signal_provider = GlobalInjector.get(SignalProvider)
+    except Exception:  # noqa: BLE001 - no signal provider bound (bare tests)
+        return
+    if signal_provider is _autocollapse_connected_provider:
+        return
+    signal = signal_provider.get_signal("datapipes.before_run") or signal_provider.create_signal(
+        "datapipes.before_run"
+    )
+    signal.connect(_autocollapse_before_run, weak=False)
+    _autocollapse_connected_provider = signal_provider

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/chain.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/chain.py
@@ -419,6 +419,14 @@ def _autocollapse_before_run(sender, *, pipe_ids=None, **kwargs) -> None:
     elsewhere never crashes an otherwise-unrelated run; the requested pipes
     just execute uncollapsed, same as if autocollapse were off.
 
+    Survivors are computed by removing exactly the pipe ids tagged
+    ``declared`` *in this request* (captured before collapsing) -- never by
+    intersecting the request with "what's still in the registry after
+    collapse". The latter would also silently drop any unrelated/typo'd
+    pipe id the caller passed (never registered to begin with, so absent
+    from the post-collapse registry too), swallowing a bug that would
+    otherwise fail loudly when ``run_datapipes`` tries to resolve it.
+
     Disable with ``kindling.temporal.autocollapse: false`` (e.g. to run one
     granular per-declaration pipe standalone for debugging).
     """
@@ -427,10 +435,13 @@ def _autocollapse_before_run(sender, *, pipe_ids=None, **kwargs) -> None:
 
     pipe_registry = GlobalInjector.get(DataPipesRegistry)
     requested = list(pipe_ids)
-    if not any(
-        _pipe_tags(pipe_registry, pipeid).get(TEMPORAL_LOWERING_TAG) == TEMPORAL_LOWERING_DECLARED
+    declared_requested = {
+        pipeid
         for pipeid in requested
-    ):
+        if _pipe_tags(pipe_registry, pipeid).get(TEMPORAL_LOWERING_TAG)
+        == TEMPORAL_LOWERING_DECLARED
+    }
+    if not declared_requested:
         return
 
     try:
@@ -438,11 +449,10 @@ def _autocollapse_before_run(sender, *, pipe_ids=None, **kwargs) -> None:
     except Exception:  # noqa: BLE001 - a declaration gap must not crash an unrelated run
         return
 
-    remaining = set(remaining_ordered)
-    survivors = [pipeid for pipeid in requested if pipeid in remaining]
-    # Iterate remaining_ordered (registry/insertion order), not the `remaining`
-    # set, so the events-chain pipe always lands before the episodes-chain
-    # pipe -- a set would scramble that via hash randomization.
+    survivors = [pipeid for pipeid in requested if pipeid not in declared_requested]
+    # Iterate remaining_ordered (registry/insertion order), not a set, so the
+    # events-chain pipe always lands before the episodes-chain pipe -- a set
+    # would scramble that via hash randomization.
     chain_additions = [
         pipeid
         for pipeid in remaining_ordered

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/registry.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/registry.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
 from injector import inject
+
 from kindling.data_entities import DataEntityRegistry
 from kindling.data_pipes import DataPipesRegistry
 from kindling.injection import GlobalInjector
@@ -178,6 +179,7 @@ class DataEvents:
                 entity_registry=cls._data_entity_registry(),
                 output_entity=events_entity,
             )
+            _ensure_autocollapse_connected()
             return func
 
         return decorator
@@ -213,6 +215,7 @@ class DataEvents:
             events_entity=events_entity,
             conditions_entity=conditions_entity,
         )
+        _ensure_autocollapse_connected()
 
 
 class DataEpisodes:
@@ -290,6 +293,7 @@ class DataEpisodes:
             entity_registry=entity_registry,
             events_entity=events_entity,
         )
+        _ensure_autocollapse_connected()
 
 
 class TemporalEventRegistryManager(TemporalEventRegistry):
@@ -337,6 +341,18 @@ class TemporalEpisodeRegistryManager(TemporalEpisodeRegistry):
 
     def get_episode_definition(self, episodeid: str) -> Optional[EpisodeMetadata]:
         return self.episodes.get(episodeid)
+
+
+def _ensure_autocollapse_connected() -> None:
+    """Wire the ``collapse_temporal_chain`` autocollapse hook. Idempotent.
+
+    Deferred import: chain.py imports this module at top level, so this
+    module must reach chain.py lazily (call time, not import time) to avoid
+    a circular top-level import.
+    """
+    from .chain import ensure_autocollapse_connected
+
+    ensure_autocollapse_connected()
 
 
 def _infer_condition_id(start_event: str) -> str:

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/translation.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/translation.py
@@ -8,6 +8,22 @@ from kindling.data_pipes import DataPipesRegistry
 if TYPE_CHECKING:
     from .registry import BaseEventMetadata, ConditionEngineMetadata, EpisodeMetadata
 
+# Tag key + values shared between the pipes that set them (here) and the
+# pipes/queries that read them back (chain.py's ``collapse_temporal_chain``).
+# Defined once, here, so setter and reader can never drift out of sync --
+# never matched by pipeid prefix/name, since ``pipeid`` is user-overridable
+# via ``metadata.pipeid``.
+TEMPORAL_LOWERING_TAG = "temporal.lowering"
+TEMPORAL_LOWERING_DECLARED = "declared"
+TEMPORAL_LOWERING_CHAIN = "chain"
+
+
+def parse_bool_config(value: Any, default: bool) -> bool:
+    """Shared ``"false"/"0"/"no"/"off"`` parsing for config-driven boolean flags."""
+    if value is None:
+        return default
+    return str(value).strip().lower() not in ("false", "0", "no", "off")
+
 
 class TemporalPipeTranslator:
     """Translate temporal declarations to native Kindling execution metadata."""
@@ -123,6 +139,7 @@ class TemporalPipeTranslator:
                 **(metadata.tags or {}),
                 "pipe_type": "temporal.base_event",
                 "temporal.kind": "base_event",
+                TEMPORAL_LOWERING_TAG: TEMPORAL_LOWERING_DECLARED,
                 "temporal.event_id": metadata.eventid,
                 "temporal.event_type": metadata.event_type,
                 "temporal.subject_type": metadata.subject_type,
@@ -142,6 +159,7 @@ class TemporalPipeTranslator:
                 **(metadata.tags or {}),
                 "pipe_type": "temporal.condition_engine",
                 "temporal.kind": "condition_engine",
+                TEMPORAL_LOWERING_TAG: TEMPORAL_LOWERING_DECLARED,
                 "temporal.engine_id": metadata.engineid,
             },
             "input_entity_ids": [
@@ -162,6 +180,7 @@ class TemporalPipeTranslator:
                 **(metadata.tags or {}),
                 "pipe_type": "temporal.episode",
                 "temporal.kind": "episode",
+                TEMPORAL_LOWERING_TAG: TEMPORAL_LOWERING_DECLARED,
                 "temporal.episode_id": metadata.episodeid,
                 "temporal.start_event": metadata.start_event,
                 "temporal.end_event": metadata.end_event,
@@ -182,6 +201,7 @@ class TemporalPipeTranslator:
                 **(metadata.tags or {}),
                 "pipe_type": "temporal.episode_event",
                 "temporal.kind": "episode_event",
+                TEMPORAL_LOWERING_TAG: TEMPORAL_LOWERING_DECLARED,
                 "temporal.episode_id": metadata.episodeid,
                 "temporal.event_type": metadata.determination_event,
                 "temporal.expiration_event_type": metadata.expiration_event,
@@ -259,7 +279,7 @@ class TemporalPipeTranslator:
             from kindling.spark_config import ConfigService
 
             enabled = GlobalInjector.get(ConfigService).get(cls.PRIOR_STATE_CONFIG_KEY, True)
-            if str(enabled).strip().lower() in ("false", "0", "no", "off"):
+            if not parse_bool_config(enabled, default=True):
                 return None
         except Exception:
             pass

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/validation.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/validation.py
@@ -243,6 +243,9 @@ class _NullPipeRegistry(DataPipesRegistry):
     def register_pipe(self, pipeid, **decorator_params):
         raise NotImplementedError("Temporal condition validation builds event-type graphs directly")
 
+    def unregister_pipe(self, pipeid):
+        raise NotImplementedError("Temporal condition validation builds event-type graphs directly")
+
     def get_pipe_ids(self):
         return []
 

--- a/packages/kindling/data_pipes.py
+++ b/packages/kindling/data_pipes.py
@@ -9,6 +9,8 @@ from typing import Any, Callable, Dict, List, Optional
 
 from delta.tables import DeltaTable
 from injector import Binder, Injector, inject, singleton
+from pyspark.sql import DataFrame
+
 from kindling.config_patterns import ConfigPatternMatcher
 from kindling.injection import *
 from kindling.sentinels import UNSET
@@ -17,7 +19,6 @@ from kindling.spark_config import ConfigService
 from kindling.spark_log_provider import *
 from kindling.spark_trace import *
 from kindling.trace_ops import COMPONENT_PIPES, tracing_gates
-from pyspark.sql import DataFrame
 
 from .data_entities import *
 from .data_entities import _raise_if_not_initialized
@@ -231,6 +232,10 @@ class DataPipesRegistry(ABC):
         pass
 
     @abstractmethod
+    def unregister_pipe(self, pipeid):
+        pass
+
+    @abstractmethod
     def get_pipe_ids(self):
         pass
 
@@ -296,6 +301,11 @@ class DataPipesManager(DataPipesRegistry):
         self._raw_params[pipeid] = dict(decorator_params)
         self.registry[pipeid] = self._build_metadata(pipeid, decorator_params)
         self.logger.debug(f"Pipe registered: {pipeid}")
+
+    def unregister_pipe(self, pipeid):
+        self.registry.pop(pipeid, None)
+        self._raw_params.pop(pipeid, None)
+        self.logger.debug(f"Pipe unregistered: {pipeid}")
 
     def apply_config_overrides(self, config_service: ConfigService) -> None:
         """Overlay the ``datapipes:`` config section onto registered pipes.
@@ -580,6 +590,17 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
         from contextlib import nullcontext
 
         from kindling.execution_orchestrator import ExecutionOrchestrator
+
+        # Mirrors the emission in _run_datapipes_sequential: DAG-mode runs
+        # never reach that method, so without this, before_run subscribers
+        # (e.g. the temporal extension's autocollapse hook) would never see
+        # a DAG-mode run at all.
+        self.emit(
+            "datapipes.before_run",
+            pipe_ids=pipes,
+            pipe_count=len(pipes),
+            run_id=str(uuid.uuid4()),
+        )
 
         orchestrator = GlobalInjector.get(ExecutionOrchestrator)
         overrides = self.dpe.tag_overrides(entity_tags) if entity_tags else nullcontext()

--- a/packages/kindling/test_framework.py
+++ b/packages/kindling/test_framework.py
@@ -715,6 +715,7 @@ class NotebookTestEnvironment:
                         self.logger = MagicMock()
 
                     self.register_pipe = MagicMock()
+                    self.unregister_pipe = MagicMock()
                     self.get_pipe_ids = MagicMock(return_value=[])
                     self.get_pipe_definition = MagicMock(return_value=MagicMock())
 

--- a/tests/unit/test_data_pipes.py
+++ b/tests/unit/test_data_pipes.py
@@ -8,6 +8,7 @@ from typing import Callable, Dict, List
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
+
 from kindling.data_entities import KindlingNotInitializedError
 from kindling.data_pipes import (
     DataPipes,
@@ -942,6 +943,35 @@ class TestDataPipesExecuter:
         assert kwargs["auto_cache"] is True
         assert kwargs["no_watermark"] is True
         assert kwargs["error_strategy"] is not None
+
+    def test_run_datapipes_dag_emits_before_run_signal(self):
+        """DAG-mode runs must emit datapipes.before_run too.
+
+        run_datapipes_dag never reaches _run_datapipes_sequential (the only
+        other emitter of this signal), so before_run subscribers -- e.g. the
+        temporal extension's autocollapse hook -- would otherwise never see
+        a DAG-mode run at all.
+        """
+        executer = DataPipesExecuter(
+            self.mock_logger_provider,
+            self.mock_entity_registry,
+            self.mock_pipes_registry,
+            self.mock_erps,
+            self.mock_trace_provider,
+        )
+        executer.emit = Mock(return_value=[])
+
+        with patch.object(
+            GlobalInjector, "get", return_value=Mock(execute=Mock(return_value="ok"))
+        ):
+            executer.run_datapipes_dag(["pipe1", "pipe2"])
+
+        executer.emit.assert_called_once()
+        args, kwargs = executer.emit.call_args
+        assert args[0] == "datapipes.before_run"
+        assert kwargs["pipe_ids"] == ["pipe1", "pipe2"]
+        assert kwargs["pipe_count"] == 2
+        assert "run_id" in kwargs
 
 
 class TestAbstractBaseClasses:

--- a/tests/unit/test_temporal_chain.py
+++ b/tests/unit/test_temporal_chain.py
@@ -1,0 +1,291 @@
+"""Unit coverage for collapse_temporal_chain and the autocollapse hook.
+
+Chain-graph correctness (the composite pipes reproducing per-pipe lowering
+semantics) is covered by tests/integration/test_temporal_chain_integration.py
+with real Spark data. This file covers the registry bookkeeping and signal
+wiring collapse_temporal_chain/_autocollapse_before_run own: which pipes get
+unregistered, what order survives, and that a declaration gap never crashes
+an unrelated run.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+EXTENSION_PACKAGE_ROOT = (
+    Path(__file__).resolve().parents[2] / "packages" / "extensions" / "kindling_ext_temporal"
+)
+
+
+@pytest.fixture(autouse=True)
+def _extension_package_on_path(monkeypatch):
+    monkeypatch.syspath_prepend(str(EXTENSION_PACKAGE_ROOT))
+
+
+def _logger_provider():
+    provider = MagicMock()
+    provider.get_logger.return_value = MagicMock()
+    return provider
+
+
+def _temporal_service_get(
+    *,
+    event_registry=None,
+    episode_registry=None,
+    entity_registry=None,
+    pipe_registry=None,
+):
+    from kindling_ext_temporal import (
+        SimpleTemporalEntityResolver,
+        TemporalEntityResolver,
+        TemporalEpisodeRegistry,
+        TemporalEpisodeRegistryManager,
+        TemporalEventRegistry,
+    )
+
+    from kindling.data_entities import DataEntityRegistry
+    from kindling.data_pipes import DataPipesRegistry
+
+    # declare_temporal_chain always consults the episode registry (for zero
+    # declared episodes, an empty one is correct), even when a test only
+    # cares about base events.
+    episode_registry = episode_registry or TemporalEpisodeRegistryManager(_logger_provider())
+
+    def _get(dep):
+        if dep is TemporalEntityResolver:
+            return SimpleTemporalEntityResolver()
+        if dep is TemporalEventRegistry and event_registry is not None:
+            return event_registry
+        if dep is TemporalEpisodeRegistry:
+            return episode_registry
+        if dep is DataEntityRegistry and entity_registry is not None:
+            return entity_registry
+        if dep is DataPipesRegistry and pipe_registry is not None:
+            return pipe_registry
+        raise AssertionError(f"Unexpected service request: {dep}")
+
+    return _get
+
+
+def _register_base_event(event_registry, entity_registry, pipe_registry, eventid):
+    from kindling_ext_temporal import DataEvents
+
+    DataEvents.reset()
+    with patch(
+        "kindling.injection.GlobalInjector.get",
+        side_effect=_temporal_service_get(
+            event_registry=event_registry,
+            entity_registry=entity_registry,
+            pipe_registry=pipe_registry,
+        ),
+    ):
+
+        @DataEvents.base_event(
+            eventid=eventid,
+            input_entity_id="bronze.telemetry",
+            subject_type="machine",
+            subject_keys=["machine_id"],
+            time_column="event_ts",
+            event_type="telemetry.observed",
+        )
+        def normalize(df):
+            return df
+
+
+def test_collapse_temporal_chain_unregisters_declared_pipes():
+    from kindling_ext_temporal import TemporalEventRegistryManager
+    from kindling_ext_temporal.chain import (
+        chain_events_pipe_id,
+        collapse_temporal_chain,
+    )
+
+    from kindling.data_entities import DataEntityManager
+    from kindling.data_pipes import DataPipesManager
+
+    event_registry = TemporalEventRegistryManager(_logger_provider())
+    entity_registry = DataEntityManager()
+    pipe_registry = DataPipesManager(_logger_provider())
+
+    _register_base_event(event_registry, entity_registry, pipe_registry, "telemetry.base")
+    declared_pipe = "temporal.event.telemetry.base"
+    assert pipe_registry.get_pipe_definition(declared_pipe) is not None
+
+    with patch(
+        "kindling.injection.GlobalInjector.get",
+        side_effect=_temporal_service_get(
+            event_registry=event_registry,
+            entity_registry=entity_registry,
+            pipe_registry=pipe_registry,
+        ),
+    ):
+        remaining = collapse_temporal_chain("t1")
+
+    assert pipe_registry.get_pipe_definition(declared_pipe) is None
+    events_pipe = chain_events_pipe_id("t1")
+    assert events_pipe in remaining
+    assert pipe_registry.get_pipe_definition(events_pipe).tags["temporal.lowering"] == "chain"
+
+    # Idempotent: nothing left tagged declared, second call just re-confirms
+    # the chain pipe.
+    with patch(
+        "kindling.injection.GlobalInjector.get",
+        side_effect=_temporal_service_get(
+            event_registry=event_registry,
+            entity_registry=entity_registry,
+            pipe_registry=pipe_registry,
+        ),
+    ):
+        remaining_again = collapse_temporal_chain("t1")
+    assert remaining_again == remaining
+
+
+class _FakePipeDef:
+    def __init__(self, tags):
+        self.tags = tags
+
+
+class _FakePipeRegistry:
+    def __init__(self, defs):
+        self._defs = dict(defs)
+
+    def get_pipe_ids(self):
+        return list(self._defs.keys())
+
+    def get_pipe_definition(self, pipeid):
+        return self._defs.get(pipeid)
+
+    def register_pipe(self, pipeid, **params):
+        self._defs[pipeid] = _FakePipeDef(params.get("tags", {}))
+
+    def unregister_pipe(self, pipeid):
+        self._defs.pop(pipeid, None)
+
+
+def test_autocollapse_before_run_preserves_registry_order_for_chain_additions():
+    """The fixed bug: chain_additions must come from the ORDERED collapse
+    result, not a set (which scrambles order under hash randomization)."""
+    from kindling_ext_temporal import chain as chain_module
+
+    declared_pipe = "temporal.event.telemetry"
+    episodes_chain = "temporal.chain.episodes.default"
+    events_chain = "temporal.chain.events.default"
+
+    # declared_pipe is still present at guard-check time -- the real
+    # collapse_temporal_chain() call (mocked below) is what would remove it;
+    # the handler's own guard only inspects current registry state.
+    registry = _FakePipeRegistry(
+        {
+            declared_pipe: _FakePipeDef({"temporal.lowering": "declared"}),
+            episodes_chain: _FakePipeDef({"temporal.lowering": "chain"}),
+            events_chain: _FakePipeDef({"temporal.lowering": "chain"}),
+        }
+    )
+
+    with (
+        patch.object(chain_module, "_autocollapse_enabled", return_value=True),
+        patch("kindling.injection.GlobalInjector.get", return_value=registry),
+        patch.object(
+            chain_module,
+            "collapse_temporal_chain",
+            # Deliberately episodes-before-events: proves the handler preserves
+            # whatever order collapse_temporal_chain returns rather than
+            # re-deriving its own (or scrambling it through a set).
+            return_value=[episodes_chain, events_chain],
+        ),
+    ):
+        pipe_ids = [declared_pipe]
+        chain_module._autocollapse_before_run(None, pipe_ids=pipe_ids)
+
+    assert pipe_ids == [episodes_chain, events_chain]
+
+
+def test_autocollapse_before_run_ignores_unrelated_runs():
+    """A run whose pipe_ids never touch a declared pipe must be untouched,
+    even if declared pipes exist elsewhere in the registry."""
+    from kindling_ext_temporal import chain as chain_module
+
+    registry = _FakePipeRegistry(
+        {
+            "temporal.event.telemetry": _FakePipeDef({"temporal.lowering": "declared"}),
+            "unrelated.pipe": _FakePipeDef({}),
+        }
+    )
+
+    collapse_spy = MagicMock()
+    with (
+        patch.object(chain_module, "_autocollapse_enabled", return_value=True),
+        patch("kindling.injection.GlobalInjector.get", return_value=registry),
+        patch.object(chain_module, "collapse_temporal_chain", collapse_spy),
+    ):
+        pipe_ids = ["unrelated.pipe"]
+        chain_module._autocollapse_before_run(None, pipe_ids=pipe_ids)
+
+    collapse_spy.assert_not_called()
+    assert pipe_ids == ["unrelated.pipe"]
+
+
+def test_autocollapse_before_run_swallows_collapse_failure():
+    """A declaration gap (e.g. episodes/condition-engines with zero base
+    events) makes collapse_temporal_chain raise -- that must never crash an
+    otherwise-unrelated run; the requested pipes just run uncollapsed."""
+    from kindling_ext_temporal import chain as chain_module
+
+    declared_pipe = "temporal.episode.foo"
+    registry = _FakePipeRegistry({declared_pipe: _FakePipeDef({"temporal.lowering": "declared"})})
+
+    def _raise(chainid="default"):
+        raise ValueError("no base events registered")
+
+    with (
+        patch.object(chain_module, "_autocollapse_enabled", return_value=True),
+        patch("kindling.injection.GlobalInjector.get", return_value=registry),
+        patch.object(chain_module, "collapse_temporal_chain", side_effect=_raise),
+    ):
+        pipe_ids = [declared_pipe]
+        chain_module._autocollapse_before_run(None, pipe_ids=pipe_ids)
+
+    assert pipe_ids == [declared_pipe]
+
+
+def test_autocollapse_disabled_leaves_pipe_ids_untouched():
+    from kindling_ext_temporal import chain as chain_module
+
+    with patch.object(chain_module, "_autocollapse_enabled", return_value=False):
+        pipe_ids = ["temporal.event.telemetry"]
+        chain_module._autocollapse_before_run(None, pipe_ids=pipe_ids)
+
+    assert pipe_ids == ["temporal.event.telemetry"]
+
+
+def test_ensure_autocollapse_connected_reconnects_after_provider_change():
+    """A rebuilt DI container hands out a new SignalProvider instance;
+    the hook must reconnect to it rather than staying attached to the old
+    one forever (the bug: a bare "connected once" flag would miss this)."""
+    from kindling_ext_temporal import chain as chain_module
+
+    chain_module._autocollapse_connected_provider = None
+    first_provider = MagicMock()
+    first_signal = MagicMock()
+    first_provider.get_signal.return_value = None
+    first_provider.create_signal.return_value = first_signal
+
+    with patch("kindling.injection.GlobalInjector.get", return_value=first_provider):
+        chain_module.ensure_autocollapse_connected()
+    first_signal.connect.assert_called_once()
+
+    with patch("kindling.injection.GlobalInjector.get", return_value=first_provider):
+        chain_module.ensure_autocollapse_connected()
+    # Same provider instance: no reconnect.
+    first_signal.connect.assert_called_once()
+
+    second_provider = MagicMock()
+    second_signal = MagicMock()
+    second_provider.get_signal.return_value = None
+    second_provider.create_signal.return_value = second_signal
+
+    with patch("kindling.injection.GlobalInjector.get", return_value=second_provider):
+        chain_module.ensure_autocollapse_connected()
+    second_signal.connect.assert_called_once()
+
+    chain_module._autocollapse_connected_provider = None

--- a/tests/unit/test_temporal_chain.py
+++ b/tests/unit/test_temporal_chain.py
@@ -200,6 +200,41 @@ def test_autocollapse_before_run_preserves_registry_order_for_chain_additions():
     assert pipe_ids == [episodes_chain, events_chain]
 
 
+def test_autocollapse_before_run_preserves_unknown_pipe_ids_verbatim():
+    """Copilot review finding on PR #218: survivors must drop exactly the
+    declared pipes collapse_temporal_chain removed -- never everything not
+    present in the post-collapse registry. An unrelated/typo'd pipe id in
+    the request (never registered at all, so also absent from the
+    post-collapse registry) must survive untouched, so run_datapipes still
+    fails loudly on it instead of autocollapse silently swallowing it."""
+    from kindling_ext_temporal import chain as chain_module
+
+    declared_pipe = "temporal.event.telemetry"
+    events_chain = "temporal.chain.events.default"
+    unknown_pipe = "typo.does_not_exist"
+
+    registry = _FakePipeRegistry(
+        {
+            declared_pipe: _FakePipeDef({"temporal.lowering": "declared"}),
+            events_chain: _FakePipeDef({"temporal.lowering": "chain"}),
+        }
+    )
+
+    with (
+        patch.object(chain_module, "_autocollapse_enabled", return_value=True),
+        patch("kindling.injection.GlobalInjector.get", return_value=registry),
+        patch.object(
+            chain_module,
+            "collapse_temporal_chain",
+            return_value=[events_chain],
+        ),
+    ):
+        pipe_ids = [declared_pipe, unknown_pipe]
+        chain_module._autocollapse_before_run(None, pipe_ids=pipe_ids)
+
+    assert pipe_ids == [unknown_pipe, events_chain]
+
+
 def test_autocollapse_before_run_ignores_unrelated_runs():
     """A run whose pipe_ids never touch a declared pipe must be untouched,
     even if declared pipes exist elsewhere in the registry."""


### PR DESCRIPTION
## What
Replaces `declare_temporal_chain()` as the go-to API with `collapse_temporal_chain()`, and adds a `kindling.temporal.autocollapse` config-gated hook so it fires automatically before execution — no manual call needed in app code.

## Why
`declare_temporal_chain()` only ever *added* the two composite chain pipes; it never removed the per-declaration base-event/condition-engine/episode/episode-event pipes it supersedes. A naive "run everything registered" then executed both lowerings over the same declarations — the per-declaration lowering is the broken, cyclic, multi-writer shape the chain exists to replace, so that combination was never actually wanted.

## Changes
- `collapse_temporal_chain(chainid="default")` (chain.py): does everything `declare_temporal_chain` does, then unregisters every pipe tagged `temporal.lowering=declared`, returning the corrected pipe id list.
- New `DataPipesRegistry.unregister_pipe()` primitive (`kindling.data_pipes`) — there was no removal method at all before this.
- New `kindling.temporal.autocollapse` config key (default `true`): a `datapipes.before_run` signal handler auto-collapses any `run_datapipes`/`run_datapipes_dag` call whose requested pipes reference a per-declaration temporal pipe. Wired lazily from the `DataEvents`/`DataEpisodes` declaration decorators (not at import time) to avoid DI/signal-provider bootstrap-ordering risk. `run_datapipes_dag` now also emits `datapipes.before_run` (previously only the sequential path did, so DAG-mode runs got no autocollapse at all).
- Every temporal pipe now carries a `temporal.lowering` tag (`declared`/`chain`), defined once in `translation.py` and exported, so pipes are identified by tag rather than by pipeid naming (`pipeid` is user-overridable via `metadata.pipeid`).
- `declare_temporal_chain()` is unchanged and still available for when you deliberately want both lowerings registered side by side (e.g. inspecting one hop in isolation with autocollapse disabled).

## Review
Two independent review passes (design/correctness + convention/maintainability) ran against this change. The first came back **CHANGES REQUESTED**: two CRITICAL bugs (autocollapse never firing for DAG-mode runs; a `set`-based ordering bug risking the episodes-chain pipe running before the events-chain pipe) plus several MAJOR/MINOR issues (signal-provider-rebuild reconnection, an uncaught-exception crash path, tag-key duplication between setter/reader, a black formatting failure). All were fixed and independently re-verified against the source; the re-review verdict is **APPROVED WITH NOTES** (one soft spot: the DAG-mode fix has no end-to-end, non-mocked test — code-inspection-verified only).

Known scope gap (unchanged, not addressed here): the Databricks SDP/Lakeflow engine path doesn't call `run_datapipes`, so autocollapse doesn't reach it — apps on that engine still call `collapse_temporal_chain()`/`declare_temporal_chain()` explicitly before SDP declares its dataset graph.

## Test plan
- [x] `poe test-unit` — 2333 passed, 1 skipped
- [x] `poe test-integration` — 125 passed, 1 skipped
- [x] `black`/`isort`/`flake8` clean on all changed files
- [x] 6 new unit tests added (`tests/unit/test_temporal_chain.py`, plus one in `tests/unit/test_data_pipes.py`) covering the ordering fix, unrelated-run scoping, exception-safety, autocollapse-disabled, provider-reconnect, and DAG-mode signal emission

Bead: kind-ec5.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)