### PR TITLE
fix(sdk): honor KINDLING_ARTIFACTS_STORAGE_PATH in DatabricksAPI job submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to spark-kindling are documented here.
 
+## Unreleased
+
+### Fixed
+
+- **Databricks SDK job submission ignored `KINDLING_ARTIFACTS_STORAGE_PATH`**
+  (gh#216): `DatabricksAPI.from_env()` only ever read the legacy
+  `AZURE_STORAGE_ACCOUNT`/`AZURE_CONTAINER`/`AZURE_BASE_PATH` triple, so
+  `kindling app run --platform databricks` / `kindling app job register`
+  failed job submission with `InvalidParameterValue: Invalid python file
+  reference: artifacts/scripts/kindling_bootstrap.py` on any workspace
+  configured with `KINDLING_ARTIFACTS_STORAGE_PATH=/Volumes/...` and no
+  legacy Azure storage vars set. `DatabricksAPI` now accepts an
+  `artifacts_path` (populated from `KINDLING_ARTIFACTS_STORAGE_PATH`) that
+  takes precedence over the legacy ABFSS synthesis; a Databricks Volumes
+  path now resolves to a valid, non-bare `python_file`. Existing
+  `AZURE_STORAGE_ACCOUNT`-only configurations are unaffected. When neither
+  is configured, artifact resolution now raises an actionable `ValueError`
+  instead of silently falling back to the bare `"artifacts"` literal.
+
 ## [0.12.3] - 2026-07-29
 
 ### Added

--- a/packages/kindling_sdk/kindling_sdk/platform_databricks.py
+++ b/packages/kindling_sdk/kindling_sdk/platform_databricks.py
@@ -56,6 +56,7 @@ class DatabricksAPI(PlatformAPI):
         storage_account: Optional[str] = None,
         container: Optional[str] = None,
         base_path: Optional[str] = None,
+        artifacts_path: Optional[str] = None,
         default_cluster_id: Optional[str] = None,
         azure_tenant_id: Optional[str] = None,
         azure_client_id: Optional[str] = None,
@@ -70,6 +71,9 @@ class DatabricksAPI(PlatformAPI):
             storage_account: Optional storage account for ABFSS cluster logs
             container: Optional container name for ABFSS cluster logs
             base_path: Optional base path within container
+            artifacts_path: Optional artifacts storage root (e.g. a Databricks
+                Volumes path) that takes precedence over the legacy
+                storage_account/container/base_path ABFSS synthesis
             default_cluster_id: Optional existing cluster ID to use when job config omits cluster
             azure_tenant_id: Optional Azure tenant ID for service principal auth
             azure_client_id: Optional Azure client ID for service principal auth
@@ -86,6 +90,7 @@ class DatabricksAPI(PlatformAPI):
         self.storage_account = storage_account
         self.container = container
         self.base_path = base_path
+        self.artifacts_path = (artifacts_path or "").strip() or None
         self.default_cluster_id = default_cluster_id
         self.azure_tenant_id = azure_tenant_id
         self.azure_client_id = azure_client_id
@@ -133,6 +138,8 @@ class DatabricksAPI(PlatformAPI):
             - DATABRICKS_HOST
 
         Optional environment variables:
+            - KINDLING_ARTIFACTS_STORAGE_PATH (e.g. /Volumes/<catalog>/<schema>/
+              <volume>/kindling; takes precedence over AZURE_STORAGE_ACCOUNT)
             - AZURE_STORAGE_ACCOUNT (for file uploads)
             - AZURE_CONTAINER (default: "artifacts")
             - AZURE_BASE_PATH (default: "system-tests")
@@ -160,6 +167,7 @@ class DatabricksAPI(PlatformAPI):
             storage_account=os.getenv("AZURE_STORAGE_ACCOUNT"),
             container=os.getenv("AZURE_CONTAINER", "artifacts"),
             base_path=os.getenv("AZURE_BASE_PATH", "system-tests"),
+            artifacts_path=os.getenv("KINDLING_ARTIFACTS_STORAGE_PATH"),
             default_cluster_id=os.getenv("DATABRICKS_CLUSTER_ID"),
             azure_tenant_id=os.getenv("AZURE_TENANT_ID"),
             azure_client_id=os.getenv("AZURE_CLIENT_ID"),
@@ -197,13 +205,22 @@ class DatabricksAPI(PlatformAPI):
             if classic_override:
                 return classic_override
 
+        resolved_artifacts_path = (getattr(self, "artifacts_path", None) or "").strip()
+        if resolved_artifacts_path:
+            return resolved_artifacts_path
+
         if self.storage_account and self.container:
             base_url = azure_abfss_uri(self.container, self.storage_account)
             if self.base_path:
                 return f"{base_url}/{self.base_path.strip('/')}"
             return base_url
 
-        return "artifacts"
+        raise ValueError(
+            "Databricks artifacts location is not configured. Set "
+            "KINDLING_ARTIFACTS_STORAGE_PATH (e.g. /Volumes/<catalog>/<schema>/"
+            "<volume>/kindling or abfss://...) or the legacy AZURE_STORAGE_ACCOUNT "
+            "(+ optional AZURE_CONTAINER, AZURE_BASE_PATH)."
+        )
 
     @staticmethod
     def _join_storage_path(root: str, *parts: str) -> str:

--- a/tests/unit/test_platform_databricks_sdk_job_config.py
+++ b/tests/unit/test_platform_databricks_sdk_job_config.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
 from kindling_sdk.platform_databricks import DatabricksAPI
 
 
@@ -249,3 +250,118 @@ def test_submit_app_run_delegates_to_one_time_run():
     submit_call = api._client.jobs.submit.call_args
     assert submit_call.kwargs["run_name"] == "kindling-adhoc-myapp"
     assert run_id == "67890"
+
+
+# --- gh#216: KINDLING_ARTIFACTS_STORAGE_PATH (Volumes) support ---
+
+
+def test_from_env_resolves_volumes_artifacts_path(monkeypatch):
+    """from_env() reads KINDLING_ARTIFACTS_STORAGE_PATH into artifacts_path."""
+    monkeypatch.setenv("DATABRICKS_HOST", "https://adb-123.azuredatabricks.net")
+    monkeypatch.setenv("KINDLING_ARTIFACTS_STORAGE_PATH", "/Volumes/cat/schema/vol/kindling")
+    monkeypatch.delenv("AZURE_STORAGE_ACCOUNT", raising=False)
+
+    with patch("databricks.sdk.WorkspaceClient"):
+        api = DatabricksAPI.from_env()
+
+    assert api.artifacts_path == "/Volumes/cat/schema/vol/kindling"
+
+
+def test_from_env_artifacts_path_none_when_unconfigured(monkeypatch):
+    """from_env() leaves artifacts_path None (and doesn't raise) when unset."""
+    monkeypatch.setenv("DATABRICKS_HOST", "https://adb-123.azuredatabricks.net")
+    monkeypatch.delenv("KINDLING_ARTIFACTS_STORAGE_PATH", raising=False)
+    monkeypatch.delenv("AZURE_STORAGE_ACCOUNT", raising=False)
+
+    with patch("databricks.sdk.WorkspaceClient"):
+        api = DatabricksAPI.from_env()
+
+    assert api.artifacts_path is None
+
+
+def test_from_env_legacy_azure_storage_account_unaffected(monkeypatch):
+    """Regression guard: AZURE_STORAGE_ACCOUNT-only setups are untouched by this fix."""
+    monkeypatch.setenv("DATABRICKS_HOST", "https://adb-123.azuredatabricks.net")
+    monkeypatch.setenv("AZURE_STORAGE_ACCOUNT", "mystorageaccount")
+    monkeypatch.delenv("KINDLING_ARTIFACTS_STORAGE_PATH", raising=False)
+
+    with patch("databricks.sdk.WorkspaceClient"):
+        api = DatabricksAPI.from_env()
+
+    assert api.artifacts_path is None
+    assert api.storage_account == "mystorageaccount"
+
+
+def test_resolve_artifacts_storage_path_prefers_artifacts_path_over_legacy_triple():
+    """KINDLING_ARTIFACTS_STORAGE_PATH wins over the legacy abfss synthesis."""
+    api = _make_api()
+    api.artifacts_path = "/Volumes/cat/schema/vol/kindling"
+
+    path = api._resolve_artifacts_storage_path({}, "uc")
+
+    assert path == "/Volumes/cat/schema/vol/kindling"
+
+
+def test_resolve_artifacts_storage_path_missing_attribute_falls_back(monkeypatch):
+    """Test doubles that never set .artifacts_path must not raise AttributeError."""
+    api = _make_api()
+    monkeypatch.delenv("AZURE_STORAGE_DFS_ENDPOINT_SUFFIX", raising=False)
+    monkeypatch.delenv("AZURE_CLOUD", raising=False)
+
+    path = api._resolve_artifacts_storage_path({}, "uc")
+
+    assert (
+        path
+        == "abfss://artifacts@mystorageaccount.dfs.core.windows.net/system-tests/run-123/databricks"
+    )
+
+
+def test_resolve_artifacts_storage_path_raises_when_nothing_configured():
+    """No explicit path, no artifacts_path, no legacy triple -> actionable error, not a bare literal."""
+    api = DatabricksAPI.__new__(DatabricksAPI)
+    api.storage_account = None
+    api.container = None
+    api.base_path = None
+    api.artifacts_path = None
+
+    with pytest.raises(ValueError, match="not configured"):
+        api._resolve_artifacts_storage_path({}, "uc")
+
+
+def test_resolve_python_file_uses_volumes_path_for_uc():
+    """_resolve_python_file has no abfss-only assumption -- a Volumes root works too."""
+    api = _make_api()
+
+    python_file = api._resolve_python_file(
+        main_file="kindling_bootstrap.py",
+        job_config={},
+        mode="uc",
+        artifacts_storage_path="/Volumes/cat/schema/vol/kindling",
+    )
+
+    assert python_file == "/Volumes/cat/schema/vol/kindling/scripts/kindling_bootstrap.py"
+
+
+def test_submit_one_time_run_produces_valid_volumes_python_file():
+    """End-to-end regression guard for the reported bug: a Volumes-only config must
+    produce a valid, non-bare python_file for jobs.submit()."""
+    api = DatabricksAPI.__new__(DatabricksAPI)
+    api.storage_account = None
+    api.container = None
+    api.base_path = None
+    api.artifacts_path = "/Volumes/cat/schema/vol/kindling"
+    api.workspace_url = "https://adb-123.azuredatabricks.net"
+    api.default_cluster_id = None
+    api._client = MagicMock()
+    api._client.jobs.submit.return_value = MagicMock(run_id=555)
+    api._job_mapping = {}
+
+    run_id = api._submit_one_time_run("myapp", {})
+
+    submit_call = api._client.jobs.submit.call_args
+    tasks = submit_call.kwargs["tasks"]
+    assert (
+        tasks[0].spark_python_task.python_file
+        == "/Volumes/cat/schema/vol/kindling/scripts/kindling_bootstrap.py"
+    )
+    assert run_id == "555"


### PR DESCRIPTION
## Summary
- `DatabricksAPI` job submission now honors `KINDLING_ARTIFACTS_STORAGE_PATH` when resolving the artifacts storage path, instead of silently falling back to the legacy `AZURE_STORAGE_ACCOUNT`/container path (or raising an opaque error).
- Missing/unset configuration now raises an actionable `ValueError` instead of returning a bare `"artifacts"` fallback.

## Test plan
- [x] `poe test-unit` — 2344 passed, 2 skipped
- [x] New unit tests in `tests/unit/test_platform_databricks_sdk_job_config.py` cover `from_env` precedence, missing-attribute guard, `ValueError` raise, and the `/Volumes/...` path case
- [x] Internal reviewer verified diff against DESIGN — APPROVE, no blockers

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)