### PR TITLE
feat(entity-provider): add merge_to_entity (SCD2) support to MemoryEntityProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to spark-kindling are documented here.
 
+## Unreleased
+
+### Added
+
+- **`MemoryEntityProvider.merge_to_entity()`** (gh#220): the in-memory
+  provider now supports the same `merge_to_entity` contract as
+  `DeltaEntityProvider` — SCD Type 2 upsert (`scd.type=2`), insert-only
+  (`write.mode=insert`), and full-row SCD1 upsert (default) — implemented as
+  plain DataFrame joins/unions rather than a Delta `MERGE INTO`. This lets
+  `kindling_ext_temporal.ingest_conditions()` (and any other caller that
+  merges into an entity) be exercised against Memory, the framework's
+  no-external-dependency test provider, instead of only against a real Delta
+  table.
+
+### Changed
+
+- `augment_schema_for_scd2`, `quote_sql_identifier`, and
+  `build_null_safe_change_condition` moved from `entity_provider_delta.py`
+  (as private, Delta-only helpers) to `data_entities.py` as public,
+  provider-agnostic functions. `DeltaEntityProvider` behavior is unchanged;
+  `_augment_schema_for_scd2` is now a one-line delegate to the shared
+  function.
+
 ## [0.12.3] - 2026-07-29
 
 ### Added

--- a/packages/kindling/data_entities.py
+++ b/packages/kindling/data_entities.py
@@ -8,13 +8,19 @@ from typing import Any, Callable, Dict, List, Optional
 
 from delta.tables import DeltaTable
 from injector import Binder, Injector, inject, singleton
-from pyspark.sql import DataFrame
-
 from kindling.config_patterns import ConfigPatternMatcher
 from kindling.injection import *
 from kindling.signaling import SignalEmitter, SignalProvider
 from kindling.spark_config import *
 from kindling.spark_log_provider import *
+from pyspark.sql import DataFrame
+from pyspark.sql.types import (
+    BooleanType,
+    MapType,
+    StructField,
+    StructType,
+    TimestampType,
+)
 
 _ENTITY_LOGGER = logging.getLogger("kindling.data_entities")
 
@@ -316,6 +322,67 @@ def scd_config_from_tags(entity: EntityMetadata) -> SCDConfig:
         source_kind=source_kind,
         delete_when=delete_when,
     )
+
+
+def quote_sql_identifier(name: str, alias: Optional[str] = None) -> str:
+    """Backtick-quote a column name for a raw SQL expression, optionally alias-qualified."""
+    escaped = name.replace("`", "``")
+    if alias:
+        return f"{alias}.`{escaped}`"
+    return f"`{escaped}`"
+
+
+def build_null_safe_change_condition(
+    source_alias: str, target_alias: str, tracked_columns: List[str], schema=None
+) -> str:
+    """Null-safe OR-of-changed-columns SQL condition for MERGE/join change detection."""
+    if not tracked_columns:
+        return "false"
+
+    unorderable = {
+        field.name
+        for field in (schema.fields if schema else [])
+        if isinstance(field.dataType, MapType)
+    }
+
+    def _comparable(column: str, alias: str) -> str:
+        ident = quote_sql_identifier(column, alias)
+        # Spark's binary comparison does not support ordering on MAP types;
+        # compare their JSON projection instead (same approach as the
+        # optimize_unchanged hash path).
+        if column in unorderable:
+            return f"to_json({ident})"
+        return ident
+
+    return " OR ".join(
+        [
+            f"({_comparable(column, source_alias)} != "
+            f"{_comparable(column, target_alias)} OR "
+            f"({quote_sql_identifier(column, source_alias)} IS NULL) != "
+            f"({quote_sql_identifier(column, target_alias)} IS NULL))"
+            for column in tracked_columns
+        ]
+    )
+
+
+def augment_schema_for_scd2(schema: StructType, cfg: SCDConfig) -> StructType:
+    """Add SCD2 temporal columns (effective_from/to, is_current) to a schema when enabled."""
+    schema_struct = schema if isinstance(schema, StructType) else StructType(schema)
+    if not cfg.enabled:
+        return schema_struct
+
+    existing_names = {field.name for field in schema_struct.fields}
+    extra_fields = []
+    if cfg.effective_from_column not in existing_names:
+        extra_fields.append(StructField(cfg.effective_from_column, TimestampType(), False))
+    if cfg.effective_to_column not in existing_names:
+        extra_fields.append(StructField(cfg.effective_to_column, TimestampType(), True))
+    if cfg.is_current_column not in existing_names:
+        extra_fields.append(StructField(cfg.is_current_column, BooleanType(), False))
+
+    if not extra_fields:
+        return schema_struct
+    return StructType(schema_struct.fields + extra_fields)
 
 
 @dataclass(frozen=True)

--- a/packages/kindling/entity_provider_delta.py
+++ b/packages/kindling/entity_provider_delta.py
@@ -27,7 +27,7 @@ from pyspark.sql.functions import (
     struct,
     to_json,
 )
-from pyspark.sql.types import BooleanType, StructField, StructType, TimestampType
+from pyspark.sql.types import StructType
 
 from .data_entities import *
 from .entity_provider import (
@@ -193,47 +193,6 @@ class SCD2MergeStrategy(DeltaMergeStrategy):
         _execute_scd2_merge(delta_table, df, entity)
 
 
-def _quote_sql_identifier(name: str, alias: Optional[str] = None) -> str:
-    escaped = name.replace("`", "``")
-    if alias:
-        return f"{alias}.`{escaped}`"
-    return f"`{escaped}`"
-
-
-def _build_null_safe_change_condition(
-    source_alias: str, target_alias: str, tracked_columns: list[str], schema=None
-) -> str:
-    if not tracked_columns:
-        return "false"
-
-    from pyspark.sql.types import MapType
-
-    unorderable = {
-        field.name
-        for field in (schema.fields if schema else [])
-        if isinstance(field.dataType, MapType)
-    }
-
-    def _comparable(column: str, alias: str) -> str:
-        ident = _quote_sql_identifier(column, alias)
-        # Spark's binary comparison does not support ordering on MAP types;
-        # compare their JSON projection instead (same approach as the
-        # optimize_unchanged hash path).
-        if column in unorderable:
-            return f"to_json({ident})"
-        return ident
-
-    return " OR ".join(
-        [
-            f"({_comparable(column, source_alias)} != "
-            f"{_comparable(column, target_alias)} OR "
-            f"({_quote_sql_identifier(column, source_alias)} IS NULL) != "
-            f"({_quote_sql_identifier(column, target_alias)} IS NULL))"
-            for column in tracked_columns
-        ]
-    )
-
-
 def _routing_key_column_expr(business_keys: list[str], method: str):
     if method == "concat":
         # Coalesce to sentinel so (None, "x") and ("x", None) produce distinct keys.
@@ -247,7 +206,7 @@ def _routing_key_column_expr(business_keys: list[str], method: str):
 def _routing_key_target_sql(business_keys: list[str], method: str) -> str:
     if method == "concat":
         key_exprs = [
-            f"COALESCE(CAST({_quote_sql_identifier(key, 'target')} AS STRING), '{_SCD2_NULL_SENTINEL}')"
+            f"COALESCE(CAST({quote_sql_identifier(key, 'target')} AS STRING), '{_SCD2_NULL_SENTINEL}')"
             for key in business_keys
         ]
         return f"concat_ws('||', {', '.join(key_exprs)})"
@@ -256,7 +215,7 @@ def _routing_key_target_sql(business_keys: list[str], method: str) -> str:
     for key in business_keys:
         safe_key = key.replace("'", "''")
         named_struct_args.append(f"'{safe_key}'")
-        named_struct_args.append(_quote_sql_identifier(key, "target"))
+        named_struct_args.append(quote_sql_identifier(key, "target"))
     return f"sha2(to_json(named_struct({', '.join(named_struct_args)})), 256)"
 
 
@@ -331,24 +290,24 @@ def _execute_scd2_merge(delta_table, df: DataFrame, entity) -> None:
     seq_guard = None
     if cfg.sequence_by:
         seq_guard = (
-            f"({_quote_sql_identifier(cfg.sequence_by, 'source')} > "
-            f"{_quote_sql_identifier(cfg.effective_from_column, 'target')})"
+            f"({quote_sql_identifier(cfg.sequence_by, 'source')} > "
+            f"{quote_sql_identifier(cfg.effective_from_column, 'target')})"
         )
 
     close_expr = (
-        _quote_sql_identifier(cfg.sequence_by, "staged")
+        quote_sql_identifier(cfg.sequence_by, "staged")
         if cfg.sequence_by
         else "current_timestamp()"
     )
     close_set = {
-        _quote_sql_identifier(cfg.effective_to_column): close_expr,
-        _quote_sql_identifier(cfg.is_current_column): "false",
+        quote_sql_identifier(cfg.effective_to_column): close_expr,
+        quote_sql_identifier(cfg.is_current_column): "false",
     }
     # Missing-key closes (snapshot) have no staged row to read a sequence
     # value from; they always close at processing time.
     close_set_missing = {
-        _quote_sql_identifier(cfg.effective_to_column): "current_timestamp()",
-        _quote_sql_identifier(cfg.is_current_column): "false",
+        quote_sql_identifier(cfg.effective_to_column): "current_timestamp()",
+        quote_sql_identifier(cfg.is_current_column): "false",
     }
 
     if cfg.optimize_unchanged:
@@ -358,7 +317,7 @@ def _execute_scd2_merge(delta_table, df: DataFrame, entity) -> None:
         # names) must match on both sides or the JSON — and thus the hash —
         # never compares equal.
         tgt_hash_sql = "sha2(to_json(struct({})), 256)".format(
-            ", ".join(_quote_sql_identifier(c, "target") for c in tracked_columns)
+            ", ".join(quote_sql_identifier(c, "target") for c in tracked_columns)
         )
         changed_where = f"source.{_SCD2_SRC_HASH_COLUMN} != {tgt_hash_sql}"
         if seq_guard:
@@ -381,7 +340,7 @@ def _execute_scd2_merge(delta_table, df: DataFrame, entity) -> None:
             )
         new_rows = upserts_df.join(current_target, on=business_keys, how="left_anti")
     else:
-        change_condition = _build_null_safe_change_condition(
+        change_condition = build_null_safe_change_condition(
             "source", "target", tracked_columns, schema=upserts_df.schema
         )
         changed_where = change_condition
@@ -444,20 +403,20 @@ def _execute_scd2_merge(delta_table, df: DataFrame, entity) -> None:
 
     source_columns = [column for column in df.columns if column not in temporal_columns]
     insert_values = {
-        _quote_sql_identifier(column): _quote_sql_identifier(column, "staged")
+        quote_sql_identifier(column): quote_sql_identifier(column, "staged")
         for column in source_columns
     }
-    insert_values[_quote_sql_identifier(cfg.effective_from_column)] = (
-        _quote_sql_identifier(cfg.sequence_by, "staged")
+    insert_values[quote_sql_identifier(cfg.effective_from_column)] = (
+        quote_sql_identifier(cfg.sequence_by, "staged")
         if cfg.sequence_by
         else "current_timestamp()"
     )
-    insert_values[_quote_sql_identifier(cfg.effective_to_column)] = "NULL"
-    insert_values[_quote_sql_identifier(cfg.is_current_column)] = "true"
+    insert_values[quote_sql_identifier(cfg.effective_to_column)] = "NULL"
+    insert_values[quote_sql_identifier(cfg.is_current_column)] = "true"
     target_routing_key_sql = _routing_key_target_sql(business_keys, cfg.routing_key_method)
     merge_condition = (
         f"{target_routing_key_sql} = staged.__merge_key "
-        f"AND {_quote_sql_identifier(cfg.is_current_column, 'target')} = true"
+        f"AND {quote_sql_identifier(cfg.is_current_column, 'target')} = true"
     )
 
     builder = delta_table.alias("target").merge(
@@ -1546,22 +1505,7 @@ class DeltaEntityProvider(
 
     def _augment_schema_for_scd2(self, schema: StructType, cfg: SCDConfig) -> StructType:
         """Add SCD2 temporal columns to a schema when SCD2 is enabled."""
-        schema_struct = schema if isinstance(schema, StructType) else StructType(schema)
-        if not cfg.enabled:
-            return schema_struct
-
-        existing_names = {field.name for field in schema_struct.fields}
-        extra_fields = []
-        if cfg.effective_from_column not in existing_names:
-            extra_fields.append(StructField(cfg.effective_from_column, TimestampType(), False))
-        if cfg.effective_to_column not in existing_names:
-            extra_fields.append(StructField(cfg.effective_to_column, TimestampType(), True))
-        if cfg.is_current_column not in existing_names:
-            extra_fields.append(StructField(cfg.is_current_column, BooleanType(), False))
-
-        if not extra_fields:
-            return schema_struct
-        return StructType(schema_struct.fields + extra_fields)
+        return augment_schema_for_scd2(schema, cfg)
 
     def _append_to_delta_table(self, df: DataFrame, entity, table_ref: DeltaTableReference):
         """Append DataFrame to existing Delta table"""

--- a/packages/kindling/entity_provider_memory.py
+++ b/packages/kindling/entity_provider_memory.py
@@ -9,9 +9,17 @@ from typing import Any, Dict, List, Optional
 
 from injector import inject
 from pyspark.sql import DataFrame
+from pyspark.sql.functions import col, expr, lit, sha2, struct, to_json
 from pyspark.sql.streaming import StreamingQuery
+from pyspark.sql.types import TimestampType
 
-from .data_entities import EntityMetadata
+from .data_entities import (
+    EntityMetadata,
+    SCDConfig,
+    augment_schema_for_scd2,
+    build_null_safe_change_condition,
+    scd_config_from_tags,
+)
 from .entity_provider import (
     BaseEntityProvider,
     StreamableEntityProvider,
@@ -21,6 +29,187 @@ from .entity_provider import (
 from .injection import GlobalInjector
 from .spark_config import get_or_create_spark_session
 from .spark_log_provider import PythonLoggerProvider
+
+
+def _memory_scd1_merge(
+    current_df: DataFrame, incoming_df: DataFrame, entity_metadata: EntityMetadata
+) -> DataFrame:
+    """Full-row upsert: incoming rows replace matching business keys, others pass through."""
+    business_keys = entity_metadata.merge_columns
+    untouched = current_df.join(incoming_df, on=business_keys, how="left_anti")
+    return untouched.unionByName(incoming_df, allowMissingColumns=True)
+
+
+def _memory_insert_only_merge(
+    current_df: DataFrame, incoming_df: DataFrame, entity_metadata: EntityMetadata
+) -> DataFrame:
+    """Insert-if-absent upsert: existing business keys are left untouched."""
+    business_keys = entity_metadata.merge_columns
+    new_only = incoming_df.join(current_df, on=business_keys, how="left_anti")
+    return current_df.unionByName(new_only, allowMissingColumns=True)
+
+
+def _memory_scd2_merge(
+    current_df: DataFrame,
+    incoming_df: DataFrame,
+    entity_metadata: EntityMetadata,
+    cfg: SCDConfig,
+    now_ts: Any,
+) -> DataFrame:
+    """Execute an SCD Type 2 upsert as plain DataFrame joins/unions.
+
+    Mirrors DeltaEntityProvider._execute_scd2_merge's declared-flow semantics
+    (sequence_by ordering, delete_when, close_on_missing) without Delta's
+    single-MERGE-statement staging trick: Memory does a full read-modify-write,
+    assembling historical rows, untouched current rows, closed (old) versions,
+    and new/changed versions, then returns the union for one write_to_entity
+    overwrite. ``now_ts`` is a single captured instant reused for every
+    timestamp this call would otherwise stamp with current_timestamp(), so a
+    closed row's effective_to and its replacement's effective_from agree.
+    """
+    # A catalog/temp-view-backed DataFrame (current_df typically comes from
+    # self.read_entity(), i.e. spark.table(...)) carries attribute lineage
+    # that breaks alias-qualified wildcard selects ("target.*") once joined
+    # and re-aliased below. Re-projecting through toDF() gives every column
+    # a fresh attribute reference, which survives the later join/select.
+    current_df = current_df.toDF(*current_df.columns)
+    incoming_df = incoming_df.toDF(*incoming_df.columns)
+
+    business_keys = entity_metadata.merge_columns
+    temporal_columns = {cfg.effective_from_column, cfg.effective_to_column, cfg.is_current_column}
+
+    if cfg.sequence_by and cfg.sequence_by not in incoming_df.columns:
+        raise ValueError(
+            f"Entity '{entity_metadata.entityid}': scd.sequence_by column "
+            f"'{cfg.sequence_by}' is missing from the incoming DataFrame"
+        )
+    if cfg.sequence_by and incoming_df.filter(col(cfg.sequence_by).isNull()).head(1):
+        raise ValueError(
+            f"Entity '{entity_metadata.entityid}': scd.sequence_by column "
+            f"'{cfg.sequence_by}' contains null values in the incoming batch; "
+            "every row must carry a sequence value"
+        )
+
+    tracked_columns = cfg.tracked_columns or [
+        column
+        for column in incoming_df.columns
+        if column not in business_keys
+        and column not in temporal_columns
+        and column != cfg.sequence_by
+    ]
+
+    historical_rows = current_df.filter(col(cfg.is_current_column) == lit(False))
+    current_rows = current_df.filter(col(cfg.is_current_column) == lit(True))
+
+    upserts_df = incoming_df
+    deletes_df = None
+    if cfg.delete_when:
+        delete_predicate = expr(cfg.delete_when)
+        deletes_df = incoming_df.filter(delete_predicate)
+        upserts_df = incoming_df.filter(~delete_predicate)
+    upserts_df = upserts_df.drop(*[c for c in temporal_columns if c in upserts_df.columns])
+
+    match = upserts_df.alias("source").join(
+        current_rows.alias("target"), on=business_keys, how="inner"
+    )
+    if cfg.optimize_unchanged:
+        hash_source = sha2(to_json(struct(*[col(f"source.{c}") for c in tracked_columns])), 256)
+        hash_target = sha2(to_json(struct(*[col(f"target.{c}") for c in tracked_columns])), 256)
+        change_where = hash_source != hash_target
+    else:
+        change_where = expr(
+            build_null_safe_change_condition(
+                "source", "target", tracked_columns, schema=upserts_df.schema
+            )
+        )
+    if cfg.sequence_by:
+        change_where = change_where & (
+            col(f"source.{cfg.sequence_by}") > col(f"target.{cfg.effective_from_column}")
+        )
+    changed_match = match.where(change_where)
+
+    new_effective_from = col(f"source.{cfg.sequence_by}") if cfg.sequence_by else lit(now_ts)
+    new_versions_from_changes = (
+        changed_match.withColumn("__new_effective_from", new_effective_from)
+        .select("source.*", "__new_effective_from")
+        .withColumn(cfg.effective_from_column, col("__new_effective_from"))
+        .withColumn(cfg.effective_to_column, lit(None).cast(TimestampType()))
+        .withColumn(cfg.is_current_column, lit(True))
+        .drop("__new_effective_from")
+    )
+
+    close_value = col(f"source.{cfg.sequence_by}") if cfg.sequence_by else lit(now_ts)
+    closed_versions_from_changes = (
+        changed_match.withColumn("__close_value", close_value)
+        .select("target.*", "__close_value")
+        .withColumn(cfg.effective_to_column, col("__close_value"))
+        .withColumn(cfg.is_current_column, lit(False))
+        .drop("__close_value")
+    )
+
+    new_match = upserts_df.join(current_rows, on=business_keys, how="left_anti")
+    new_versions_from_new_keys = (
+        new_match.withColumn(
+            cfg.effective_from_column,
+            col(cfg.sequence_by) if cfg.sequence_by else lit(now_ts),
+        )
+        .withColumn(cfg.effective_to_column, lit(None).cast(TimestampType()))
+        .withColumn(cfg.is_current_column, lit(True))
+    )
+
+    closed_versions_from_missing = None
+    if cfg.close_on_missing:
+        missing_match = current_rows.join(upserts_df, on=business_keys, how="left_anti")
+        closed_versions_from_missing = missing_match.withColumn(
+            cfg.effective_to_column, lit(now_ts)
+        ).withColumn(cfg.is_current_column, lit(False))
+
+    closed_versions_from_deletes = None
+    if deletes_df is not None:
+        delete_match = deletes_df.alias("source").join(
+            current_rows.alias("target"), on=business_keys, how="inner"
+        )
+        if cfg.sequence_by:
+            delete_match = delete_match.where(
+                col(f"source.{cfg.sequence_by}") > col(f"target.{cfg.effective_from_column}")
+            )
+        delete_close_value = col(f"source.{cfg.sequence_by}") if cfg.sequence_by else lit(now_ts)
+        closed_versions_from_deletes = (
+            delete_match.withColumn("__close_value", delete_close_value)
+            .select("target.*", "__close_value")
+            .withColumn(cfg.effective_to_column, col("__close_value"))
+            .withColumn(cfg.is_current_column, lit(False))
+            .drop("__close_value")
+        )
+
+    closed_frames = [
+        frame
+        for frame in (
+            closed_versions_from_changes,
+            closed_versions_from_missing,
+            closed_versions_from_deletes,
+        )
+        if frame is not None
+    ]
+
+    if closed_frames:
+        touched_keys = closed_frames[0].select(*business_keys)
+        for frame in closed_frames[1:]:
+            touched_keys = touched_keys.unionByName(frame.select(*business_keys))
+        current_rows_not_touched = current_rows.join(
+            touched_keys, on=business_keys, how="left_anti"
+        )
+    else:
+        current_rows_not_touched = current_rows
+
+    result = historical_rows
+    for frame in (
+        [current_rows_not_touched]
+        + closed_frames
+        + [new_versions_from_changes, new_versions_from_new_keys]
+    ):
+        result = result.unionByName(frame, allowMissingColumns=True)
+    return result
 
 
 @GlobalInjector.singleton_autobind()
@@ -333,6 +522,59 @@ class MemoryEntityProvider(
                 include_traceback=True,
             )
             raise
+
+    def merge_to_entity(self, df: DataFrame, entity_metadata: EntityMetadata) -> None:
+        """
+        Merge DataFrame into memory entity (SCD2, insert-only, or SCD1 upsert).
+
+        Dispatches on the entity's tags exactly like DeltaEntityProvider's
+        merge_to_entity: scd.type=2 runs an SCD2 upsert, write.mode=insert
+        only inserts new business keys, and the default runs a full-row SCD1
+        upsert. Implemented as plain DataFrame joins/unions (no MERGE INTO
+        primitive), then a single write_to_entity overwrite of the result.
+
+        Args:
+            df: Incoming DataFrame to merge
+            entity_metadata: Entity metadata (tags select the merge strategy)
+        """
+        cfg = scd_config_from_tags(entity_metadata)
+        write_mode = str((entity_metadata.tags or {}).get("write.mode") or "").strip().lower()
+        exists = self.check_entity_exists(entity_metadata)
+
+        if cfg.enabled:
+            self.logger.info(f"Merging memory entity '{entity_metadata.entityid}' (mode: scd2)")
+            if exists:
+                current_df = self.read_entity(entity_metadata)
+            else:
+                if entity_metadata.schema is None:
+                    raise ValueError(
+                        f"Memory entity '{entity_metadata.entityid}' has scd.type=2 but no "
+                        "schema defined. A schema is required to bootstrap the SCD2 "
+                        "temporal columns for a not-yet-existing entity."
+                    )
+                current_df = self.spark.createDataFrame(
+                    [], augment_schema_for_scd2(entity_metadata.schema, cfg)
+                )
+            now_ts = self.spark.sql("SELECT current_timestamp() AS ts").collect()[0]["ts"]
+            result = _memory_scd2_merge(current_df, df, entity_metadata, cfg, now_ts)
+        elif write_mode == "insert":
+            self.logger.info(
+                f"Merging memory entity '{entity_metadata.entityid}' (mode: insert_only)"
+            )
+            result = (
+                _memory_insert_only_merge(self.read_entity(entity_metadata), df, entity_metadata)
+                if exists
+                else df
+            )
+        else:
+            self.logger.info(f"Merging memory entity '{entity_metadata.entityid}' (mode: scd1)")
+            result = (
+                _memory_scd1_merge(self.read_entity(entity_metadata), df, entity_metadata)
+                if exists
+                else df
+            )
+
+        self.write_to_entity(result, entity_metadata)
 
     def append_as_stream(
         self,

--- a/tests/integration/test_scd2_provider_parity.py
+++ b/tests/integration/test_scd2_provider_parity.py
@@ -1,0 +1,267 @@
+"""Cross-provider SCD2 parity: DeltaEntityProvider vs. MemoryEntityProvider.
+
+Both providers implement the same declared-flow SCD2 contract (SCDConfig /
+scd_config_from_tags) — Delta via a single staged MERGE INTO, Memory via
+plain DataFrame joins/unions (see entity_provider_memory.py). This file runs
+the same scenarios (existing rows + incoming batch + tags) through both,
+asserting equivalent current-row content and is_current/effective_to
+structure. Local Spark + local Delta only, no Azure — same placement as
+tests/integration/test_scd2_declared_flow.py, which characterizes Delta's
+own behavior in far more depth; this file only asserts parity.
+
+Effective_from/effective_to are stamped from current_timestamp() when
+scd.sequence_by is unset, so wall-clock equality across providers is not
+asserted for those scenarios — only structure (is_current, non-null-ness,
+ordering). With sequence_by set, both providers stamp from the identical
+incoming data value, so exact equality is asserted.
+"""
+
+import shutil
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from delta import configure_spark_with_delta_pip
+from kindling.data_entities import EntityNameMapper, EntityPathLocator
+from kindling.entity_provider_delta import DeltaEntityProvider
+from kindling.entity_provider_memory import MemoryEntityProvider
+from kindling.spark_config import ConfigService
+from kindling.spark_log_provider import PythonLoggerProvider
+from pyspark.sql import SparkSession
+from pyspark.sql.types import (
+    BooleanType,
+    StringType,
+    StructField,
+    StructType,
+    TimestampType,
+)
+
+
+def _teardown_existing_spark_jvm():
+    """See test_scd2_declared_flow.py — Delta jars are only on the classpath
+    if this module's session launches the JVM."""
+    from pyspark import SparkContext
+
+    active = SparkSession.getActiveSession()
+    if active is not None:
+        active.stop()
+    if SparkContext._gateway is not None:
+        try:
+            SparkContext._gateway.shutdown()
+        except Exception:
+            pass
+        SparkContext._gateway = None
+        SparkContext._jvm = None
+
+
+@pytest.fixture(scope="module")
+def spark():
+    _teardown_existing_spark_jvm()
+    builder = (
+        SparkSession.builder.appName("SCD2ProviderParity")
+        .master("local[2]")
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+        .config("spark.sql.shuffle.partitions", "2")
+        .config("spark.ui.enabled", "false")
+    )
+    spark = configure_spark_with_delta_pip(builder).getOrCreate()
+    spark.sparkContext.setLogLevel("ERROR")
+    yield spark
+    spark.stop()
+
+
+@pytest.fixture
+def temp_dir():
+    temp_path = tempfile.mkdtemp(prefix="kindling-scd2-parity-test-")
+    yield Path(temp_path)
+    shutil.rmtree(temp_path, ignore_errors=True)
+
+
+@pytest.fixture
+def delta_provider(spark, temp_dir, monkeypatch):
+    monkeypatch.setattr("kindling.entity_provider_delta.get_or_create_spark_session", lambda: spark)
+    config = MagicMock(spec=ConfigService)
+    config.get.side_effect = lambda key, default=None: (
+        "storage" if key == "kindling.delta.access_mode" else default
+    )
+    name_mapper = MagicMock(spec=EntityNameMapper)
+    name_mapper.get_table_name.side_effect = lambda entity: entity.entityid.replace(".", "_")
+    path_locator = MagicMock(spec=EntityPathLocator)
+    path_locator.get_table_path.side_effect = lambda entity: str(
+        Path(str(temp_dir)) / entity.entityid
+    )
+    logger_provider = MagicMock(spec=PythonLoggerProvider)
+    logger_provider.get_logger.return_value = MagicMock()
+    return DeltaEntityProvider(
+        config=config,
+        entity_name_mapper=name_mapper,
+        path_locator=path_locator,
+        tp=logger_provider,
+        signal_provider=None,
+    )
+
+
+@pytest.fixture
+def memory_provider(spark, monkeypatch):
+    monkeypatch.setattr(
+        "kindling.entity_provider_memory.get_or_create_spark_session", lambda: MagicMock()
+    )
+    logger_provider = MagicMock(spec=PythonLoggerProvider)
+    logger_provider.get_logger.return_value = MagicMock()
+    provider = MemoryEntityProvider(logger_provider)
+    provider.spark = spark
+    return provider
+
+
+@pytest.fixture(params=["delta", "memory"])
+def provider(request, delta_provider, memory_provider):
+    return {"delta": delta_provider, "memory": memory_provider}[request.param]
+
+
+BUSINESS_SCHEMA = [
+    StructField("customer_id", StringType(), False),
+    StructField("status", StringType(), True),
+    StructField("updated_at", TimestampType(), True),
+]
+
+TEMPORAL_SCHEMA = [
+    StructField("__effective_from", TimestampType(), True),
+    StructField("__effective_to", TimestampType(), True),
+    StructField("__is_current", BooleanType(), True),
+]
+
+FULL_SCHEMA = StructType(BUSINESS_SCHEMA + TEMPORAL_SCHEMA)
+SOURCE_SCHEMA = StructType(BUSINESS_SCHEMA)
+
+
+def _make_entity(entityid, tags):
+    return SimpleNamespace(
+        entityid=entityid,
+        name=entityid.split(".")[-1],
+        partition_columns=[],
+        cluster_columns=None,
+        merge_columns=["customer_id"],
+        tags={"scd.type": "2", **tags},
+        schema=FULL_SCHEMA,
+    )
+
+
+def _merge_batch(spark, provider, entity, rows):
+    """Merge a batch, relying on the provider's own first-call bootstrap —
+    both DeltaEntityProvider and MemoryEntityProvider self-create the table
+    (augmented schema included) on an unseen entity."""
+    df = spark.createDataFrame(rows, SOURCE_SCHEMA)
+    provider.merge_to_entity(df, entity)
+
+
+def _rows(provider, entity):
+    return {
+        (r["customer_id"], r["__is_current"]): r for r in provider.read_entity(entity).collect()
+    }
+
+
+TS = lambda day, hour=0: datetime(2026, 7, day, hour, 0, 0)  # noqa: E731
+
+
+def test_plain_change_feed_upsert_parity(spark, provider, request):
+    """Insert then change a tracked column: one closed + one current version,
+    with equivalent content and structure regardless of provider."""
+    entity = _make_entity(f"silver.parity_upsert_{request.node.callspec.id}", {})
+
+    _merge_batch(spark, provider, entity, [("c1", "bronze", TS(1))])
+    rows = _rows(provider, entity)
+    assert ("c1", True) in rows
+    assert rows[("c1", True)]["status"] == "bronze"
+    assert rows[("c1", True)]["__effective_to"] is None
+
+    _merge_batch(spark, provider, entity, [("c1", "silver", TS(2))])
+    all_rows = provider.read_entity(entity).collect()
+    current = [r for r in all_rows if r["__is_current"]]
+    closed = [r for r in all_rows if not r["__is_current"]]
+    assert len(current) == 1 and current[0]["status"] == "silver"
+    assert current[0]["__effective_to"] is None
+    assert len(closed) == 1 and closed[0]["status"] == "bronze"
+    assert closed[0]["__effective_to"] is not None, "closed version must record when it closed"
+
+
+def test_close_on_missing_snapshot_parity(spark, provider, request):
+    """A key absent from a later snapshot batch is closed in both providers;
+    a present, unchanged key stays current in both."""
+    entity = _make_entity(
+        f"silver.parity_snapshot_{request.node.callspec.id}",
+        {"scd.close_on_missing": "true"},
+    )
+
+    _merge_batch(spark, provider, entity, [("c1", "bronze", TS(1)), ("c2", "gold", TS(1))])
+    # c2 vanishes from the next snapshot; c1 is present and unchanged (same
+    # updated_at too — scd.sequence_by is unset here, so updated_at is itself
+    # a tracked column and must stay identical for c1 to count as unchanged).
+    _merge_batch(spark, provider, entity, [("c1", "bronze", TS(1))])
+
+    rows = _rows(provider, entity)
+    assert ("c1", True) in rows, "present, unchanged key must stay current"
+    assert ("c1", False) not in rows
+    assert ("c2", False) in rows, "vanished key must be closed"
+    assert ("c2", True) not in rows
+
+
+def test_sequence_by_ordering_parity(spark, provider, request):
+    """With scd.sequence_by set, both providers stamp effective_from/to from
+    the identical incoming data value — wall-clock equality is assertable
+    here (unlike the current_timestamp()-driven scenarios above)."""
+    entity = _make_entity(
+        f"silver.parity_seq_{request.node.callspec.id}", {"scd.sequence_by": "updated_at"}
+    )
+
+    _merge_batch(spark, provider, entity, [("c1", "bronze", TS(1))])
+    _merge_batch(spark, provider, entity, [("c1", "silver", TS(5))])
+
+    all_rows = provider.read_entity(entity).collect()
+    current = next(r for r in all_rows if r["__is_current"])
+    closed = next(r for r in all_rows if not r["__is_current"])
+    assert current["status"] == "silver"
+    assert current["__effective_from"] == TS(5)
+    assert closed["__effective_to"] == TS(5), (
+        "the closed version's validity must end exactly where the new "
+        "version begins, identically for both providers"
+    )
+
+    # Out-of-order (older sequence value) must be ignored by both.
+    _merge_batch(spark, provider, entity, [("c1", "bronze", TS(2))])
+    all_rows = provider.read_entity(entity).collect()
+    assert len(all_rows) == 2, "a stale out-of-order row must not be applied"
+    current = next(r for r in all_rows if r["__is_current"])
+    assert current["status"] == "silver"
+
+
+def test_delete_when_parity(spark, provider, request):
+    """A delete_when match closes the current version without inserting a
+    new one; deletes for unknown keys are no-ops. Identical for both."""
+    entity = _make_entity(
+        f"silver.parity_delete_{request.node.callspec.id}",
+        {"scd.delete_when": "status = 'DELETED'", "scd.sequence_by": "updated_at"},
+    )
+
+    _merge_batch(spark, provider, entity, [("c1", "bronze", TS(1))])
+    _merge_batch(spark, provider, entity, [("c1", "DELETED", TS(3))])
+
+    all_rows = provider.read_entity(entity).collect()
+    assert len(all_rows) == 1, "a delete closes; it must not insert a new version"
+    assert all_rows[0]["__is_current"] is False
+    assert all_rows[0]["status"] == "bronze"
+    assert all_rows[0]["__effective_to"] == TS(3)
+
+    # Delete for an unknown key is a no-op.
+    other_entity = _make_entity(
+        f"silver.parity_delete_unknown_{request.node.callspec.id}",
+        {"scd.delete_when": "status = 'DELETED'", "scd.sequence_by": "updated_at"},
+    )
+    _merge_batch(spark, provider, other_entity, [("zz", "DELETED", TS(3))])
+    assert provider.read_entity(other_entity).count() == 0

--- a/tests/unit/test_entity_provider_memory.py
+++ b/tests/unit/test_entity_provider_memory.py
@@ -7,7 +7,6 @@ Tests in-memory operations, rate streams, and memory sinks.
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from kindling.data_entities import EntityMetadata
 from kindling.entity_provider_memory import MemoryEntityProvider
 
@@ -16,8 +15,11 @@ class TestMemoryEntityProvider:
     """Tests for MemoryEntityProvider"""
 
     @pytest.fixture
-    def provider(self):
+    def provider(self, monkeypatch):
         """Create Memory provider with mocked dependencies"""
+        monkeypatch.setattr(
+            "kindling.entity_provider_memory.get_or_create_spark_session", lambda: MagicMock()
+        )
         logger_provider = MagicMock()
         logger_provider.get_logger.return_value = MagicMock()
         provider = MemoryEntityProvider(logger_provider)
@@ -291,7 +293,10 @@ class TestMemoryProviderSeedRows:
     """Tests for provider.seed.rows inline seeding."""
 
     @pytest.fixture
-    def provider(self):
+    def provider(self, monkeypatch):
+        monkeypatch.setattr(
+            "kindling.entity_provider_memory.get_or_create_spark_session", lambda: MagicMock()
+        )
         logger_provider = MagicMock()
         logger_provider.get_logger.return_value = MagicMock()
         provider = MemoryEntityProvider(logger_provider)
@@ -426,8 +431,11 @@ class TestMemoryProviderErrorHandling:
     """Tests for error handling in MemoryEntityProvider"""
 
     @pytest.fixture
-    def provider(self):
+    def provider(self, monkeypatch):
         """Create Memory provider"""
+        monkeypatch.setattr(
+            "kindling.entity_provider_memory.get_or_create_spark_session", lambda: MagicMock()
+        )
         logger_provider = MagicMock()
         logger_provider.get_logger.return_value = MagicMock()
         provider = MemoryEntityProvider(logger_provider)

--- a/tests/unit/test_entity_provider_memory_scd2.py
+++ b/tests/unit/test_entity_provider_memory_scd2.py
@@ -1,0 +1,411 @@
+"""
+Unit tests for MemoryEntityProvider.merge_to_entity (SCD1, insert-only, SCD2).
+
+Uses a real SparkSession — not a MagicMock — because this exercises genuine
+DataFrame join/filter/union logic that a mock cannot meaningfully stand in
+for. Deliberately does not depend on conftest.py's shared, Delta-configured
+``spark_session`` fixture: that fixture's builder unconditionally sets
+``spark.sql.catalog.spark_catalog`` to Delta's catalog class, and
+``SparkSession.getOrCreate()`` applies that onto whatever SparkSession is
+already active in the process, including a plain one some earlier,
+unrelated unit test created without delta-spark on its classpath — which
+then breaks every later query with "Cannot find catalog plugin class."
+Memory needs no Delta capability at all, so a local, Delta-free fixture
+sidesteps the conflict regardless of what else ran earlier in the suite.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from kindling.data_entities import EntityMetadata
+from kindling.entity_provider_memory import MemoryEntityProvider
+from pyspark.sql import SparkSession
+from pyspark.sql.types import (
+    IntegerType,
+    StringType,
+    StructField,
+    StructType,
+    TimestampType,
+)
+
+from tests.conftest import _sockets_permitted
+
+TS = lambda day, hour=0: datetime(2026, 7, day, hour, 0, 0)  # noqa: E731
+
+
+@pytest.fixture(scope="module")
+def spark_session():
+    """Plain (non-Delta) SparkSession, module-scoped — see module docstring."""
+    if not _sockets_permitted():
+        pytest.skip(
+            "Sockets are not permitted in this environment; cannot start a real SparkSession."
+        )
+    spark = SparkSession.builder.appName("MemorySCD2Tests").master("local[2]").getOrCreate()
+    spark.sparkContext.setLogLevel("ERROR")
+    yield spark
+
+
+BUSINESS_SCHEMA = StructType(
+    [
+        StructField("id", StringType(), False),
+        StructField("status", StringType(), True),
+        StructField("seq", IntegerType(), True),
+    ]
+)
+
+SCD2_SCHEMA = StructType(
+    [
+        StructField("id", StringType(), False),
+        StructField("status", StringType(), True),
+        StructField("category", StringType(), True),
+        StructField("updated_at", TimestampType(), True),
+    ]
+)
+
+
+def _make_provider(spark_session):
+    logger_provider = MagicMock()
+    logger_provider.get_logger.return_value = MagicMock()
+    provider = MemoryEntityProvider(logger_provider)
+    provider.spark = spark_session
+    return provider
+
+
+def _make_entity(entityid, tags=None, schema=BUSINESS_SCHEMA):
+    return EntityMetadata(
+        entityid=entityid,
+        name=entityid.split(".")[-1],
+        merge_columns=["id"],
+        tags=tags or {},
+        schema=schema,
+    )
+
+
+def _make_df(spark_session, rows, schema=BUSINESS_SCHEMA):
+    return spark_session.createDataFrame(rows, schema)
+
+
+def _rows_by_id(provider, entity):
+    return {r["id"]: r for r in provider.read_entity(entity).collect()}
+
+
+class TestMemoryProviderMergeSCD1:
+    """merge_to_entity with no scd.*/write.mode tags: full-row SCD1 upsert."""
+
+    def test_first_merge_writes_incoming_as_is(self, spark_session):
+        provider = _make_provider(spark_session)
+        entity = _make_entity("silver.scd1_first")
+
+        provider.merge_to_entity(_make_df(spark_session, [("a", "new", 1)]), entity)
+
+        assert _rows_by_id(provider, entity)["a"]["status"] == "new"
+
+    def test_matched_key_is_fully_replaced(self, spark_session):
+        provider = _make_provider(spark_session)
+        entity = _make_entity("silver.scd1_replace")
+        provider.merge_to_entity(_make_df(spark_session, [("a", "old", 1)]), entity)
+
+        provider.merge_to_entity(_make_df(spark_session, [("a", "new", 2)]), entity)
+
+        rows = _rows_by_id(provider, entity)
+        assert len(rows) == 1
+        assert rows["a"]["status"] == "new"
+        assert rows["a"]["seq"] == 2
+
+    def test_new_key_inserted_and_untouched_key_survives(self, spark_session):
+        provider = _make_provider(spark_session)
+        entity = _make_entity("silver.scd1_survive")
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "old", 1), ("b", "old", 1)]), entity
+        )
+
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "new", 2), ("c", "new", 1)]), entity
+        )
+
+        rows = _rows_by_id(provider, entity)
+        assert set(rows) == {"a", "b", "c"}
+        assert rows["a"]["status"] == "new"
+        assert rows["b"]["status"] == "old", "untouched key must survive unchanged"
+        assert rows["c"]["status"] == "new"
+
+
+class TestMemoryProviderMergeInsertOnly:
+    """merge_to_entity with write.mode=insert: existing keys are never touched."""
+
+    def _entity(self, entityid):
+        return _make_entity(entityid, tags={"write.mode": "insert"})
+
+    def test_first_merge_writes_incoming_as_is(self, spark_session):
+        provider = _make_provider(spark_session)
+        entity = self._entity("silver.insert_first")
+
+        provider.merge_to_entity(_make_df(spark_session, [("a", "new", 1)]), entity)
+
+        assert _rows_by_id(provider, entity)["a"]["status"] == "new"
+
+    def test_existing_key_untouched_even_when_incoming_differs(self, spark_session):
+        provider = _make_provider(spark_session)
+        entity = self._entity("silver.insert_untouched")
+        provider.merge_to_entity(_make_df(spark_session, [("a", "original", 1)]), entity)
+
+        provider.merge_to_entity(_make_df(spark_session, [("a", "changed", 2)]), entity)
+
+        rows = _rows_by_id(provider, entity)
+        assert len(rows) == 1
+        assert rows["a"]["status"] == "original", "insert-only must never touch an existing key"
+
+    def test_new_key_is_inserted(self, spark_session):
+        provider = _make_provider(spark_session)
+        entity = self._entity("silver.insert_new")
+        provider.merge_to_entity(_make_df(spark_session, [("a", "original", 1)]), entity)
+
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "changed", 2), ("b", "new", 1)]), entity
+        )
+
+        rows = _rows_by_id(provider, entity)
+        assert set(rows) == {"a", "b"}
+        assert rows["a"]["status"] == "original"
+        assert rows["b"]["status"] == "new"
+
+
+class TestMemoryProviderMergeSCD2:
+    """merge_to_entity with scd.type=2: full declared-flow SCD2 semantics."""
+
+    def _entity(self, entityid, **tags):
+        return _make_entity(entityid, tags={"scd.type": "2", **tags}, schema=SCD2_SCHEMA)
+
+    def test_first_merge_bootstraps_temporal_columns_on_missing_entity(self, spark_session):
+        """entity.schema has no temporal columns; merge_to_entity must add them
+        even though the entity does not exist yet."""
+        provider = _make_provider(spark_session)
+        entity = self._entity("silver.scd2_bootstrap")
+
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "new", "x", TS(1))], SCD2_SCHEMA), entity
+        )
+
+        rows = provider.read_entity(entity).collect()
+        assert len(rows) == 1
+        assert rows[0]["__is_current"] is True
+        assert rows[0]["__effective_to"] is None
+        assert rows[0]["__effective_from"] is not None
+
+    def test_unchanged_row_produces_no_new_version(self, spark_session):
+        provider = _make_provider(spark_session)
+        entity = self._entity("silver.scd2_unchanged")
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "same", "x", TS(1))], SCD2_SCHEMA), entity
+        )
+        first_effective_from = provider.read_entity(entity).collect()[0]["__effective_from"]
+
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "same", "x", TS(1))], SCD2_SCHEMA), entity
+        )
+
+        rows = provider.read_entity(entity).collect()
+        assert len(rows) == 1
+        assert rows[0]["__is_current"] is True
+        assert (
+            rows[0]["__effective_from"] == first_effective_from
+        ), "an unchanged tracked-column row must not open a new version"
+
+    def test_changed_row_closes_old_version_and_opens_new(self, spark_session):
+        provider = _make_provider(spark_session)
+        entity = self._entity("silver.scd2_changed")
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "bronze", "x", TS(1))], SCD2_SCHEMA), entity
+        )
+
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "silver", "x", TS(1))], SCD2_SCHEMA), entity
+        )
+
+        rows = provider.read_entity(entity).collect()
+        current = [r for r in rows if r["__is_current"]]
+        closed = [r for r in rows if not r["__is_current"]]
+        assert len(current) == 1 and current[0]["status"] == "silver"
+        assert current[0]["__effective_to"] is None
+        assert len(closed) == 1 and closed[0]["status"] == "bronze"
+        assert closed[0]["__effective_to"] is not None
+
+    def test_close_on_missing_closes_absent_key_but_not_unchanged_present_key(self, spark_session):
+        provider = _make_provider(spark_session)
+        entity = self._entity("silver.scd2_com", **{"scd.close_on_missing": "true"})
+        provider.merge_to_entity(
+            _make_df(
+                spark_session,
+                [("a", "bronze", "x", TS(1)), ("b", "gold", "x", TS(1))],
+                SCD2_SCHEMA,
+            ),
+            entity,
+        )
+
+        # "b" vanishes from the next snapshot; "a" is present and unchanged.
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "bronze", "x", TS(1))], SCD2_SCHEMA), entity
+        )
+
+        rows = provider.read_entity(entity).collect()
+        current_ids = {r["id"] for r in rows if r["__is_current"]}
+        closed_ids = {r["id"] for r in rows if not r["__is_current"]}
+        assert "a" in current_ids, "present, unchanged key must stay current"
+        assert "a" not in closed_ids
+        assert "b" in closed_ids, "vanished key must be closed"
+        assert "b" not in current_ids
+
+    def test_sequence_by_stale_row_is_ignored(self, spark_session):
+        provider = _make_provider(spark_session)
+        entity = self._entity("silver.scd2_seq_stale", **{"scd.sequence_by": "updated_at"})
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "silver", "x", TS(5))], SCD2_SCHEMA), entity
+        )
+
+        # Older sequence value than the current version -> must be ignored.
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "bronze", "x", TS(2))], SCD2_SCHEMA), entity
+        )
+
+        rows = provider.read_entity(entity).collect()
+        assert len(rows) == 1
+        assert rows[0]["status"] == "silver"
+        assert rows[0]["__is_current"] is True
+
+    def test_sequence_by_effective_columns_carry_sequence_values(self, spark_session):
+        provider = _make_provider(spark_session)
+        entity = self._entity("silver.scd2_seq_chain", **{"scd.sequence_by": "updated_at"})
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "bronze", "x", TS(1))], SCD2_SCHEMA), entity
+        )
+
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "silver", "x", TS(5))], SCD2_SCHEMA), entity
+        )
+
+        rows = provider.read_entity(entity).collect()
+        current = next(r for r in rows if r["__is_current"])
+        closed = next(r for r in rows if not r["__is_current"])
+        assert current["__effective_from"] == TS(5)
+        assert closed["__effective_to"] == TS(
+            5
+        ), "closed version's effective_to must equal the new version's effective_from"
+
+    def test_sequence_by_missing_column_in_batch_raises(self, spark_session):
+        provider = _make_provider(spark_session)
+        entity = self._entity("silver.scd2_seq_missing_col", **{"scd.sequence_by": "updated_at"})
+        no_seq_schema = StructType(
+            [StructField("id", StringType(), False), StructField("status", StringType(), True)]
+        )
+
+        with pytest.raises(ValueError, match="sequence_by"):
+            provider.merge_to_entity(
+                _make_df(spark_session, [("a", "bronze")], no_seq_schema), entity
+            )
+
+    def test_sequence_by_null_value_in_batch_raises(self, spark_session):
+        provider = _make_provider(spark_session)
+        entity = self._entity("silver.scd2_seq_null", **{"scd.sequence_by": "updated_at"})
+
+        with pytest.raises(ValueError, match="null values"):
+            provider.merge_to_entity(
+                _make_df(spark_session, [("a", "bronze", "x", None)], SCD2_SCHEMA), entity
+            )
+
+    def test_delete_when_closes_without_inserting(self, spark_session):
+        provider = _make_provider(spark_session)
+        entity = self._entity("silver.scd2_delete", **{"scd.delete_when": "status = 'DELETED'"})
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "bronze", "x", TS(1))], SCD2_SCHEMA), entity
+        )
+
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "DELETED", "x", TS(1))], SCD2_SCHEMA), entity
+        )
+
+        rows = provider.read_entity(entity).collect()
+        assert len(rows) == 1, "a delete closes; it must not insert a new version"
+        assert rows[0]["__is_current"] is False
+        assert rows[0]["status"] == "bronze"
+        assert rows[0]["__effective_to"] is not None
+
+    def test_delete_when_unknown_key_is_a_no_op(self, spark_session):
+        provider = _make_provider(spark_session)
+        entity = self._entity(
+            "silver.scd2_delete_unknown", **{"scd.delete_when": "status = 'DELETED'"}
+        )
+
+        provider.merge_to_entity(
+            _make_df(spark_session, [("zz", "DELETED", "x", TS(1))], SCD2_SCHEMA), entity
+        )
+
+        assert provider.read_entity(entity).count() == 0
+
+    def test_optimize_unchanged_matches_default_classification(self, spark_session):
+        provider = _make_provider(spark_session)
+        entity = self._entity("silver.scd2_opt", **{"scd.optimize_unchanged": "true"})
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "bronze", "x", TS(1))], SCD2_SCHEMA), entity
+        )
+
+        # Same content: no new version.
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "bronze", "x", TS(1))], SCD2_SCHEMA), entity
+        )
+        assert len(provider.read_entity(entity).collect()) == 1
+
+        # Changed content: new version.
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "silver", "x", TS(1))], SCD2_SCHEMA), entity
+        )
+        rows = provider.read_entity(entity).collect()
+        current = [r for r in rows if r["__is_current"]]
+        closed = [r for r in rows if not r["__is_current"]]
+        assert len(current) == 1 and current[0]["status"] == "silver"
+        assert len(closed) == 1 and closed[0]["status"] == "bronze"
+
+    def test_explicit_tracked_columns_ignore_untracked_changes(self, spark_session):
+        provider = _make_provider(spark_session)
+        entity = self._entity("silver.scd2_tracked_explicit", **{"scd.tracked": "status"})
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "bronze", "x", TS(1))], SCD2_SCHEMA), entity
+        )
+
+        # "category" changes but is not in scd.tracked -> must not open a new version.
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "bronze", "y", TS(1))], SCD2_SCHEMA), entity
+        )
+
+        rows = provider.read_entity(entity).collect()
+        assert len(rows) == 1
+        assert rows[0]["category"] == "x", "untracked column change must not be picked up"
+
+    def test_auto_derived_tracked_columns_excludes_business_and_sequence_columns(
+        self, spark_session
+    ):
+        """Without scd.tracked, every non-key/non-temporal/non-sequence column is
+        tracked automatically: a sequence-only bump must not open a new version,
+        but a change to another business column must."""
+        provider = _make_provider(spark_session)
+        entity = self._entity("silver.scd2_tracked_auto", **{"scd.sequence_by": "updated_at"})
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "bronze", "x", TS(1))], SCD2_SCHEMA), entity
+        )
+
+        # updated_at alone bumps (sequence_by is excluded from auto-tracked columns).
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "bronze", "x", TS(2))], SCD2_SCHEMA), entity
+        )
+        assert (
+            len(provider.read_entity(entity).collect()) == 1
+        ), "sequence_by must be excluded from auto-derived tracked columns"
+
+        # category changes -> auto-tracked, must open a new version.
+        provider.merge_to_entity(
+            _make_df(spark_session, [("a", "bronze", "y", TS(3))], SCD2_SCHEMA), entity
+        )
+        rows = provider.read_entity(entity).collect()
+        current = [r for r in rows if r["__is_current"]]
+        assert len(current) == 1 and current[0]["category"] == "y"
+        assert current[0]["__effective_from"] == TS(3)

--- a/tests/unit/test_temporal_extension.py
+++ b/tests/unit/test_temporal_extension.py
@@ -738,3 +738,105 @@ def test_conditions_ingestion_result_and_config_key():
     assert QUARANTINE_ENTITY_CONFIG_KEY == "kindling.temporal.conditions.quarantine_entity_id"
     assert ConditionsIngestionResult(ingested_count=3).is_clean is True
     assert ConditionsIngestionResult(ingested_count=0, quarantined=[object()]).is_clean is False
+
+
+@pytest.fixture(scope="module")
+def _memory_spark_session():
+    """Plain (non-Delta) SparkSession — see test_entity_provider_memory_scd2.py's
+    module docstring for why this avoids conftest.py's shared, Delta-configured
+    spark_session fixture (MemoryEntityProvider never needs Delta, and that
+    fixture forces Delta config onto whatever SparkSession is already active
+    in the process, which breaks if an earlier, unrelated test created a plain
+    one first)."""
+    from pyspark.sql import SparkSession
+
+    from tests.conftest import _sockets_permitted
+
+    if not _sockets_permitted():
+        pytest.skip(
+            "Sockets are not permitted in this environment; cannot start a real SparkSession."
+        )
+    spark = (
+        SparkSession.builder.appName("TemporalConditionsIngestTests")
+        .master("local[2]")
+        .getOrCreate()
+    )
+    spark.sparkContext.setLogLevel("ERROR")
+    yield spark
+
+
+def test_ingest_conditions_end_to_end_against_memory_provider(_memory_spark_session, monkeypatch):
+    """Acceptance criterion #2: ingest_conditions() against a real MemoryEntityProvider
+    — validation/quarantine on first ingest, then an SCD2 re-ingest that changes a
+    tracked field (enabled) closes the old version and opens exactly one new one."""
+    from kindling.entity_provider_memory import MemoryEntityProvider
+    from kindling_ext_temporal import (
+        SimpleTemporalEntityResolver,
+        conditions_schema,
+        ingest_conditions,
+    )
+
+    spark = _memory_spark_session
+    monkeypatch.setattr(
+        "kindling.entity_provider_memory.get_or_create_spark_session", lambda: MagicMock()
+    )
+    memory_provider = MemoryEntityProvider(_logger_provider())
+    memory_provider.spark = spark
+
+    resolver = SimpleTemporalEntityResolver()
+    valid_from = datetime(2026, 1, 1)
+
+    df = spark.createDataFrame(
+        [
+            _condition_row(condition_id="condition.temperature_high", valid_from=valid_from),
+            _condition_row(
+                condition_id="condition.bad",
+                valid_from=valid_from,
+                parameters={
+                    "enter_when": "",
+                    "exit_when": "cast(payload['temperature'] as double) <= 90",
+                },
+            ),
+        ],
+        conditions_schema(),
+    )
+
+    result = ingest_conditions(
+        df,
+        resolver=resolver,
+        provider_factory=lambda entity: memory_provider,
+        quarantine_entity_id=None,
+    )
+
+    assert result.ingested_count == 1
+    assert [invalid.condition_id for invalid in result.quarantined] == ["condition.bad"]
+
+    stored = memory_provider.read_entity(resolver.get_conditions_entity()).collect()
+    current = [row for row in stored if row["__is_current"]]
+    assert len(current) == 1
+    assert current[0]["condition_id"] == "condition.temperature_high"
+    assert current[0]["enabled"] is True
+
+    # Re-ingest the same condition with a tracked field (enabled) flipped.
+    changed_df = spark.createDataFrame(
+        [
+            _condition_row(
+                condition_id="condition.temperature_high", enabled=False, valid_from=valid_from
+            )
+        ],
+        conditions_schema(),
+    )
+    ingest_conditions(
+        changed_df,
+        resolver=resolver,
+        provider_factory=lambda entity: memory_provider,
+        quarantine_entity_id=None,
+    )
+
+    all_rows = memory_provider.read_entity(resolver.get_conditions_entity()).collect()
+    current_rows = [row for row in all_rows if row["__is_current"]]
+    closed_rows = [row for row in all_rows if not row["__is_current"]]
+    assert len(current_rows) == 1
+    assert current_rows[0]["enabled"] is False
+    assert len(closed_rows) == 1, "exactly one prior version must be closed, not duplicated"
+    assert closed_rows[0]["enabled"] is True


### PR DESCRIPTION
## Summary
- `MemoryEntityProvider.merge_to_entity()` now supports the same contract as `DeltaEntityProvider`: SCD Type 2 upsert (`scd.type=2`), insert-only (`write.mode=insert`), and full-row SCD1 upsert (default), implemented as plain DataFrame joins/unions rather than a Delta `MERGE INTO`.
- `augment_schema_for_scd2`, `quote_sql_identifier`, and `build_null_safe_change_condition` moved from `entity_provider_delta.py` to `data_entities.py` as public, provider-agnostic functions (behavior-preserving; `_augment_schema_for_scd2` is now a one-line delegate).
- Lets `kindling_ext_temporal.ingest_conditions()` (and any other merge caller) be exercised against Memory, the framework's no-external-dependency test provider, instead of only against a real Delta table.

Closes #220

## Test plan
- [x] `poe test-unit`: 2375 passed, 2 skipped (full unit suite incl. merge with main's gh#221/#222 changes)
- [x] `poe test-integration`: 133 passed, 1 skipped (tester's pre-merge run against this branch's own commit)
- [x] `gitleaks detect` clean on the push range
- [x] Reviewed against the human-approved DESIGN note (kind-665) and AGENTS.md conventions — APPROVE, no blockers

🤖 Generated with [Claude Code](https://claude.com/claude-code)