### PR TITLE
fix(temporal): guard ingest_conditions() merge call for non-merge-capable providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to spark-kindling are documented here.
 
+## Unreleased
+
+### Fixed
+
+- **`ingest_conditions()` no longer crashes with a raw `AttributeError`
+  against a non-merge-capable provider** (gh#221):
+  `kindling_ext_temporal.conditions.ingest_conditions()` called
+  `provider_factory(entity).merge_to_entity(...)` unconditionally. It now
+  raises a clear `ValueError` naming the entity and provider type when the
+  resolved provider does not implement `merge_to_entity` (csv, parquet, sql,
+  adx today), matching the existing guard in
+  `simple_read_persist_strategy.py`.
+
 ## [0.12.3] - 2026-07-29
 
 ### Added

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/conditions.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/conditions.py
@@ -260,7 +260,15 @@ def ingest_conditions(
             for row in valid_rows
         ]
         valid_df = conditions_df.sparkSession.createDataFrame(stamped, conditions_entity_schema())
-        provider_factory(entity).merge_to_entity(valid_df, entity)
+        provider = provider_factory(entity)
+        if not hasattr(provider, "merge_to_entity"):
+            provider_type = (entity.tags or {}).get("provider_type", "unknown")
+            raise ValueError(
+                f"Entity '{entity.entityid}': ingest_conditions() requires a "
+                f"merge-capable provider, but provider '{provider_type}' does "
+                "not support merge operations"
+            )
+        provider.merge_to_entity(valid_df, entity)
 
     quarantined = duplicates + list(report.invalid_conditions) + too_deep
     if quarantine_entity_id is UNSET:

--- a/tests/integration/test_temporal_extension_integration.py
+++ b/tests/integration/test_temporal_extension_integration.py
@@ -878,6 +878,16 @@ class _RecordingProvider:
         self.appended.append((df, entity))
 
 
+class _NonMergingProvider:
+    """A provider double with no merge_to_entity — e.g. csv/parquet/sql/adx today."""
+
+    def __init__(self):
+        self.appended = []
+
+    def append_to_entity(self, df, entity):
+        self.appended.append((df, entity))
+
+
 def _conditions_rows_df(spark, rows):
     from kindling_ext_temporal import conditions_schema
 
@@ -1023,6 +1033,41 @@ def test_ingest_conditions_raises_on_event_type_graph_cycle(spark):
             provider_factory=lambda entity: provider,
         )
     assert provider.merged == []
+
+
+@pytest.mark.requires_spark
+def test_ingest_conditions_raises_for_non_merge_capable_provider(spark):
+    from kindling_ext_temporal import SimpleTemporalEntityResolver, ingest_conditions
+
+    observed_at = datetime(2026, 7, 14, 12, 0, 0)
+    rows = [
+        (
+            "condition.temperature_high",
+            ["telemetry.observed"],
+            "machine",
+            {
+                "enter_when": "cast(payload['temperature'] as double) > 90",
+                "exit_when": "cast(payload['temperature'] as double) <= 90",
+            },
+            True,
+            observed_at,
+            None,
+        ),
+    ]
+    provider = _NonMergingProvider()
+
+    with pytest.raises(ValueError) as exc_info:
+        ingest_conditions(
+            _conditions_rows_df(spark, rows),
+            resolver=SimpleTemporalEntityResolver(),
+            provider_factory=lambda entity: provider,
+            quarantine_entity_id=None,
+        )
+
+    message = str(exc_info.value)
+    assert "silver.conditions" in message
+    assert "merge-capable provider" in message
+    assert provider.appended == []
 
 
 @pytest.mark.requires_spark


### PR DESCRIPTION
## Summary

`merge_to_entity` isn't a formal interface anywhere in `entity_provider.py` — it's ad-hoc/duck-typed, and only providers that choose to implement it do (today: only `DeltaEntityProvider`). Every other caller in the framework treats "provider doesn't support merge" as an expected, guarded condition (e.g. `simple_read_persist_strategy.py:323-338` raises a clear `ValueError` up front), but `kindling_ext_temporal/conditions.py:263` called `provider_factory(entity).merge_to_entity(...)` with no guard — pointing `ingest_conditions()` at any non-merge-capable provider (memory, csv, parquet, sql, adx today) crashed with a raw `AttributeError` deep in the call stack instead of a legible message.

## Changes

- `ingest_conditions()` (`conditions.py`) now checks `hasattr(provider, "merge_to_entity")` before the merge call and raises a clear `ValueError` naming the entity and provider type when absent, matching the existing guarded style in `simple_read_persist_strategy.py`.
- New integration regression test (`test_ingest_conditions_raises_for_non_merge_capable_provider`) covering the guarded path against a non-merging provider double.
- `CHANGELOG.md` `Unreleased/Fixed` entry.

## Test plan
- [x] `poe test-unit` — 2336 passed, 2 skipped
- [x] `PYTEST_ADDOPTS='-k test_ingest_conditions_raises_for_non_merge_capable_provider' poe test-integration` — 1 passed
- [x] Internal review: APPROVE, no blockers — guard placement matches the DESIGN note exactly (inside `if valid_rows:`, before the merge call, outside the quarantine try/except); error-message convention matches the established precedent in `simple_read_persist_strategy.py`
- [x] gitleaks scan of push range: clean

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)
