### PR TITLE
feat(temporal): add registry-declared condition sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to spark-kindling are documented here.
 
+## Unreleased
+
+### Added
+
+- **Registry-declared temporal conditions** (`kindling_ext_temporal`, gh#222):
+  a second, explicit `condition_source` for condition engines, alongside the
+  existing table-backed rules-as-data path.
+  - `DataConditions.register(...)`: declares a static, application-owned
+    condition directly in Python — `enter_when`/`exit_when` are
+    `Callable[[DataFrame], Column]` predicate builders invoked with the
+    scoped events DataFrame at execution time, rather than serialized SQL
+    strings. Required fields and duplicate `condition_id`s raise
+    `ConditionValidationError` immediately (registry conditions are code,
+    not data, and fail fast rather than being quarantined).
+  - `DataEvents.condition_engine(..., condition_source="registry")`:
+    evaluates the condition registry's current contents instead of the
+    table-backed conditions entity — zero conditions table/entity
+    involvement. `condition_source="table"` (the default, unchanged) keeps
+    reading rows from the configured current conditions entity.
+    Event-type graph cycles in the registry are rejected at this
+    declaration call. `declare_temporal_chain()`/`collapse_temporal_chain()`
+    omit the conditions-current input entirely for a chain whose declared
+    condition engines are all registry-sourced, and raise if a table rule
+    and a registry rule combine into a cross-source event-type cycle.
+  - Both sources normalize to the same `ConditionRule` representation and
+    emit the same `{condition_id}.entered`/`.exited` boundary events through
+    `ConditionEngineRunner`, so a table rule and a registry rule can execute
+    side by side in the same pass.
+  - Existing table-backed declarations, entities, schemas, and chain
+    behavior are unchanged.
+
 ## [0.12.3] - 2026-07-29
 
 ### Added

--- a/docs/proposals/temporal_condition_sources.md
+++ b/docs/proposals/temporal_condition_sources.md
@@ -1,0 +1,230 @@
+# Temporal Condition Sources
+
+## Status
+
+Proposed.
+
+## Context
+
+The temporal extension currently uses one concept, Condition, for two
+different kinds of content:
+
+1. A condition engine is declared in Python through
+   `DataEvents.condition_engine()`.
+2. The condition rules evaluated by that engine are loaded from the current
+   view of the `silver.conditions` table.
+
+The second path is intentionally rules-as-data. It supports high-cardinality
+and frequently changing rules, SCD2 history, ingestion validation, and
+quarantine. It is not the right representation for a small set of static
+application rules, especially when those rules should use native PySpark
+expressions rather than serialized SQL strings.
+
+## Decision
+
+Support two explicit condition sources:
+
+- `table`: rules are loaded from the configured current conditions entity.
+- `registry`: rules are declared in application code and held in the temporal
+  condition registry.
+
+The source is part of condition-engine metadata. An engine has one source; it
+does not silently union registry rules with table rows.
+
+The existing table source remains the default so current applications retain
+their behavior:
+
+```python
+DataEvents.condition_engine(engineid="default")
+# Equivalent to condition_source="table"
+```
+
+The explicit form is:
+
+```python
+DataEvents.condition_engine(
+    engineid="dynamic_conditions",
+    condition_source="table",
+)
+```
+
+## Registry-declared conditions
+
+Condition content should have its own declaration namespace rather than
+making `DataEvents.condition()` look like an event normalizer. A proposed API
+is:
+
+```python
+from pyspark.sql import Column, DataFrame
+from pyspark.sql import functions as F
+
+from kindling_ext_temporal import DataConditions, DataEvents
+
+
+def temperature(events: DataFrame) -> Column:
+    return events["payload"].getItem("temperature").cast("double")
+
+
+def overheat_enter(events: DataFrame) -> Column:
+    return temperature(events) > F.lit(90)
+
+
+def overheat_exit(events: DataFrame) -> Column:
+    return temperature(events) <= F.lit(90)
+
+
+DataConditions.register(
+    condition_id="condition.system_overheat",
+    consumes_event_type=["telemetry.observed"],
+    subject_type="machine",
+    enter_when=overheat_enter,
+    exit_when=overheat_exit,
+)
+
+DataEvents.condition_engine(
+    engineid="static_conditions",
+    condition_source="registry",
+)
+```
+
+`enter_when` and `exit_when` are predicate builders with the shape
+`Callable[[DataFrame], Column]`. The builder is called with the scoped events
+DataFrame at execution time. The registry stores the callable, not a
+DataFrame-bound `Column`, so declarations do not capture a Spark session or a
+particular execution plan.
+
+The registry path is intended for static, application-owned rules. A registry
+condition is not ingested, versioned, or quarantined as a row in
+`silver.conditions`.
+
+## Table-backed conditions
+
+The table path remains the current rules-as-data interface:
+
+```python
+from kindling_ext_temporal import conditions_schema, ingest_conditions
+
+
+conditions_df = spark.createDataFrame(
+    [
+        (
+            "condition.machine_threshold",
+            ["telemetry.observed"],
+            "machine",
+            {
+                "enter_when": "cast(payload['temperature'] as double) > 75",
+                "exit_when": "cast(payload['temperature'] as double) <= 75",
+            },
+            True,
+            None,
+            None,
+        )
+    ],
+    conditions_schema(),
+)
+
+ingest_conditions(conditions_df)
+
+DataEvents.condition_engine(
+    engineid="table_conditions",
+    condition_source="table",
+)
+```
+
+The lowered table-backed pipe continues to depend on both the events entity
+and the configured current conditions entity. `ingest_conditions()` keeps its
+existing validation, SCD2, duplicate detection, graph-cycle detection, and
+quarantine behavior.
+
+## Shared execution model
+
+Both sources normalize to the same internal condition representation:
+
+- condition ID;
+- consumed event types;
+- subject type;
+- enabled and business-validity state where applicable;
+- an enter predicate;
+- an exit predicate.
+
+The condition engine continues to scope events by subject and consumed event
+type, evaluate enter and exit predicates, and emit the same canonical boundary
+events:
+
+```text
+{condition_id}.entered
+{condition_id}.exited
+```
+
+For table rows, the predicates remain serialized Spark SQL expressions. For
+registry definitions, the engine invokes the PySpark predicate builders and
+passes their returned `Column` objects to `DataFrame.filter()`.
+
+The registry path must preserve Spark laziness: builders may construct
+columns and expressions, but must not call actions, collect data, or mutate
+the DataFrame. A builder must return a boolean `Column`; arbitrary joins or
+DataFrame-to-DataFrame transformations are outside this predicate API and
+need a separate condition-evaluation path.
+
+## Validation and failure behavior
+
+Registry declarations are code and should fail fast rather than be
+quarantined:
+
+- required metadata and duplicate condition IDs are validated during
+  registration;
+- event-type graph cycles are rejected when the registry is validated for an
+  engine;
+- predicate-builder errors, or a non-`Column` return value, fail the registry
+  engine execution clearly.
+
+Table rows retain their current behavior: malformed rows can be quarantined
+by ingestion, and invalid table SQL is rejected by the existing validation
+pass.
+
+## Mixed-source policy
+
+An engine must specify one source. Applications that need both use two engine
+declarations, normally with distinct condition IDs:
+
+```python
+DataEvents.condition_engine(
+    engineid="static_conditions",
+    condition_source="registry",
+)
+DataEvents.condition_engine(
+    engineid="dynamic_conditions",
+    condition_source="table",
+)
+```
+
+Condition IDs must be unique across both engines because they determine the
+boundary event types and event IDs. A future `combined` mode could define
+explicit precedence and duplicate handling, but implicit merging is unsafe
+and is not part of this proposal.
+
+## Compatibility and migration
+
+- Existing calls to `DataEvents.condition_engine()` continue to mean
+  table-backed conditions.
+- Existing condition entities, schemas, ingestion functions, and current
+  views remain unchanged.
+- New registry declarations do not require a conditions table or a synthetic
+  placeholder row.
+- Chain lowering must carry the selected source: registry-backed chains read
+  only events, while table-backed chains retain the conditions-current input.
+- Episode declarations and downstream consumers continue to consume the same
+  boundary event contract.
+
+## Non-goals
+
+This proposal does not add:
+
+- dynamic Python code stored in a table;
+- automatic merging of static and dynamic rules;
+- arbitrary DataFrame transforms inside a condition predicate;
+- a replacement for the existing table-backed rules-as-data model.
+
+## Tracking
+
+Implementation tracking: `kind-ec5.6`.

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/__init__.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/__init__.py
@@ -27,9 +27,12 @@ from .entities import (
 from .registry import (
     BaseEventMetadata,
     ConditionEngineMetadata,
+    DataConditions,
     DataEpisodes,
     DataEvents,
     EpisodeMetadata,
+    TemporalConditionRegistry,
+    TemporalConditionRegistryManager,
     TemporalEpisodeRegistry,
     TemporalEpisodeRegistryManager,
     TemporalEventRegistry,
@@ -67,6 +70,7 @@ __all__ = [
     "ConditionValidationReport",
     "ConditionsIngestionResult",
     "QUARANTINE_ENTITY_CONFIG_KEY",
+    "DataConditions",
     "DataEpisodes",
     "DataEvents",
     "EpisodeMetadata",
@@ -76,6 +80,8 @@ __all__ = [
     "TEMPORAL_LOWERING_CHAIN",
     "TEMPORAL_LOWERING_DECLARED",
     "TEMPORAL_LOWERING_TAG",
+    "TemporalConditionRegistry",
+    "TemporalConditionRegistryManager",
     "TemporalConditionValidator",
     "TemporalEntityResolver",
     "TemporalEpisodeRegistry",
@@ -97,13 +103,15 @@ __version__ = "0.2.5"
 def _register_services():
     """Register extension services with Kindling's DI container."""
     from injector import singleton
-
     from kindling.injection import GlobalInjector
 
     injector = GlobalInjector.get_injector()
     injector.binder.bind(TemporalEventRegistry, to=TemporalEventRegistryManager, scope=singleton)
     injector.binder.bind(
         TemporalEpisodeRegistry, to=TemporalEpisodeRegistryManager, scope=singleton
+    )
+    injector.binder.bind(
+        TemporalConditionRegistry, to=TemporalConditionRegistryManager, scope=singleton
     )
 
 

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/chain.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/chain.py
@@ -62,7 +62,11 @@ from kindling.data_pipes import DataPipesRegistry
 from kindling.injection import GlobalInjector
 
 from .entities import TemporalEntityResolver
-from .registry import TemporalEpisodeRegistry, TemporalEventRegistry
+from .registry import (
+    TemporalConditionRegistry,
+    TemporalEpisodeRegistry,
+    TemporalEventRegistry,
+)
 from .translation import (
     TEMPORAL_LOWERING_CHAIN,
     TEMPORAL_LOWERING_DECLARED,
@@ -119,25 +123,46 @@ def _resolve_max_generations(entity_dfs: Dict[str, Any]) -> int:
     return int(value)
 
 
-def _chain_events_execute(driving_entity_id, conditions_current_id, base_defs, episode_defs):
-    """Build the events-chain body: strata in memory, one returned frame."""
+def _chain_events_execute(
+    driving_entity_id,
+    conditions_current_id,
+    base_defs,
+    episode_defs,
+    *,
+    has_table_engine,
+    has_registry_engine,
+):
+    """Build the events-chain body: strata in memory, one returned frame.
+
+    ``conditions_current_id`` is ``None`` for a purely-registry chain (at
+    least one condition engine declared, none of them table-sourced) — the
+    conditions entity is never read at all in that case. A chain with zero
+    declared condition engines still receives a real
+    ``conditions_current_id`` (pre-existing behavior, left untouched — that
+    edge case isn't part of this feature), so gating the table read on
+    ``conditions_current_id is not None`` (rather than on
+    ``has_table_engine``) is what keeps it unchanged.
+
+    ``has_table_engine``/``has_registry_engine`` reflect which kinds of
+    condition engine are actually declared for this chain; they gate
+    whether registry rules are pulled in and whether the cross-source cycle
+    check below runs.
+    """
 
     def execute(**entity_dfs):
         driving_key = driving_entity_id.replace(".", "_")
-        conditions_key = conditions_current_id.replace(".", "_")
         try:
             driving_df = entity_dfs[driving_key]
-            conditions_df = entity_dfs[conditions_key]
         except KeyError as exc:
             available = ", ".join(sorted(entity_dfs.keys()))
             raise ValueError(
-                f"Temporal events chain expected inputs '{driving_key}' and "
-                f"'{conditions_key}', got: {available}"
+                f"Temporal events chain expected input '{driving_key}', got: {available}"
             ) from exc
 
         from .engine import ConditionEngineRunner, EpisodeRunner
         from .validation import (
             ActiveSparkSqlExpressionParser,
+            ConditionValidationError,
             TemporalConditionValidator,
         )
 
@@ -155,10 +180,41 @@ def _chain_events_execute(driving_entity_id, conditions_current_id, base_defs, e
             )
         )
 
-        validator = TemporalConditionValidator(
-            expression_parser=ActiveSparkSqlExpressionParser(driving_df.sparkSession)
+        table_rules: List[Any] = []
+        if conditions_current_id is not None:
+            conditions_key = conditions_current_id.replace(".", "_")
+            try:
+                conditions_df = entity_dfs[conditions_key]
+            except KeyError as exc:
+                available = ", ".join(sorted(entity_dfs.keys()))
+                raise ValueError(
+                    f"Temporal events chain expected input '{conditions_key}', got: {available}"
+                ) from exc
+            validator = TemporalConditionValidator(
+                expression_parser=ActiveSparkSqlExpressionParser(driving_df.sparkSession)
+            )
+            table_rules = validator.validate_or_raise(conditions_df.collect()).valid_rules
+
+        registry_rules = (
+            GlobalInjector.get(TemporalConditionRegistry).get_all_conditions()
+            if has_registry_engine
+            else []
         )
-        valid_rules = validator.validate_or_raise(conditions_df.collect()).valid_rules
+        combined_rules = table_rules + registry_rules
+
+        # Each source validates its own rules in isolation -- table rows via
+        # validate_or_raise above, registry rules at condition_engine()
+        # declaration time (registry.py). Neither ever checks a rule from
+        # ONE source consuming a produced event type from the OTHER: the one
+        # genuinely new cross-source interaction this feature introduces, so
+        # it is checked here, once, whenever both kinds of engine are
+        # declared on this chain.
+        if has_table_engine and has_registry_engine and combined_rules:
+            cross_validator = TemporalConditionValidator()
+            graph = cross_validator.build_event_type_graph(combined_rules)
+            cycles = cross_validator.graph_builder.detect_cycles(graph)
+            if cycles:
+                raise ConditionValidationError(f"Conditions set is not ingestible:\n{cycles[0]}")
 
         # Prior episode state is resolved ONCE, before anything persists —
         # both this pipe's determination events and (later) the episodes
@@ -174,8 +230,8 @@ def _chain_events_execute(driving_entity_id, conditions_current_id, base_defs, e
         for _ in range(_resolve_max_generations(entity_dfs)):
             fresh: List[Any] = []
 
-            if valid_rules:
-                boundaries = _checkpoint(engine.execute_rules(stratum, valid_rules))
+            if combined_rules:
+                boundaries = _checkpoint(engine.execute_rules(stratum, combined_rules))
                 if not boundaries.isEmpty():
                     accumulated = accumulated.unionByName(boundaries)
                     fresh.append(boundaries)
@@ -281,21 +337,44 @@ def declare_temporal_chain(chainid: str = "default") -> List[str]:
         )
     driving_entity_id = driving_entities[0]
 
+    # A chain with zero declared condition engines still wires the
+    # conditions entity unconditionally -- pre-existing behavior, left
+    # untouched (that edge case isn't part of this feature). A chain with at
+    # least one declared engine omits it only when EVERY declared engine is
+    # registry-sourced: a purely-registry chain reads events only, per the
+    # proposal's compatibility section.
+    engine_defs = [
+        event_registry.get_condition_engine_definition(engineid)
+        for engineid in event_registry.get_condition_engine_ids()
+    ]
+    has_table_engine = any(metadata.condition_source == "table" for metadata in engine_defs)
+    has_registry_engine = any(metadata.condition_source == "registry" for metadata in engine_defs)
+    include_conditions_current = not engine_defs or has_table_engine
+
     events_entity = resolver.get_events_entity()
-    conditions_entity = resolver.get_conditions_entity()
-    conditions_tags = conditions_entity.tags or {}
-    conditions_current_id = conditions_tags.get(
-        "scd.current_entity_id", f"{conditions_entity.entityid}.current"
-    )
     TemporalPipeTranslator.ensure_entity(entity_registry, events_entity)
-    TemporalPipeTranslator.ensure_entity(entity_registry, conditions_entity)
+
+    conditions_current_id = None
+    if include_conditions_current:
+        conditions_entity = resolver.get_conditions_entity()
+        conditions_current_id = resolver.get_conditions_current_entity_id()
+        TemporalPipeTranslator.ensure_entity(entity_registry, conditions_entity)
+
+    events_input_entity_ids = [driving_entity_id]
+    if conditions_current_id is not None:
+        events_input_entity_ids.append(conditions_current_id)
 
     events_pipe = chain_events_pipe_id(chainid)
     pipe_registry.register_pipe(
         events_pipe,
         name=f"Temporal events chain: {chainid}",
         execute=_chain_events_execute(
-            driving_entity_id, conditions_current_id, base_defs, episode_defs
+            driving_entity_id,
+            conditions_current_id,
+            base_defs,
+            episode_defs,
+            has_table_engine=has_table_engine,
+            has_registry_engine=has_registry_engine,
         ),
         tags={
             "pipe_type": "temporal.chain_events",
@@ -304,7 +383,7 @@ def declare_temporal_chain(chainid: str = "default") -> List[str]:
             "temporal.chain_id": chainid,
             "temporal.reads_prior_state": "true",
         },
-        input_entity_ids=[driving_entity_id, conditions_current_id],
+        input_entity_ids=events_input_entity_ids,
         output_entity_id=events_entity.entityid,
         output_type=(events_entity.tags or {}).get("provider_type", "delta"),
         use_watermark=True,

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/engine.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/engine.py
@@ -27,6 +27,13 @@ class ConditionEngineRunner:
         The chain executor validates the conditions set once per run and
         drives this per generation stratum; ``execute`` keeps the
         validate-every-call behavior for independent pipe execution.
+
+        A rule's ``enter_when``/``exit_when`` is either a table row's
+        serialized Spark SQL string (already parsed at validation time) or a
+        registry rule's ``Callable[[DataFrame], Column]`` predicate builder
+        (see ``DataConditions.register``) -- ``_condition_column`` resolves
+        either shape to a boolean ``Column``, so both sources execute
+        side by side through the exact same loop below.
         """
         if not valid_rules:
             return events_df.sparkSession.createDataFrame([], events_schema())
@@ -36,7 +43,7 @@ class ConditionEngineRunner:
             scoped = self._scope_events(events_df, rule)
             outputs.append(
                 self._boundary_events(
-                    scoped.filter(rule.parameters["enter_when"]),
+                    scoped.filter(self._condition_column(scoped, rule, "enter_when")),
                     rule,
                     boundary="entered",
                     event_type=rule.entered_event_type,
@@ -44,7 +51,7 @@ class ConditionEngineRunner:
             )
             outputs.append(
                 self._boundary_events(
-                    scoped.filter(rule.parameters["exit_when"]),
+                    scoped.filter(self._condition_column(scoped, rule, "exit_when")),
                     rule,
                     boundary="exited",
                     event_type=rule.exited_event_type,
@@ -52,6 +59,30 @@ class ConditionEngineRunner:
             )
 
         return reduce(lambda left, right: left.unionByName(right), outputs)
+
+    @staticmethod
+    def _condition_column(scoped, rule, key: str):
+        """Resolve ``rule.parameters[key]`` to a boolean Column.
+
+        A table row's predicate is already a Spark SQL string (passed
+        through unchanged -- ``DataFrame.filter`` accepts either a string or
+        a ``Column``). A registry rule's predicate is a callable; it is
+        invoked here, against the scoped events frame, so the builder is
+        called at execution time, never at declaration time.
+        """
+        from pyspark.sql import Column
+
+        predicate = rule.parameters[key]
+        if not callable(predicate):
+            return predicate
+
+        condition_col = predicate(scoped)
+        if not isinstance(condition_col, Column):
+            raise TypeError(
+                f"Condition '{rule.condition_id}' {key} builder returned "
+                f"{type(condition_col).__name__}, expected a Column"
+            )
+        return condition_col
 
     @staticmethod
     def _scope_events(events_df, rule):

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/entities.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/entities.py
@@ -122,6 +122,19 @@ class TemporalEntityResolver(ABC):
     def get_episodes_entity(self) -> Any:
         pass
 
+    def get_conditions_current_entity_id(self) -> str:
+        """Return the id of this app's current-conditions view entity.
+
+        Concrete (not abstract): a resolver gets a working default derived
+        from ``get_conditions_entity()`` for free and only needs to override
+        this when its current-view naming convention differs. Kept as one
+        shared helper so table-sourced condition-engine registration
+        (``registry.py``) and chain lowering (``chain.py``) can never derive
+        this id differently from each other.
+        """
+        entity = self.get_conditions_entity()
+        return (entity.tags or {}).get("scd.current_entity_id", f"{entity.entityid}.current")
+
 
 @GlobalInjector.singleton_autobind()
 class SimpleTemporalEntityResolver(TemporalEntityResolver):

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/registry.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/registry.py
@@ -5,14 +5,19 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
 from injector import inject
-
 from kindling.data_entities import DataEntityRegistry
 from kindling.data_pipes import DataPipesRegistry
 from kindling.injection import GlobalInjector
 from kindling.spark_log_provider import PythonLoggerProvider
+from pyspark.sql import Column, DataFrame
 
 from .entities import TemporalEntityResolver
 from .translation import TemporalPipeTranslator
+from .validation import (
+    ConditionRule,
+    ConditionValidationError,
+    TemporalConditionValidator,
+)
 
 
 @dataclass
@@ -38,8 +43,9 @@ class BaseEventMetadata:
 class ConditionEngineMetadata:
     engineid: str
     events_entity_id: str
-    conditions_entity_id: str
-    conditions_current_entity_id: str
+    condition_source: str = "table"
+    conditions_entity_id: Optional[str] = None
+    conditions_current_entity_id: Optional[str] = None
     name: Optional[str] = None
     pipeid: Optional[str] = None
     output_type: str = "delta"
@@ -108,6 +114,38 @@ class TemporalEpisodeRegistry(ABC):
 
     @abstractmethod
     def get_episode_definition(self, episodeid: str) -> Optional[EpisodeMetadata]:
+        pass
+
+
+class TemporalConditionRegistry(ABC):
+    """Holds registry-declared Conditions (see ``DataConditions.register``).
+
+    Deliberately stricter than ``TemporalEventRegistry``/
+    ``TemporalEpisodeRegistry`` above: those two silently overwrite on a
+    duplicate id and do no required-field checking beyond the dataclass
+    constructor. Registry conditions are code, not data, so they are
+    expected to fail fast -- duplicate ids and missing fields raise instead
+    of overwriting or deferring to execution time.
+    """
+
+    @abstractmethod
+    def register_condition(self, rule: ConditionRule) -> None:
+        pass
+
+    @abstractmethod
+    def get_condition_ids(self) -> List[str]:
+        pass
+
+    @abstractmethod
+    def get_condition_definition(self, condition_id: str) -> Optional[ConditionRule]:
+        pass
+
+    @abstractmethod
+    def get_all_conditions(self) -> List[ConditionRule]:
+        pass
+
+    @abstractmethod
+    def reset(self) -> None:
         pass
 
 
@@ -185,21 +223,65 @@ class DataEvents:
         return decorator
 
     @classmethod
-    def condition_engine(cls, *, engineid: str, tags: Optional[Dict[str, str]] = None):
-        """Register the generic rules-as-data condition engine."""
+    def condition_engine(
+        cls,
+        *,
+        engineid: str,
+        tags: Optional[Dict[str, str]] = None,
+        condition_source: str = "table",
+    ):
+        """Register the generic rules-as-data condition engine.
+
+        ``condition_source`` selects where this engine's rules come from --
+        an engine has exactly one source, never a silent union of both:
+
+        - ``"table"`` (default): unchanged from the original behavior. Rules
+          are read from the configured current conditions entity, which is
+          resolved/ensured and wired as an input alongside the events
+          entity.
+        - ``"registry"``: rules are read from the in-process condition
+          registry (see ``DataConditions.register``) instead. No conditions
+          entity is resolved, ensured, or wired -- zero table/entity
+          involvement. Because this is the moment an engine commits to
+          consuming the registry, the registry's *current* contents are
+          checked for event-type graph cycles right now rather than
+          deferred to chain/pipe execution; a condition registered after
+          this call is a known, accepted gap (not revalidated later).
+        """
+        if condition_source not in ("table", "registry"):
+            raise ValueError(
+                f"Temporal condition engine '{engineid}': condition_source must be "
+                f"'table' or 'registry', got {condition_source!r}"
+            )
+
         events_entity = cls._resolver().get_events_entity()
-        conditions_entity = cls._resolver().get_conditions_entity()
-        conditions_entity_tags = conditions_entity.tags or {}
-        conditions_current_entity_id = conditions_entity_tags.get(
-            "scd.current_entity_id", f"{conditions_entity.entityid}.current"
-        )
         entity_registry = cls._data_entity_registry()
         TemporalPipeTranslator.ensure_entity(entity_registry, events_entity)
-        TemporalPipeTranslator.ensure_entity(entity_registry, conditions_entity)
+
+        conditions_entity = None
+        conditions_entity_id = None
+        conditions_current_entity_id = None
+        if condition_source == "table":
+            conditions_entity = cls._resolver().get_conditions_entity()
+            conditions_entity_id = conditions_entity.entityid
+            conditions_current_entity_id = cls._resolver().get_conditions_current_entity_id()
+            TemporalPipeTranslator.ensure_entity(entity_registry, conditions_entity)
+        else:
+            registry_rules = GlobalInjector.get(TemporalConditionRegistry).get_all_conditions()
+            if registry_rules:
+                validator = TemporalConditionValidator()
+                graph = validator.build_event_type_graph(registry_rules)
+                cycles = validator.graph_builder.detect_cycles(graph)
+                if cycles:
+                    raise ConditionValidationError(
+                        f"Conditions set is not ingestible:\n{cycles[0]}"
+                    )
+
         cls._registry().register_condition_engine(
             engineid,
             events_entity_id=events_entity.entityid,
-            conditions_entity_id=conditions_entity.entityid,
+            condition_source=condition_source,
+            conditions_entity_id=conditions_entity_id,
             conditions_current_entity_id=conditions_current_entity_id,
             tags=tags or {},
         )
@@ -216,6 +298,76 @@ class DataEvents:
             conditions_entity=conditions_entity,
         )
         _ensure_autocollapse_connected()
+
+
+class DataConditions:
+    """Declaration namespace for registry-declared temporal Conditions.
+
+    Unlike ``DataEvents``/``DataEpisodes``, registering a condition here does
+    not lower to a Kindling pipe by itself -- it only ever populates the
+    in-process condition registry. A condition only takes effect once a
+    ``DataEvents.condition_engine(condition_source="registry")`` reads the
+    registry's current contents (see registry.py's ``condition_engine``).
+    """
+
+    @classmethod
+    def reset(cls) -> None:
+        cls._registry().reset()
+
+    @classmethod
+    def _registry(cls) -> TemporalConditionRegistry:
+        return GlobalInjector.get(TemporalConditionRegistry)
+
+    @classmethod
+    def register(
+        cls,
+        *,
+        condition_id: str,
+        consumes_event_type: List[str],
+        subject_type: str,
+        enter_when: Callable[[DataFrame], Column],
+        exit_when: Callable[[DataFrame], Column],
+        enabled: bool = True,
+        valid_from: Optional[Any] = None,
+        valid_to: Optional[Any] = None,
+    ) -> None:
+        """Register a static, application-owned condition.
+
+        ``enter_when``/``exit_when`` are predicate builders shaped
+        ``Callable[[DataFrame], Column]``. The registry stores the callable
+        itself, not a DataFrame-bound ``Column`` -- the builder is invoked
+        with the scoped events DataFrame at condition-engine execution time
+        (see ``ConditionEngineRunner``), so a registration never captures a
+        Spark session or a particular execution plan.
+
+        Required metadata and a duplicate ``condition_id`` both raise
+        ``ConditionValidationError`` immediately: registry conditions are
+        code, not data, and are expected to fail fast rather than be
+        quarantined like a malformed table row.
+        """
+        if not condition_id or not condition_id.strip():
+            raise ConditionValidationError("condition_id is required")
+        if not subject_type or not subject_type.strip():
+            raise ConditionValidationError("subject_type is required")
+        if not consumes_event_type:
+            raise ConditionValidationError(
+                "consumes_event_type must contain at least one event type"
+            )
+        if not callable(enter_when):
+            raise ConditionValidationError("enter_when must be callable")
+        if not callable(exit_when):
+            raise ConditionValidationError("exit_when must be callable")
+
+        rule = ConditionRule(
+            condition_id=condition_id,
+            consumes_event_type=list(consumes_event_type),
+            subject_type=subject_type,
+            parameters={"enter_when": enter_when, "exit_when": exit_when},
+            enabled=enabled,
+            valid_from=valid_from,
+            valid_to=valid_to,
+        )
+        cls._registry().register_condition(rule)
 
 
 class DataEpisodes:
@@ -341,6 +493,33 @@ class TemporalEpisodeRegistryManager(TemporalEpisodeRegistry):
 
     def get_episode_definition(self, episodeid: str) -> Optional[EpisodeMetadata]:
         return self.episodes.get(episodeid)
+
+
+class TemporalConditionRegistryManager(TemporalConditionRegistry):
+    @inject
+    def __init__(self, logger_provider: PythonLoggerProvider):
+        self.logger = logger_provider.get_logger("TemporalConditionRegistryManager")
+        self._conditions: Dict[str, ConditionRule] = {}
+
+    def register_condition(self, rule: ConditionRule) -> None:
+        if rule.condition_id in self._conditions:
+            raise ConditionValidationError(
+                f"Duplicate condition_id '{rule.condition_id}' already registered"
+            )
+        self._conditions[rule.condition_id] = rule
+        self.logger.debug(f"Temporal condition registered: {rule.condition_id}")
+
+    def get_condition_ids(self) -> List[str]:
+        return list(self._conditions.keys())
+
+    def get_condition_definition(self, condition_id: str) -> Optional[ConditionRule]:
+        return self._conditions.get(condition_id)
+
+    def get_all_conditions(self) -> List[ConditionRule]:
+        return list(self._conditions.values())
+
+    def reset(self) -> None:
+        self._conditions.clear()
 
 
 def _ensure_autocollapse_connected() -> None:

--- a/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/translation.py
+++ b/packages/extensions/kindling_ext_temporal/kindling_ext_temporal/translation.py
@@ -152,6 +152,14 @@ class TemporalPipeTranslator:
 
     @classmethod
     def condition_engine_pipe_params(cls, metadata: "ConditionEngineMetadata") -> Dict[str, Any]:
+        if metadata.condition_source == "registry":
+            input_entity_ids = [metadata.events_entity_id]
+        else:
+            input_entity_ids = [
+                metadata.events_entity_id,
+                metadata.conditions_current_entity_id,
+            ]
+
         return {
             "name": metadata.name or f"Temporal condition engine: {metadata.engineid}",
             "execute": cls.condition_engine_execute(metadata),
@@ -162,10 +170,7 @@ class TemporalPipeTranslator:
                 TEMPORAL_LOWERING_TAG: TEMPORAL_LOWERING_DECLARED,
                 "temporal.engine_id": metadata.engineid,
             },
-            "input_entity_ids": [
-                metadata.events_entity_id,
-                metadata.conditions_current_entity_id,
-            ],
+            "input_entity_ids": input_entity_ids,
             "output_entity_id": metadata.events_entity_id,
             "output_type": metadata.output_type,
             "use_watermark": metadata.use_watermark,
@@ -351,9 +356,27 @@ class TemporalPipeTranslator:
 
         def execute(**entity_dfs):
             events_key = metadata.events_entity_id.replace(".", "_")
-            conditions_key = metadata.conditions_current_entity_id.replace(".", "_")
             try:
                 events_df = entity_dfs[events_key]
+            except KeyError as exc:
+                available = ", ".join(sorted(entity_dfs.keys()))
+                raise ValueError(
+                    f"Temporal condition engine '{metadata.engineid}' expected "
+                    f"input '{events_key}', got: {available}"
+                ) from exc
+
+            from .engine import ConditionEngineRunner
+
+            if metadata.condition_source == "registry":
+                from kindling.injection import GlobalInjector
+
+                from .registry import TemporalConditionRegistry
+
+                registry_rules = GlobalInjector.get(TemporalConditionRegistry).get_all_conditions()
+                return ConditionEngineRunner().execute_rules(events_df, registry_rules)
+
+            conditions_key = metadata.conditions_current_entity_id.replace(".", "_")
+            try:
                 conditions_df = entity_dfs[conditions_key]
             except KeyError as exc:
                 available = ", ".join(sorted(entity_dfs.keys()))
@@ -361,8 +384,6 @@ class TemporalPipeTranslator:
                     f"Temporal condition engine '{metadata.engineid}' expected "
                     f"inputs '{events_key}' and '{conditions_key}', got: {available}"
                 ) from exc
-
-            from .engine import ConditionEngineRunner
 
             return ConditionEngineRunner().execute(events_df, conditions_df)
 

--- a/tests/integration/test_temporal_chain_integration.py
+++ b/tests/integration/test_temporal_chain_integration.py
@@ -306,3 +306,266 @@ def test_chain_cross_run_revision_with_prior_state(spark, temporal_graph):
     # The corrective .closed determination event is in run 2's event output.
     types_2 = {row.event_type for row in events_2.collect()}
     assert "episode.temperature_high_active.closed" in types_2
+
+
+# --- gh#222: registry-declared temporal conditions in the chain lowering -----
+
+
+def _base_event_services(
+    event_registry, episode_registry, condition_registry, entity_registry, pipe_registry
+):
+    from kindling.data_entities import DataEntityRegistry
+    from kindling.data_pipes import DataPipesRegistry
+    from kindling_ext_temporal import (
+        SimpleTemporalEntityResolver,
+        TemporalConditionRegistry,
+        TemporalEntityResolver,
+        TemporalEpisodeRegistry,
+        TemporalEventRegistry,
+    )
+
+    return _service_get(
+        {
+            TemporalEntityResolver: SimpleTemporalEntityResolver(),
+            TemporalEventRegistry: event_registry,
+            TemporalEpisodeRegistry: episode_registry,
+            TemporalConditionRegistry: condition_registry,
+            DataEntityRegistry: entity_registry,
+            DataPipesRegistry: pipe_registry,
+        }
+    )
+
+
+def test_chain_registry_only_produces_boundary_events_without_conditions_table(spark):
+    """End-to-end registry-only chain: DataConditions.register(...) +
+    DataEvents.condition_engine(condition_source="registry") ->
+    declare_temporal_chain() -> execute -> {condition_id}.entered/.exited
+    boundary events appear, with no conditions table ever created or read."""
+    from kindling.data_entities import DataEntityManager
+    from kindling.data_pipes import DataPipesManager
+    from kindling_ext_temporal import (
+        DataConditions,
+        DataEvents,
+        TemporalConditionRegistryManager,
+        TemporalEpisodeRegistryManager,
+        TemporalEventRegistryManager,
+        declare_temporal_chain,
+    )
+
+    DataEvents.reset()
+    event_registry = TemporalEventRegistryManager(_logger_provider())
+    episode_registry = TemporalEpisodeRegistryManager(_logger_provider())
+    condition_registry = TemporalConditionRegistryManager(_logger_provider())
+    entity_registry = DataEntityManager()
+    pipe_registry = DataPipesManager(_logger_provider())
+
+    services = _base_event_services(
+        event_registry, episode_registry, condition_registry, entity_registry, pipe_registry
+    )
+
+    with patch("kindling.injection.GlobalInjector.get", side_effect=services):
+
+        @DataEvents.base_event(
+            eventid="telemetry.base",
+            input_entity_id="bronze.telemetry",
+            subject_type="machine",
+            subject_keys=["machine_id"],
+            time_column="reading_ts",
+            event_type="telemetry.observed",
+            payload_columns=["temperature"],
+        )
+        def normalize(df):
+            return df
+
+        DataConditions.register(
+            condition_id="condition.registry_overheat",
+            consumes_event_type=["telemetry.observed"],
+            subject_type="machine",
+            enter_when=lambda events: events["payload"]["temperature"].cast("double") > 90,
+            exit_when=lambda events: events["payload"]["temperature"].cast("double") <= 90,
+        )
+        DataEvents.condition_engine(engineid="static_conditions", condition_source="registry")
+
+        chain_pipe_ids = declare_temporal_chain("registry_only")
+        events_pipe = pipe_registry.get_pipe_definition(chain_pipe_ids[0])
+
+        # Wiring: no conditions table/entity is ever created or read.
+        assert events_pipe.input_entity_ids == ["bronze.telemetry"]
+        assert entity_registry.get_entity_definition("silver.conditions") is None
+        assert entity_registry.get_entity_definition("silver.conditions.current") is None
+
+        telemetry = spark.createDataFrame([("machine-1", T0, 95.0)], TELEMETRY_COLUMNS)
+        result = events_pipe.execute(bronze_telemetry=telemetry)
+
+    event_types = {row.event_type for row in result.collect()}
+    assert "condition.registry_overheat.entered" in event_types
+
+
+def test_chain_mixed_table_and_registry_engines_both_produce_boundary_events(spark):
+    """Both rule sets independently produce correct boundary events in a
+    single combined chain-events run."""
+    from kindling.data_entities import DataEntityManager
+    from kindling.data_pipes import DataPipesManager
+    from kindling_ext_temporal import (
+        DataConditions,
+        DataEvents,
+        TemporalConditionRegistryManager,
+        TemporalEpisodeRegistryManager,
+        TemporalEventRegistryManager,
+        conditions_schema,
+        declare_temporal_chain,
+    )
+
+    DataEvents.reset()
+    event_registry = TemporalEventRegistryManager(_logger_provider())
+    episode_registry = TemporalEpisodeRegistryManager(_logger_provider())
+    condition_registry = TemporalConditionRegistryManager(_logger_provider())
+    entity_registry = DataEntityManager()
+    pipe_registry = DataPipesManager(_logger_provider())
+
+    services = _base_event_services(
+        event_registry, episode_registry, condition_registry, entity_registry, pipe_registry
+    )
+
+    with patch("kindling.injection.GlobalInjector.get", side_effect=services):
+
+        @DataEvents.base_event(
+            eventid="telemetry.base",
+            input_entity_id="bronze.telemetry",
+            subject_type="machine",
+            subject_keys=["machine_id"],
+            time_column="reading_ts",
+            event_type="telemetry.observed",
+            payload_columns=["temperature"],
+        )
+        def normalize(df):
+            return df
+
+        DataConditions.register(
+            condition_id="condition.registry_overheat",
+            consumes_event_type=["telemetry.observed"],
+            subject_type="machine",
+            enter_when=lambda events: events["payload"]["temperature"].cast("double") > 90,
+            exit_when=lambda events: events["payload"]["temperature"].cast("double") <= 90,
+        )
+        DataEvents.condition_engine(engineid="static_conditions", condition_source="registry")
+        DataEvents.condition_engine(engineid="dynamic_conditions", condition_source="table")
+
+        chain_pipe_ids = declare_temporal_chain("mixed")
+        events_pipe = pipe_registry.get_pipe_definition(chain_pipe_ids[0])
+        assert events_pipe.input_entity_ids == ["bronze.telemetry", "silver.conditions.current"]
+
+        telemetry = spark.createDataFrame([("machine-1", T0, 95.0)], TELEMETRY_COLUMNS)
+        # valid_from is non-nullable in conditions_schema(); a time strictly
+        # before the telemetry event keeps the rule in scope for it.
+        valid_from = datetime(2026, 7, 14, 11, 0, 0)
+        conditions_df = spark.createDataFrame(
+            [
+                (
+                    "condition.table_humidity",
+                    ["telemetry.observed"],
+                    "machine",
+                    {
+                        "enter_when": "cast(payload['temperature'] as double) > 80",
+                        "exit_when": "cast(payload['temperature'] as double) <= 80",
+                    },
+                    True,
+                    valid_from,
+                    None,
+                ),
+            ],
+            conditions_schema(),
+        )
+        result = events_pipe.execute(
+            bronze_telemetry=telemetry, silver_conditions_current=conditions_df
+        )
+
+    event_types = {row.event_type for row in result.collect()}
+    assert "condition.registry_overheat.entered" in event_types
+    assert "condition.table_humidity.entered" in event_types
+
+
+def test_chain_cross_source_cycle_raises_even_though_neither_rule_is_cyclic_alone(spark):
+    """A table rule consuming a registry rule's produced event type (or vice
+    versa) is the one interaction neither source's own isolated validation
+    ever checks: table rows validate via validate_or_raise, registry rules
+    validate at condition_engine() declaration time, and neither looks at
+    the OTHER source's current rules. The combined graph is only checked
+    once both kinds of engine are declared AND the events-chain pipe
+    actually executes (chain.py's _chain_events_execute)."""
+    from kindling.data_entities import DataEntityManager
+    from kindling.data_pipes import DataPipesManager
+    from kindling_ext_temporal import (
+        ConditionValidationError,
+        DataConditions,
+        DataEvents,
+        TemporalConditionRegistryManager,
+        TemporalEpisodeRegistryManager,
+        TemporalEventRegistryManager,
+        conditions_schema,
+        declare_temporal_chain,
+    )
+
+    DataEvents.reset()
+    event_registry = TemporalEventRegistryManager(_logger_provider())
+    episode_registry = TemporalEpisodeRegistryManager(_logger_provider())
+    condition_registry = TemporalConditionRegistryManager(_logger_provider())
+    entity_registry = DataEntityManager()
+    pipe_registry = DataPipesManager(_logger_provider())
+
+    services = _base_event_services(
+        event_registry, episode_registry, condition_registry, entity_registry, pipe_registry
+    )
+
+    with patch("kindling.injection.GlobalInjector.get", side_effect=services):
+
+        @DataEvents.base_event(
+            eventid="telemetry.base",
+            input_entity_id="bronze.telemetry",
+            subject_type="machine",
+            subject_keys=["machine_id"],
+            time_column="reading_ts",
+            event_type="telemetry.observed",
+            payload_columns=["temperature"],
+        )
+        def normalize(df):
+            return df
+
+        # condition.table_rule consumes condition.registry_rule's produced
+        # boundary type, and vice versa -- a 2-node cycle spanning both
+        # sources. Neither rule is cyclic when checked against its own
+        # source alone (confirmed by the declaration calls below succeeding).
+        DataConditions.register(
+            condition_id="condition.registry_rule",
+            consumes_event_type=["condition.table_rule.entered"],
+            subject_type="machine",
+            enter_when=lambda events: events["payload"]["temperature"].cast("double") > 90,
+            exit_when=lambda events: events["payload"]["temperature"].cast("double") <= 90,
+        )
+        DataEvents.condition_engine(engineid="dynamic_conditions", condition_source="table")
+        DataEvents.condition_engine(engineid="static_conditions", condition_source="registry")
+
+        chain_pipe_ids = declare_temporal_chain("cross")
+        events_pipe = pipe_registry.get_pipe_definition(chain_pipe_ids[0])
+
+        # valid_from is non-nullable in conditions_schema(); a time strictly
+        # before the telemetry event keeps the rule in scope for it.
+        valid_from = datetime(2026, 7, 14, 11, 0, 0)
+        conditions_df = spark.createDataFrame(
+            [
+                (
+                    "condition.table_rule",
+                    ["condition.registry_rule.entered"],
+                    "machine",
+                    {"enter_when": "true", "exit_when": "false"},
+                    True,
+                    valid_from,
+                    None,
+                ),
+            ],
+            conditions_schema(),
+        )
+        telemetry = spark.createDataFrame([("machine-1", T0, 95.0)], TELEMETRY_COLUMNS)
+
+        with pytest.raises(ConditionValidationError, match="Conditions set is not ingestible"):
+            events_pipe.execute(bronze_telemetry=telemetry, silver_conditions_current=conditions_df)

--- a/tests/unit/test_temporal_chain.py
+++ b/tests/unit/test_temporal_chain.py
@@ -33,19 +33,20 @@ def _temporal_service_get(
     *,
     event_registry=None,
     episode_registry=None,
+    condition_registry=None,
     entity_registry=None,
     pipe_registry=None,
 ):
+    from kindling.data_entities import DataEntityRegistry
+    from kindling.data_pipes import DataPipesRegistry
     from kindling_ext_temporal import (
         SimpleTemporalEntityResolver,
+        TemporalConditionRegistry,
         TemporalEntityResolver,
         TemporalEpisodeRegistry,
         TemporalEpisodeRegistryManager,
         TemporalEventRegistry,
     )
-
-    from kindling.data_entities import DataEntityRegistry
-    from kindling.data_pipes import DataPipesRegistry
 
     # declare_temporal_chain always consults the episode registry (for zero
     # declared episodes, an empty one is correct), even when a test only
@@ -59,6 +60,8 @@ def _temporal_service_get(
             return event_registry
         if dep is TemporalEpisodeRegistry:
             return episode_registry
+        if dep is TemporalConditionRegistry and condition_registry is not None:
+            return condition_registry
         if dep is DataEntityRegistry and entity_registry is not None:
             return entity_registry
         if dep is DataPipesRegistry and pipe_registry is not None:
@@ -94,14 +97,13 @@ def _register_base_event(event_registry, entity_registry, pipe_registry, eventid
 
 
 def test_collapse_temporal_chain_unregisters_declared_pipes():
+    from kindling.data_entities import DataEntityManager
+    from kindling.data_pipes import DataPipesManager
     from kindling_ext_temporal import TemporalEventRegistryManager
     from kindling_ext_temporal.chain import (
         chain_events_pipe_id,
         collapse_temporal_chain,
     )
-
-    from kindling.data_entities import DataEntityManager
-    from kindling.data_pipes import DataPipesManager
 
     event_registry = TemporalEventRegistryManager(_logger_provider())
     entity_registry = DataEntityManager()
@@ -138,6 +140,106 @@ def test_collapse_temporal_chain_unregisters_declared_pipes():
     ):
         remaining_again = collapse_temporal_chain("t1")
     assert remaining_again == remaining
+
+
+# --- gh#222: registry-declared temporal conditions in declare_temporal_chain -
+
+
+def test_declare_temporal_chain_with_zero_condition_engines_still_includes_conditions_current():
+    """Pre-existing behavior, deliberately left untouched by gh#222: a chain
+    with no declared condition engine at all still wires the conditions
+    entity unconditionally. Only a chain with at least one declared engine,
+    every one of them registry-sourced, omits it (see the next test)."""
+    from kindling.data_entities import DataEntityManager
+    from kindling.data_pipes import DataPipesManager
+    from kindling_ext_temporal import TemporalEventRegistryManager
+    from kindling_ext_temporal.chain import declare_temporal_chain
+
+    event_registry = TemporalEventRegistryManager(_logger_provider())
+    entity_registry = DataEntityManager()
+    pipe_registry = DataPipesManager(_logger_provider())
+
+    _register_base_event(event_registry, entity_registry, pipe_registry, "telemetry.base")
+
+    with patch(
+        "kindling.injection.GlobalInjector.get",
+        side_effect=_temporal_service_get(
+            event_registry=event_registry,
+            entity_registry=entity_registry,
+            pipe_registry=pipe_registry,
+        ),
+    ):
+        declare_temporal_chain("t1")
+
+    events_pipe = pipe_registry.get_pipe_definition("temporal.chain.events.t1")
+    assert events_pipe.input_entity_ids == ["bronze.telemetry", "silver.conditions.current"]
+
+
+def test_declare_temporal_chain_registry_only_omits_conditions_current():
+    from kindling.data_entities import DataEntityManager
+    from kindling.data_pipes import DataPipesManager
+    from kindling_ext_temporal import DataEvents, TemporalEventRegistryManager
+    from kindling_ext_temporal.chain import declare_temporal_chain
+
+    DataEvents.reset()
+    event_registry = TemporalEventRegistryManager(_logger_provider())
+    entity_registry = DataEntityManager()
+    pipe_registry = DataPipesManager(_logger_provider())
+    condition_registry = MagicMock()
+    condition_registry.get_all_conditions.return_value = []
+
+    _register_base_event(event_registry, entity_registry, pipe_registry, "telemetry.base")
+
+    with patch(
+        "kindling.injection.GlobalInjector.get",
+        side_effect=_temporal_service_get(
+            event_registry=event_registry,
+            entity_registry=entity_registry,
+            pipe_registry=pipe_registry,
+            condition_registry=condition_registry,
+        ),
+    ):
+        DataEvents.condition_engine(engineid="static_conditions", condition_source="registry")
+        declare_temporal_chain("t1")
+
+    events_pipe = pipe_registry.get_pipe_definition("temporal.chain.events.t1")
+    assert events_pipe.input_entity_ids == ["bronze.telemetry"]
+    assert entity_registry.get_entity_definition("silver.conditions") is None
+    assert entity_registry.get_entity_definition("silver.conditions.current") is None
+
+
+def test_declare_temporal_chain_mixed_sources_still_includes_conditions_current():
+    from kindling.data_entities import DataEntityManager
+    from kindling.data_pipes import DataPipesManager
+    from kindling_ext_temporal import DataEvents, TemporalEventRegistryManager
+    from kindling_ext_temporal.chain import declare_temporal_chain
+
+    DataEvents.reset()
+    event_registry = TemporalEventRegistryManager(_logger_provider())
+    entity_registry = DataEntityManager()
+    pipe_registry = DataPipesManager(_logger_provider())
+    condition_registry = MagicMock()
+    condition_registry.get_all_conditions.return_value = []
+
+    _register_base_event(event_registry, entity_registry, pipe_registry, "telemetry.base")
+
+    with patch(
+        "kindling.injection.GlobalInjector.get",
+        side_effect=_temporal_service_get(
+            event_registry=event_registry,
+            entity_registry=entity_registry,
+            pipe_registry=pipe_registry,
+            condition_registry=condition_registry,
+        ),
+    ):
+        DataEvents.condition_engine(engineid="dynamic_conditions", condition_source="table")
+        DataEvents.condition_engine(engineid="static_conditions", condition_source="registry")
+        declare_temporal_chain("t1")
+
+    events_pipe = pipe_registry.get_pipe_definition("temporal.chain.events.t1")
+    assert events_pipe.input_entity_ids == ["bronze.telemetry", "silver.conditions.current"]
+    assert entity_registry.get_entity_definition("silver.conditions") is not None
+    assert entity_registry.get_entity_definition("silver.conditions.current") is not None
 
 
 class _FakePipeDef:

--- a/tests/unit/test_temporal_extension.py
+++ b/tests/unit/test_temporal_extension.py
@@ -24,6 +24,7 @@ def _temporal_service_get(
     *,
     event_registry=None,
     episode_registry=None,
+    condition_registry=None,
     entity_registry=None,
     pipe_registry=None,
 ):
@@ -31,6 +32,7 @@ def _temporal_service_get(
     from kindling.data_pipes import DataPipesRegistry
     from kindling_ext_temporal import (
         SimpleTemporalEntityResolver,
+        TemporalConditionRegistry,
         TemporalEntityResolver,
         TemporalEpisodeRegistry,
         TemporalEventRegistry,
@@ -43,6 +45,8 @@ def _temporal_service_get(
             return event_registry
         if dep is TemporalEpisodeRegistry and episode_registry is not None:
             return episode_registry
+        if dep is TemporalConditionRegistry and condition_registry is not None:
+            return condition_registry
         if dep is DataEntityRegistry and entity_registry is not None:
             return entity_registry
         if dep is DataPipesRegistry and pipe_registry is not None:
@@ -50,6 +54,12 @@ def _temporal_service_get(
         raise AssertionError(f"Unexpected service request: {dep}")
 
     return _get
+
+
+def _condition_registry():
+    from kindling_ext_temporal import TemporalConditionRegistryManager
+
+    return TemporalConditionRegistryManager(_logger_provider())
 
 
 def test_default_resolver_returns_canonical_entities():
@@ -738,3 +748,480 @@ def test_conditions_ingestion_result_and_config_key():
     assert QUARANTINE_ENTITY_CONFIG_KEY == "kindling.temporal.conditions.quarantine_entity_id"
     assert ConditionsIngestionResult(ingested_count=3).is_clean is True
     assert ConditionsIngestionResult(ingested_count=0, quarantined=[object()]).is_clean is False
+
+
+# --- gh#222: registry-declared temporal conditions ---------------------------
+
+
+def test_data_conditions_register_is_retrievable_via_registry():
+    from kindling_ext_temporal import DataConditions
+
+    condition_registry = _condition_registry()
+
+    def enter_when(events):
+        return events["payload"]["temperature"] > 90
+
+    def exit_when(events):
+        return events["payload"]["temperature"] <= 90
+
+    with patch(
+        "kindling.injection.GlobalInjector.get",
+        side_effect=_temporal_service_get(condition_registry=condition_registry),
+    ):
+        DataConditions.register(
+            condition_id="condition.overheat",
+            consumes_event_type=["telemetry.observed"],
+            subject_type="machine",
+            enter_when=enter_when,
+            exit_when=exit_when,
+        )
+
+    rule = condition_registry.get_condition_definition("condition.overheat")
+    assert rule.condition_id == "condition.overheat"
+    assert rule.consumes_event_type == ["telemetry.observed"]
+    assert rule.subject_type == "machine"
+    assert rule.parameters["enter_when"] is enter_when
+    assert rule.parameters["exit_when"] is exit_when
+    assert rule.enabled is True
+    assert condition_registry.get_condition_ids() == ["condition.overheat"]
+    assert condition_registry.get_all_conditions() == [rule]
+
+
+def test_data_conditions_register_requires_condition_id():
+    from kindling_ext_temporal import ConditionValidationError, DataConditions
+
+    with patch(
+        "kindling.injection.GlobalInjector.get",
+        side_effect=_temporal_service_get(condition_registry=_condition_registry()),
+    ):
+        with pytest.raises(ConditionValidationError, match="condition_id is required"):
+            DataConditions.register(
+                condition_id="",
+                consumes_event_type=["telemetry.observed"],
+                subject_type="machine",
+                enter_when=lambda events: events,
+                exit_when=lambda events: events,
+            )
+
+
+def test_data_conditions_register_requires_subject_type():
+    from kindling_ext_temporal import ConditionValidationError, DataConditions
+
+    with patch(
+        "kindling.injection.GlobalInjector.get",
+        side_effect=_temporal_service_get(condition_registry=_condition_registry()),
+    ):
+        with pytest.raises(ConditionValidationError, match="subject_type is required"):
+            DataConditions.register(
+                condition_id="condition.overheat",
+                consumes_event_type=["telemetry.observed"],
+                subject_type="",
+                enter_when=lambda events: events,
+                exit_when=lambda events: events,
+            )
+
+
+def test_data_conditions_register_requires_consumes_event_type():
+    from kindling_ext_temporal import ConditionValidationError, DataConditions
+
+    with patch(
+        "kindling.injection.GlobalInjector.get",
+        side_effect=_temporal_service_get(condition_registry=_condition_registry()),
+    ):
+        with pytest.raises(
+            ConditionValidationError,
+            match="consumes_event_type must contain at least one event type",
+        ):
+            DataConditions.register(
+                condition_id="condition.overheat",
+                consumes_event_type=[],
+                subject_type="machine",
+                enter_when=lambda events: events,
+                exit_when=lambda events: events,
+            )
+
+
+def test_data_conditions_register_requires_callable_enter_when():
+    from kindling_ext_temporal import ConditionValidationError, DataConditions
+
+    with patch(
+        "kindling.injection.GlobalInjector.get",
+        side_effect=_temporal_service_get(condition_registry=_condition_registry()),
+    ):
+        with pytest.raises(ConditionValidationError, match="enter_when must be callable"):
+            DataConditions.register(
+                condition_id="condition.overheat",
+                consumes_event_type=["telemetry.observed"],
+                subject_type="machine",
+                enter_when="not callable",
+                exit_when=lambda events: events,
+            )
+
+
+def test_data_conditions_register_requires_callable_exit_when():
+    from kindling_ext_temporal import ConditionValidationError, DataConditions
+
+    with patch(
+        "kindling.injection.GlobalInjector.get",
+        side_effect=_temporal_service_get(condition_registry=_condition_registry()),
+    ):
+        with pytest.raises(ConditionValidationError, match="exit_when must be callable"):
+            DataConditions.register(
+                condition_id="condition.overheat",
+                consumes_event_type=["telemetry.observed"],
+                subject_type="machine",
+                enter_when=lambda events: events,
+                exit_when="not callable",
+            )
+
+
+def test_data_conditions_register_rejects_duplicate_condition_id():
+    from kindling_ext_temporal import ConditionValidationError, DataConditions
+
+    condition_registry = _condition_registry()
+
+    with patch(
+        "kindling.injection.GlobalInjector.get",
+        side_effect=_temporal_service_get(condition_registry=condition_registry),
+    ):
+        DataConditions.register(
+            condition_id="condition.overheat",
+            consumes_event_type=["telemetry.observed"],
+            subject_type="machine",
+            enter_when=lambda events: events,
+            exit_when=lambda events: events,
+        )
+        with pytest.raises(ConditionValidationError, match="Duplicate condition_id"):
+            DataConditions.register(
+                condition_id="condition.overheat",
+                consumes_event_type=["telemetry.observed"],
+                subject_type="machine",
+                enter_when=lambda events: events,
+                exit_when=lambda events: events,
+            )
+
+
+def test_data_conditions_reset_clears_registered_conditions():
+    from kindling_ext_temporal import DataConditions
+
+    condition_registry = _condition_registry()
+
+    with patch(
+        "kindling.injection.GlobalInjector.get",
+        side_effect=_temporal_service_get(condition_registry=condition_registry),
+    ):
+        DataConditions.register(
+            condition_id="condition.overheat",
+            consumes_event_type=["telemetry.observed"],
+            subject_type="machine",
+            enter_when=lambda events: events,
+            exit_when=lambda events: events,
+        )
+        DataConditions.reset()
+
+    assert condition_registry.get_all_conditions() == []
+    assert condition_registry.get_condition_ids() == []
+
+
+def test_condition_engine_registry_source_has_no_table_entities():
+    from kindling.data_entities import DataEntityManager
+    from kindling.data_pipes import DataPipesManager
+    from kindling_ext_temporal import DataEvents, TemporalEventRegistryManager
+
+    DataEvents.reset()
+    event_registry = TemporalEventRegistryManager(_logger_provider())
+    entity_registry = DataEntityManager()
+    pipe_registry = DataPipesManager(_logger_provider())
+    condition_registry = _condition_registry()
+
+    with patch(
+        "kindling.injection.GlobalInjector.get",
+        side_effect=_temporal_service_get(
+            event_registry=event_registry,
+            entity_registry=entity_registry,
+            pipe_registry=pipe_registry,
+            condition_registry=condition_registry,
+        ),
+    ):
+        DataEvents.condition_engine(engineid="static_conditions", condition_source="registry")
+
+    metadata = event_registry.get_condition_engine_definition("static_conditions")
+    assert metadata.condition_source == "registry"
+    assert metadata.conditions_entity_id is None
+    assert metadata.conditions_current_entity_id is None
+    assert metadata.events_entity_id == "silver.events"
+    assert entity_registry.get_entity_definition("silver.events") is not None
+    assert entity_registry.get_entity_definition("silver.conditions") is None
+    assert entity_registry.get_entity_definition("silver.conditions.current") is None
+
+    pipe = pipe_registry.get_pipe_definition("temporal.condition.static_conditions")
+    assert pipe.input_entity_ids == ["silver.events"]
+    assert pipe.output_entity_id == "silver.events"
+    assert callable(pipe.execute)
+
+
+def test_condition_engine_rejects_invalid_condition_source():
+    from kindling.data_entities import DataEntityManager
+    from kindling.data_pipes import DataPipesManager
+    from kindling_ext_temporal import DataEvents, TemporalEventRegistryManager
+
+    DataEvents.reset()
+    event_registry = TemporalEventRegistryManager(_logger_provider())
+    entity_registry = DataEntityManager()
+    pipe_registry = DataPipesManager(_logger_provider())
+
+    with patch(
+        "kindling.injection.GlobalInjector.get",
+        side_effect=_temporal_service_get(
+            event_registry=event_registry,
+            entity_registry=entity_registry,
+            pipe_registry=pipe_registry,
+        ),
+    ):
+        with pytest.raises(ValueError, match="condition_source must be"):
+            DataEvents.condition_engine(engineid="bogus", condition_source="both")
+
+    assert event_registry.get_condition_engine_definition("bogus") is None
+
+
+def test_condition_engine_registry_source_rejects_cycle_at_declaration_time():
+    from kindling.data_entities import DataEntityManager
+    from kindling.data_pipes import DataPipesManager
+    from kindling_ext_temporal import (
+        ConditionRule,
+        ConditionValidationError,
+        DataEvents,
+        TemporalEventRegistryManager,
+    )
+
+    DataEvents.reset()
+    event_registry = TemporalEventRegistryManager(_logger_provider())
+    entity_registry = DataEntityManager()
+    pipe_registry = DataPipesManager(_logger_provider())
+    condition_registry = _condition_registry()
+    # Neither rule is cyclic alone; each consumes the OTHER's produced
+    # boundary event type, forming a 2-condition cycle in the registry's
+    # current contents -- mirrors test_condition_validator_rejects_event_
+    # type_cycles, but through the registry's own declaration-time check
+    # (registry.py's condition_engine()) rather than TemporalConditionValidator
+    # .validate() directly.
+    condition_registry.register_condition(
+        ConditionRule(
+            condition_id="condition.first",
+            consumes_event_type=["condition.second.entered"],
+            subject_type="machine",
+            parameters={"enter_when": lambda events: events, "exit_when": lambda events: events},
+        )
+    )
+    condition_registry.register_condition(
+        ConditionRule(
+            condition_id="condition.second",
+            consumes_event_type=["condition.first.entered"],
+            subject_type="machine",
+            parameters={"enter_when": lambda events: events, "exit_when": lambda events: events},
+        )
+    )
+
+    with patch(
+        "kindling.injection.GlobalInjector.get",
+        side_effect=_temporal_service_get(
+            event_registry=event_registry,
+            entity_registry=entity_registry,
+            pipe_registry=pipe_registry,
+            condition_registry=condition_registry,
+        ),
+    ):
+        with pytest.raises(ConditionValidationError, match="Conditions set is not ingestible"):
+            DataEvents.condition_engine(engineid="static_conditions", condition_source="registry")
+
+    # The rejected declaration must not have partially registered the engine.
+    assert event_registry.get_condition_engine_definition("static_conditions") is None
+
+
+def test_condition_engine_pipe_params_registry_source_omits_conditions_current():
+    from kindling_ext_temporal import ConditionEngineMetadata, TemporalPipeTranslator
+
+    metadata = ConditionEngineMetadata(
+        engineid="static_conditions",
+        events_entity_id="silver.events",
+        condition_source="registry",
+    )
+
+    params = TemporalPipeTranslator.condition_engine_pipe_params(metadata)
+
+    assert params["input_entity_ids"] == ["silver.events"]
+    assert params["output_entity_id"] == "silver.events"
+
+
+def test_condition_engine_execute_registry_source_calls_execute_rules_directly():
+    from kindling_ext_temporal import (
+        ConditionEngineMetadata,
+        TemporalConditionRegistry,
+        TemporalPipeTranslator,
+    )
+
+    metadata = ConditionEngineMetadata(
+        engineid="static_conditions",
+        events_entity_id="silver.events",
+        condition_source="registry",
+    )
+    events_df = object()
+    registry_rules = [object()]
+    runner = MagicMock()
+    runner.execute_rules.return_value = "boundary_events"
+
+    def _get(dep):
+        if dep is TemporalConditionRegistry:
+            condition_registry = MagicMock()
+            condition_registry.get_all_conditions.return_value = registry_rules
+            return condition_registry
+        raise AssertionError(f"Unexpected service request: {dep}")
+
+    execute = TemporalPipeTranslator.condition_engine_execute(metadata)
+    with (
+        patch("kindling.injection.GlobalInjector.get", side_effect=_get),
+        patch("kindling_ext_temporal.engine.ConditionEngineRunner", return_value=runner),
+    ):
+        # Deliberately no "silver_conditions_current" key -- a registry
+        # engine must never look for a conditions-current input.
+        result = execute(silver_events=events_df)
+
+    assert result == "boundary_events"
+    runner.execute_rules.assert_called_once_with(events_df, registry_rules)
+
+
+@pytest.fixture(scope="module")
+def spark():
+    from pyspark.sql import SparkSession
+
+    spark = (
+        SparkSession.builder.appName("TemporalExtensionUnit")
+        .master("local[1]")
+        .config("spark.sql.shuffle.partitions", "1")
+        .config("spark.ui.enabled", "false")
+        .getOrCreate()
+    )
+    yield spark
+    spark.stop()
+
+
+def _predicate_events_df(spark):
+    from kindling_ext_temporal import events_schema
+
+    now = datetime(2026, 7, 14, 12, 0, 0)
+    rows = [
+        (
+            "evt-hot",
+            "telemetry.observed",
+            0,
+            "base",
+            "machine",
+            "machine-1",
+            now,
+            "test",
+            None,
+            {"temperature": "95.0"},
+            None,
+            now,
+        ),
+        (
+            "evt-cold",
+            "telemetry.observed",
+            0,
+            "base",
+            "machine",
+            "machine-1",
+            now,
+            "test",
+            None,
+            {"temperature": "50.0"},
+            None,
+            now,
+        ),
+    ]
+    return spark.createDataFrame(rows, events_schema())
+
+
+@pytest.mark.requires_spark
+def test_execute_rules_invokes_callable_predicate_and_filters_on_returned_column(spark):
+    from kindling_ext_temporal import ConditionEngineRunner, ConditionRule
+
+    events_df = _predicate_events_df(spark)
+    enter_calls = []
+    exit_calls = []
+
+    def enter_when(events):
+        enter_calls.append(events)
+        return events["payload"]["temperature"].cast("double") > 90
+
+    def exit_when(events):
+        exit_calls.append(events)
+        return events["payload"]["temperature"].cast("double") <= 90
+
+    rule = ConditionRule(
+        condition_id="condition.registry_overheat",
+        consumes_event_type=["telemetry.observed"],
+        subject_type="machine",
+        parameters={"enter_when": enter_when, "exit_when": exit_when},
+    )
+
+    result = ConditionEngineRunner().execute_rules(events_df, [rule])
+    event_types = {row.event_type for row in result.collect()}
+
+    assert len(enter_calls) == 1
+    assert len(exit_calls) == 1
+    assert "payload" in enter_calls[0].columns
+    assert "condition.registry_overheat.entered" in event_types
+    assert "condition.registry_overheat.exited" in event_types
+
+
+@pytest.mark.requires_spark
+def test_execute_rules_raises_clearly_when_predicate_builder_returns_non_column(spark):
+    from kindling_ext_temporal import ConditionEngineRunner, ConditionRule
+
+    events_df = _predicate_events_df(spark)
+    rule = ConditionRule(
+        condition_id="condition.bad_builder",
+        consumes_event_type=["telemetry.observed"],
+        subject_type="machine",
+        parameters={
+            "enter_when": lambda events: True,  # not a Column
+            "exit_when": lambda events: events["payload"]["temperature"].cast("double") <= 90,
+        },
+    )
+
+    with pytest.raises(TypeError, match="expected a Column"):
+        ConditionEngineRunner().execute_rules(events_df, [rule])
+
+
+@pytest.mark.requires_spark
+def test_execute_rules_runs_table_and_registry_rules_side_by_side(spark):
+    from kindling_ext_temporal import ConditionEngineRunner, ConditionRule
+
+    events_df = _predicate_events_df(spark)
+    table_rule = ConditionRule(
+        condition_id="condition.table_overheat",
+        consumes_event_type=["telemetry.observed"],
+        subject_type="machine",
+        parameters={
+            "enter_when": "cast(payload['temperature'] as double) > 90",
+            "exit_when": "cast(payload['temperature'] as double) <= 90",
+        },
+    )
+    registry_rule = ConditionRule(
+        condition_id="condition.registry_overheat",
+        consumes_event_type=["telemetry.observed"],
+        subject_type="machine",
+        parameters={
+            "enter_when": lambda events: events["payload"]["temperature"].cast("double") > 90,
+            "exit_when": lambda events: events["payload"]["temperature"].cast("double") <= 90,
+        },
+    )
+
+    result = ConditionEngineRunner().execute_rules(events_df, [table_rule, registry_rule])
+    event_types = {row.event_type for row in result.collect()}
+
+    assert "condition.table_overheat.entered" in event_types
+    assert "condition.table_overheat.exited" in event_types
+    assert "condition.registry_overheat.entered" in event_types
+    assert "condition.registry_overheat.exited" in event_types


### PR DESCRIPTION
## Summary

Adds a second, explicit `condition_source` for temporal condition engines alongside the existing table-backed rules-as-data path. Today all temporal conditions must be rows in a conditions table resolved through the conditions-entity machinery; there was no way to declare a static, application-owned condition directly in code. This closes that gap with a registry-backed alternative that coexists with table-backed conditions in the same chain.

## Changes

- `DataConditions.register(...)` declares a condition with `enter_when`/`exit_when` as `Callable[[DataFrame], Column]` predicate builders invoked against the scoped events DataFrame at execution time, rather than serialized SQL strings. Missing required fields and duplicate `condition_id`s raise `ConditionValidationError` immediately — registry conditions are code, not data, and fail fast instead of being quarantined.
- `DataEvents.condition_engine(..., condition_source="registry")` evaluates the registry's current contents instead of the conditions table, with zero conditions-entity involvement. The default `condition_source="table"` is unchanged. Event-type graph cycles in the registry are rejected at engine-declaration time rather than deferred to chain/pipe execution.
- `declare_temporal_chain()`/`collapse_temporal_chain()` gain per-engine-kind enumeration: an all-registry chain omits the conditions-current input entirely; a mixed table+registry chain still wires it, unions both rule sets through the same `ConditionEngineRunner.execute_rules` pass, and raises on a cross-source event-type cycle that neither source's own isolated validation would catch alone.
- `ConditionEngineRunner.execute_rules` resolves each rule's `enter_when`/`exit_when` to a `Column` whether it's a SQL string (table rows) or a predicate builder (registry rules), so both sources execute side by side unchanged.
- Existing table-backed declarations, entities, schemas, ingestion, and chain behavior are unchanged (regression-tested).
- Full design rationale in `docs/proposals/temporal_condition_sources.md`.

## Test plan
- [x] `poe test-unit` — 2356 passed, 1 skipped
- [x] `PYTEST_ADDOPTS='-k chain_matches_per_pipe_lowering_and_converges_in_one_run' poe test-integration` — 1 passed
- [x] Internal review: APPROVE, no blockers — verified against the DESIGN note and AGENTS.md conventions; registry-source path skips all conditions-entity resolution, cycle checks run at declaration time, cross-source cycle check only runs when both engine kinds are present, zero-engines-declared case preserved, test coverage matches every scenario the DESIGN note promised
- [x] gitleaks scan of push range: clean

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)
