### PR TITLE
fix(devcontainer): publish multi-arch domain image

### DIFF
--- a/.github/Dockerfile.devcontainer
+++ b/.github/Dockerfile.devcontainer
@@ -29,7 +29,12 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+# Resolve JAVA_HOME dynamically so the image works on both amd64 and arm64.
+RUN JAVA_BIN="$(readlink -f "$(command -v java)")" \
+    && JAVA_HOME_REAL="$(dirname "$(dirname "$JAVA_BIN")")" \
+    && ln -sfn "$JAVA_HOME_REAL" /usr/lib/jvm/java-21-openjdk-current
+
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-current
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 # Install Poetry and Poe globally (version-pinned for reproducibility)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -966,6 +966,7 @@ jobs:
         with:
           context: .
           file: .github/Dockerfile.devcontainer
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             KINDLING_VERSION=${{ steps.version.outputs.version }}

--- a/scripts/publish_devcontainer.py
+++ b/scripts/publish_devcontainer.py
@@ -19,6 +19,7 @@ REGISTRY = "ghcr.io"
 REPO = "sep/spark-kindling-framework"
 IMAGE = f"{REGISTRY}/{REPO}/devcontainer"
 DOCKERFILE = Path(".github/Dockerfile.devcontainer")
+DEFAULT_PLATFORMS = "linux/amd64,linux/arm64"
 
 
 def _current_version() -> str:
@@ -98,7 +99,7 @@ def _ensure_builder(env: dict) -> None:
         )
 
 
-def main(version: str = "", push: bool = True) -> int:
+def main(version: str = "", push: bool = True, platforms: str = DEFAULT_PLATFORMS) -> int:
     try:
         resolved_version = version or _current_version()
         print(f"Building devcontainer image version {resolved_version}")
@@ -118,6 +119,8 @@ def main(version: str = "", push: bool = True) -> int:
                 "build",
                 "--file",
                 str(DOCKERFILE),
+                "--platform",
+                platforms,
                 "--build-arg",
                 f"KINDLING_VERSION={resolved_version}",
                 "--tag",
@@ -168,5 +171,10 @@ if __name__ == "__main__":
     parser.add_argument(
         "--no-push", dest="push", action="store_false", help="Build only, do not push"
     )
+    parser.add_argument(
+        "--platforms",
+        default=DEFAULT_PLATFORMS,
+        help=("Comma-separated target platforms for buildx (default: " f"{DEFAULT_PLATFORMS})"),
+    )
     args = parser.parse_args()
-    sys.exit(main(version=args.version, push=args.push))
+    sys.exit(main(version=args.version, push=args.push, platforms=args.platforms))


### PR DESCRIPTION
## Summary
- publish the release devcontainer image as a multi-arch manifest for amd64 and arm64
- make JAVA_HOME resolution in the release devcontainer image architecture-agnostic
- update the manual publish script to build multi-arch images by default

## Testing
- verified Java home discovery logic resolves to a valid installed JDK path
- passed pre-commit hooks during commit
