### PR TITLE
fix(pipes): enforce the List[str] contract get_pipe_ids callers depend on

### DIFF
--- a/packages/kindling/data_entities.py
+++ b/packages/kindling/data_entities.py
@@ -8,12 +8,13 @@ from typing import Any, Callable, Dict, List, Optional
 
 from delta.tables import DeltaTable
 from injector import Binder, Injector, inject, singleton
+from pyspark.sql import DataFrame
+
 from kindling.config_patterns import ConfigPatternMatcher
 from kindling.injection import *
 from kindling.signaling import SignalEmitter, SignalProvider
 from kindling.spark_config import *
 from kindling.spark_log_provider import *
-from pyspark.sql import DataFrame
 
 _ENTITY_LOGGER = logging.getLogger("kindling.data_entities")
 
@@ -701,7 +702,14 @@ class DataEntityRegistry(ABC):
         pass
 
     @abstractmethod
-    def get_entity_ids(self):
+    def get_entity_ids(self) -> List[str]:
+        """Every registered entity id, as a plain list.
+
+        Implementations must return a real ``list``, never a live view
+        (e.g. ``dict.keys()``) over internal state -- see
+        ``DataPipesRegistry.get_pipe_ids()`` for why this matters even
+        when nothing currently mutates the result in place.
+        """
         pass
 
     @abstractmethod
@@ -965,8 +973,8 @@ class DataEntityManager(DataEntityRegistry, SignalEmitter):
                     companion_entity_id=companion_id,
                 )
 
-    def get_entity_ids(self):
-        return self.registry.keys()
+    def get_entity_ids(self) -> List[str]:
+        return list(self.registry.keys())
 
     def get_entity_definition(self, name):
         """Get entity definition with tag overrides applied.

--- a/packages/kindling/data_pipes.py
+++ b/packages/kindling/data_pipes.py
@@ -236,7 +236,14 @@ class DataPipesRegistry(ABC):
         pass
 
     @abstractmethod
-    def get_pipe_ids(self):
+    def get_pipe_ids(self) -> List[str]:
+        """Every registered pipe id, as a plain list.
+
+        Implementations must return a real ``list``, never a live view
+        (e.g. ``dict.keys()``) over internal state -- callers routinely
+        pass this straight into ``run_datapipes``/``run_datapipes_dag``,
+        which pass it on to signal handlers that mutate it in place.
+        """
         pass
 
     @abstractmethod
@@ -363,8 +370,8 @@ class DataPipesManager(DataPipesRegistry):
                 params[key] = raw_params[key]
         return PipeMetadata(pipeid, **params)
 
-    def get_pipe_ids(self):
-        return self.registry.keys()
+    def get_pipe_ids(self) -> List[str]:
+        return list(self.registry.keys())
 
     def get_pipe_definition(self, name):
         return self.registry.get(name)
@@ -417,6 +424,11 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
                 the call, then restore.
             **dag_kwargs: Additional DAG execution options
         """
+        # Enforce the List[str] contract the signature promises: callers
+        # routinely pass registry.get_pipe_ids() directly (a dict_keys view,
+        # not a list), which downstream code -- signal handlers mutating
+        # pipe_ids in place, index-based access -- cannot assume.
+        pipes = list(pipes)
         if use_dag:
             return self.run_datapipes_dag(
                 pipes,
@@ -590,6 +602,14 @@ class DataPipesExecuter(DataPipesExecution, SignalEmitter):
         from contextlib import nullcontext
 
         from kindling.execution_orchestrator import ExecutionOrchestrator
+
+        # Enforce the List[str] contract the signature promises: this is a
+        # public entry point callers invoke directly (not only via
+        # run_datapipes(use_dag=True)), and registry.get_pipe_ids() -- a
+        # dict_keys view, not a list -- is a common way to build the pipe
+        # list. before_run subscribers that mutate pipe_ids in place (e.g.
+        # the temporal extension's autocollapse hook) require a real list.
+        pipes = list(pipes)
 
         # Mirrors the emission in _run_datapipes_sequential: DAG-mode runs
         # never reach that method, so without this, before_run subscribers

--- a/packages/kindling/file_ingestion.py
+++ b/packages/kindling/file_ingestion.py
@@ -12,6 +12,9 @@ from typing import Any, Callable, Dict, List, Optional
 
 from delta.tables import DeltaTable
 from injector import Binder, Injector, inject, singleton
+from pyspark.sql import DataFrame
+from pyspark.sql.functions import current_timestamp, lit
+
 from kindling.data_entities import *
 from kindling.file_ingestion import *
 from kindling.injection import *
@@ -22,8 +25,6 @@ from kindling.spark_log_provider import *
 from kindling.spark_session import *
 from kindling.spark_trace import *
 from kindling.trace_ops import COMPONENT_INGESTION, tracing_gates
-from pyspark.sql import DataFrame
-from pyspark.sql.functions import current_timestamp, lit
 
 
 @dataclass
@@ -78,7 +79,14 @@ class FileIngestionRegistry(ABC):
         pass
 
     @abstractmethod
-    def get_entry_ids(self):
+    def get_entry_ids(self) -> List[str]:
+        """Every registered entry id, as a plain list.
+
+        Implementations must return a real ``list``, never a live view
+        (e.g. ``dict.keys()``) over internal state -- see
+        ``DataPipesRegistry.get_pipe_ids()`` for why this matters even
+        when nothing currently mutates the result in place.
+        """
         pass
 
     @abstractmethod
@@ -97,8 +105,8 @@ class FileIngestionManager(FileIngestionRegistry):
     def register_entry(self, entryId, **decorator_params):
         self.registry[entryId] = FileIngestionMetadata(entryId, **decorator_params)
 
-    def get_entry_ids(self):
-        return self.registry.keys()
+    def get_entry_ids(self) -> List[str]:
+        return list(self.registry.keys())
 
     def get_entry_definition(self, entryId):
         return self.registry.get(entryId)

--- a/tests/unit/test_data_entities.py
+++ b/tests/unit/test_data_entities.py
@@ -1006,8 +1006,16 @@ class TestDataEntitiesEdgeCases:
         assert entity is not None
         assert entity.entityid == "manual_entry"
 
-    def test_data_entity_manager_get_entity_ids_returns_dict_keys(self):
-        """Test that get_entity_ids returns a dict_keys view"""
+    def test_data_entity_manager_get_entity_ids_returns_a_plain_list_snapshot(self):
+        """get_entity_ids() must return a real list, not a dict.keys() view.
+
+        A live view is exactly the antipattern that caused a production bug
+        in the equivalent DataPipesRegistry.get_pipe_ids(): a signal handler
+        mutating the returned collection in place (slice assignment) crashes
+        on dict_keys, which doesn't support item assignment. The contract is
+        a static snapshot at call time -- it must NOT reflect later registry
+        changes.
+        """
         manager = DataEntityManager()
         manager.register_entity(
             "entity1", name="E1", partition_columns=[], merge_columns=[], tags={}, schema={}
@@ -1015,13 +1023,12 @@ class TestDataEntitiesEdgeCases:
 
         entity_ids = manager.get_entity_ids()
 
-        # Should be dict_keys type
-        assert hasattr(entity_ids, "__iter__"), "get_entity_ids should return iterable"
+        assert isinstance(entity_ids, list)
+        entity_ids[:] = entity_ids  # must support slice assignment
 
-        # Should be dynamically updated when registry changes
         manager.register_entity(
             "entity2", name="E2", partition_columns=[], merge_columns=[], tags={}, schema={}
         )
 
-        # The dict_keys view should reflect the change
-        assert len(list(entity_ids)) == 2, "dict_keys view should reflect registry updates"
+        # Snapshot at call time -- later registrations must NOT appear.
+        assert entity_ids == ["entity1"]

--- a/tests/unit/test_data_pipes.py
+++ b/tests/unit/test_data_pipes.py
@@ -971,7 +971,62 @@ class TestDataPipesExecuter:
         assert args[0] == "datapipes.before_run"
         assert kwargs["pipe_ids"] == ["pipe1", "pipe2"]
         assert kwargs["pipe_count"] == 2
-        assert "run_id" in kwargs
+
+    def test_run_datapipes_dag_accepts_dict_keys_view(self):
+        """Production bug: callers routinely build the pipe list from
+        registry.get_pipe_ids() directly (a dict_keys view), not
+        list(registry.get_pipe_ids()) -- e.g. `orchestrator.run_datapipes_dag
+        (registry.get_pipe_ids())`. A before_run subscriber that mutates
+        pipe_ids in place via slice assignment (pipe_ids[:] = ...) then
+        crashes with 'dict_keys object does not support item assignment'.
+        run_datapipes_dag must coerce to a real list itself rather than
+        trusting the type hint."""
+        executer = DataPipesExecuter(
+            self.mock_logger_provider,
+            self.mock_entity_registry,
+            self.mock_pipes_registry,
+            self.mock_erps,
+            self.mock_trace_provider,
+        )
+
+        def _mutate_in_place(sender, *, pipe_ids=None, **kwargs):
+            pipe_ids[:] = list(pipe_ids) + ["extra"]
+
+        executer.emit = Mock(side_effect=_mutate_in_place)
+        mock_orchestrator = Mock()
+        mock_orchestrator.execute.return_value = "ok"
+
+        pipe_ids_view = {"pipe1": None, "pipe2": None}.keys()
+        with patch.object(GlobalInjector, "get", return_value=mock_orchestrator):
+            result = executer.run_datapipes_dag(pipe_ids_view)
+
+        assert result == "ok"
+        kwargs = mock_orchestrator.execute.call_args.kwargs
+        assert kwargs["pipe_ids"] == ["pipe1", "pipe2", "extra"]
+
+    def test_run_datapipes_accepts_dict_keys_view_sequential_and_dag(self):
+        """Same coercion, through the run_datapipes(use_dag=...) facade for
+        both the sequential and DAG paths."""
+        executer = DataPipesExecuter(
+            self.mock_logger_provider,
+            self.mock_entity_registry,
+            self.mock_pipes_registry,
+            self.mock_erps,
+            self.mock_trace_provider,
+        )
+        executer.run_datapipes_dag = Mock(return_value="dag-result")
+        pipe_ids_view = {"pipe1": None}.keys()
+
+        executer.run_datapipes(pipe_ids_view, use_dag=True)
+        called_with = executer.run_datapipes_dag.call_args.args[0]
+        assert called_with == ["pipe1"]
+        assert isinstance(called_with, list)
+
+        executer._run_datapipes_sequential = Mock(return_value=None)
+        executer.run_datapipes(pipe_ids_view, use_dag=False)
+        called_with = executer._run_datapipes_sequential.call_args.args[0]
+        assert called_with == ["pipe1"]
+        assert isinstance(called_with, list)
 
 
 class TestAbstractBaseClasses:

--- a/tests/unit/test_data_pipes.py
+++ b/tests/unit/test_data_pipes.py
@@ -971,6 +971,7 @@ class TestDataPipesExecuter:
         assert args[0] == "datapipes.before_run"
         assert kwargs["pipe_ids"] == ["pipe1", "pipe2"]
         assert kwargs["pipe_count"] == 2
+        assert "run_id" in kwargs
 
     def test_run_datapipes_dag_accepts_dict_keys_view(self):
         """Production bug: callers routinely build the pipe list from

--- a/tests/unit/test_file_ingestion.py
+++ b/tests/unit/test_file_ingestion.py
@@ -35,6 +35,34 @@ def test_metadata_accepts_static_values_dict():
     assert m.static_values == {"source": "system_a", "region": "us-east-1"}
 
 
+def test_file_ingestion_manager_get_entry_ids_returns_a_plain_list_snapshot():
+    """get_entry_ids() must return a real list, not a dict.keys() view.
+
+    A live view is exactly the antipattern that caused a production bug in
+    the equivalent DataPipesRegistry.get_pipe_ids(): a signal handler
+    mutating the returned collection in place (slice assignment) crashes on
+    dict_keys, which doesn't support item assignment. The contract is a
+    static snapshot at call time -- it must NOT reflect later registrations.
+    """
+    from kindling.file_ingestion import FileIngestionManager
+
+    manager = FileIngestionManager(MagicMock())
+    manager.register_entry(
+        "entry1", name="E1", patterns=[".*\\.csv"], dest_entity_id="dest", tags={}
+    )
+
+    entry_ids = manager.get_entry_ids()
+
+    assert isinstance(entry_ids, list)
+    entry_ids[:] = entry_ids  # must support slice assignment
+
+    manager.register_entry(
+        "entry2", name="E2", patterns=[".*\\.json"], dest_entity_id="dest", tags={}
+    )
+
+    assert entry_ids == ["entry1"]
+
+
 def test_metadata_field_is_optional():
     """static_values must have a default so it is not in the required-fields set."""
     from kindling.file_ingestion import FileIngestionMetadata


### PR DESCRIPTION
## What
Fixes a production crash: `run_datapipes_dag(registry.get_pipe_ids())` — a real, direct call site — raised `TypeError: 'dict_keys' object does not support item assignment`.

## Why
`DataPipesRegistry.get_pipe_ids()` returned `self.registry.keys()`, a live `dict_keys` view over the registry's internal dict, not a real list. The new `kindling.temporal.autocollapse` signal handler (from #218) mutates the received `pipe_ids` in place via slice assignment (`pipe_ids[:] = ...`) — which `dict_keys` doesn't support.

The `pipes: List[str]` type hint on `run_datapipes`/`run_datapipes_dag` has existed since March; nothing ever enforced it, so real callers never had to honor it. Every other consumer only ever *iterated* over the result, which works identically whether the underlying object is a list, a set, a `dict_keys` view, or a tuple — that's exactly why this went unnoticed until a handler needed real list/mutation semantics.

## Changes
- `DataPipesRegistry.get_pipe_ids()` now returns `list(self.registry.keys())` instead of the raw view.
- `run_datapipes`/`run_datapipes_dag` coerce their `pipes` argument via `list(pipes)` at entry, so the `datapipes.before_run` signal payload is always a real list regardless of what the caller passed.
- Audited the rest of the codebase for the same pattern (a `get_*_ids()`-style method returning a live registry view instead of a list). Found two structural twins with no live bug yet, but the same latent gap — fixed both proactively:
  - `DataEntityManager.get_entity_ids()`
  - `FileIngestionManager.get_entry_ids()`
  - One existing test (`test_data_entity_manager_get_entity_ids_returns_dict_keys`) had explicitly encoded the old live-view behavior as an intended feature ("dict_keys view should reflect registry updates") — rewritten to assert the correct contract (a static list snapshot).

Confirmed safe: no call site anywhere in the repo relies on set-operation semantics (`&`, `|`, `-`) on any of these methods' return values — every existing consumer either already wraps in `list()`/`sorted()`, or only iterates (for which a list behaves identically, and is actually *safer* than a live view since it can't raise "dictionary changed size during iteration").

## Test plan
- [x] `poe test-unit` — 2337 passed, 1 skipped
- [x] `poe test-integration` — 125 passed, 1 skipped
- [x] New regression tests reproducing the exact reported traceback (`dict_keys` passed through `run_datapipes_dag` with a real in-place-mutating handler attached) plus coverage for `get_entity_ids`/`get_entry_ids`'s new snapshot contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)